### PR TITLE
Add test coverage display to README

### DIFF
--- a/.changeset/add-test-coverage-display.md
+++ b/.changeset/add-test-coverage-display.md
@@ -1,0 +1,13 @@
+---
+'@bilbomd/backend': patch
+'@bilbomd/ui': patch
+'@bilbomd/worker': patch
+---
+
+Add test coverage display to README
+
+- Add json-summary reporter to backend and worker vitest configs
+- Add json-summary reporter to UI vite config
+- Create coverage update script for GitHub Actions
+- Add coverage-report job to CI workflow
+- Add test coverage table to README with automatic updates on main branch pushes

--- a/.github/scripts/update-coverage-readme.js
+++ b/.github/scripts/update-coverage-readme.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const rootDir = join(__dirname, '../..')
+
+const apps = [
+  { name: 'Backend', path: 'apps/backend/coverage/coverage-summary.json' },
+  { name: 'UI', path: 'apps/ui/coverage/coverage-summary.json' },
+  { name: 'Worker', path: 'apps/worker/coverage/coverage-summary.json' },
+  { name: 'Scoper', path: null } // No tests yet
+]
+
+const readCoverage = (path) => {
+  if (!path) return null
+
+  try {
+    const fullPath = join(rootDir, path)
+    const data = JSON.parse(readFileSync(fullPath, 'utf8'))
+    return data.total
+  } catch (error) {
+    console.warn(`Warning: Could not read coverage file at ${path}:`, error.message)
+    return null
+  }
+}
+
+const formatPercent = (value) => {
+  if (value === null || value === undefined) return 'N/A'
+  return `${value.pct.toFixed(2)}%`
+}
+
+const buildCoverageTable = () => {
+  const rows = apps.map((app) => {
+    const coverage = readCoverage(app.path)
+
+    if (!coverage) {
+      return `| ${app.name} | N/A | N/A | N/A | N/A |`
+    }
+
+    return `| ${app.name} | ${formatPercent(coverage.statements)} | ${formatPercent(coverage.branches)} | ${formatPercent(coverage.functions)} | ${formatPercent(coverage.lines)} |`
+  })
+
+  return [
+    '| App | Statements | Branches | Functions | Lines |',
+    '|-----|-----------|----------|-----------|-------|',
+    ...rows
+  ].join('\n')
+}
+
+const updateReadme = () => {
+  const readmePath = join(rootDir, 'README.md')
+  const readmeContent = readFileSync(readmePath, 'utf8')
+
+  const startMarker = '<!-- COVERAGE-TABLE:START -->'
+  const endMarker = '<!-- COVERAGE-TABLE:END -->'
+
+  const startIndex = readmeContent.indexOf(startMarker)
+  const endIndex = readmeContent.indexOf(endMarker)
+
+  if (startIndex === -1 || endIndex === -1) {
+    console.error('Error: Could not find coverage table markers in README.md')
+    process.exit(1)
+  }
+
+  const coverageTable = buildCoverageTable()
+
+  const newContent =
+    readmeContent.substring(0, startIndex + startMarker.length) +
+    '\n' + coverageTable + '\n' +
+    readmeContent.substring(endIndex)
+
+  writeFileSync(readmePath, newContent, 'utf8')
+  console.log('Successfully updated coverage in README.md')
+}
+
+updateReadme()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1012,3 +1012,48 @@ jobs:
             fi
           done
           echo "All required jobs succeeded"
+
+  coverage-report:
+    name: Update Coverage in README
+    runs-on: ubuntu-22.04
+    needs: [backend-unit-tests, ui-unit-tests, worker-unit-tests]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build dependencies
+        run: pnpm build
+
+      - name: Run backend tests with coverage
+        run: pnpm -C apps/backend run test
+
+      - name: Run ui tests with coverage
+        run: pnpm -C apps/ui run test
+
+      - name: Run worker tests with coverage
+        run: pnpm -C apps/worker run test
+
+      - name: Update README with coverage
+        run: node .github/scripts/update-coverage-readme.js
+
+      - name: Commit coverage update
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git diff --quiet && git diff --staged --quiet || git commit -m "chore: update test coverage in README [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ This pipeline is designed to run Alphafold2 on your provided protein sequence an
 
 ![Auto](apps/ui/public/images/bilbomd-classic-crd-schematic-dark.png)
 
+## Test Coverage
+
+Current test coverage across BilboMD apps:
+
+<!-- COVERAGE-TABLE:START -->
+| App | Statements | Branches | Functions | Lines |
+|-----|-----------|----------|-----------|-------|
+| Backend | 75.85% | 60.93% | 69.04% | 76.38% |
+| UI | 65.60% | 55.65% | 62.64% | 67.17% |
+| Worker | 89.65% | 73.49% | 93.93% | 89.23% |
+| Scoper | N/A | N/A | N/A | N/A |
+<!-- COVERAGE-TABLE:END -->
+
+*Coverage is automatically updated on each push to main.*
+
 ## Deployment
 
 There are 2 instances of BilboMD available. Each deployment has a different selection of pipelines available. This is primarily because of access to high performance NVIDIA GPUs at NERSC which are unavailable at the SIBYLS beamline on Hyperion.

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'json-summary', 'html'],
       exclude: ['node_modules/', 'build/', 'dist/', '**/*.d.ts']
     }
   }

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
     coverage: {
       enabled: true,
       provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
       reportsDirectory: 'coverage',
       exclude: [
         'node_modules/',

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./test/setup.ts'],
     coverage: {
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json-summary', 'html'],
       exclude: ['node_modules/', 'build/', 'dist/', '**/*.d.ts']
     }
   }


### PR DESCRIPTION
## Summary

This PR adds test coverage display to the main README.md for better visibility into code quality and test coverage across the monorepo.

## Changes

### Vitest Configuration Updates
- **Backend** (`apps/backend/vitest.config.ts`): Added `json-summary` reporter to coverage config
- **UI** (`apps/ui/vite.config.ts`): Added `json-summary` reporter to coverage config  
- **Worker** (`apps/worker/vitest.config.ts`): Added `json-summary` reporter to coverage config

### Coverage Automation
- **Script** (`.github/scripts/update-coverage-readme.js`): Node.js script that reads coverage-summary.json files and updates README.md
- **CI Workflow** (`.github/workflows/ci.yml`): Added `coverage-report` job that:
  - Runs only on pushes to main branch
  - Runs tests with coverage for backend, UI, and worker
  - Updates README with coverage data
  - Commits changes with `[skip ci]` to prevent infinite loops

### Documentation
- **README.md**: Added "Test Coverage" section with a table showing:
  - Backend: 75.85% statements, 60.93% branches, 69.04% functions, 76.38% lines
  - UI: 65.60% statements, 55.65% branches, 62.64% functions, 67.17% lines
  - Worker: 89.65% statements, 73.49% branches, 93.93% functions, 89.23% lines
  - Scoper: N/A (no tests configured yet)

## How It Works

1. On every push to `main`, the `coverage-report` job runs
2. Tests are executed with coverage for backend, UI, and worker
3. Coverage summary files (`coverage-summary.json`) are generated
4. Update script parses the JSON files and updates the README table
5. Changes are committed back to the repository with `[skip ci]` flag

## Testing

- ✅ Verified backend tests generate coverage-summary.json
- ✅ Verified UI tests generate coverage-summary.json
- ✅ Verified worker tests generate coverage-summary.json
- ✅ Tested coverage update script locally
- ✅ Verified README.md is updated with correct percentages

## Notes

- Coverage updates only happen on `main` branch (not on PRs)
- The `[skip ci]` flag prevents the coverage commit from triggering another CI run
- Scoper shows "N/A" since it has no tests configured yet
- Coverage percentages will update automatically on each main branch push

🤖 Generated with [Claude Code](https://claude.com/claude-code)