### PR TITLE
fix: correct job creation API response type handling

### DIFF
--- a/.changeset/fix-job-creation-response-type.md
+++ b/.changeset/fix-job-creation-response-type.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Fix job submission error by correcting API response type handling. The job creation endpoints return a flat response structure with jobid, uuid, and md_engine fields, but the frontend was expecting a nested BilboMDJobDTO structure. Added JobCreationResponse interface and updated all job form components to handle the correct response structure.

--- a/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
+++ b/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
@@ -479,10 +479,10 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const authSuccessResponse =
     authJobResponse && mode === 'authenticated'
       ? {
-          message: 'Job submitted successfully',
-          jobid: authJobResponse.id,
-          uuid: authJobResponse.mongo.uuid,
-          md_engine: authJobResponse.mongo.md_engine
+          message: authJobResponse.message || 'Job submitted successfully',
+          jobid: authJobResponse.jobid,
+          uuid: authJobResponse.uuid,
+          md_engine: authJobResponse.md_engine
         }
       : undefined
 

--- a/apps/ui/src/features/autojob/NewAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/NewAutoJobForm.tsx
@@ -56,10 +56,10 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const authSuccessResponse =
     authJobResponse && mode === 'authenticated'
       ? {
-          message: 'Job submitted successfully',
-          jobid: authJobResponse.id,
-          uuid: authJobResponse.mongo.uuid,
-          md_engine: authJobResponse.mongo.md_engine
+          message: authJobResponse.message || 'Job submitted successfully',
+          jobid: authJobResponse.jobid,
+          uuid: authJobResponse.uuid,
+          md_engine: authJobResponse.md_engine
         }
       : undefined
 

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -73,10 +73,10 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const authSuccessResponse =
     authJobResponse && mode === 'authenticated'
       ? {
-          message: 'Job submitted successfully',
-          jobid: authJobResponse.id,
-          uuid: authJobResponse.mongo.uuid,
-          md_engine: authJobResponse.mongo.md_engine
+          message: authJobResponse.message || 'Job submitted successfully',
+          jobid: authJobResponse.jobid,
+          uuid: authJobResponse.uuid,
+          md_engine: authJobResponse.md_engine
         }
       : undefined
 

--- a/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
+++ b/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
@@ -89,10 +89,10 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const authSuccessResponse =
     authJobResponse && mode === 'authenticated'
       ? {
-          message: 'Job submitted successfully',
-          jobid: authJobResponse.id,
-          uuid: authJobResponse.mongo.uuid,
-          md_engine: authJobResponse.mongo.md_engine
+          message: authJobResponse.message || 'Job submitted successfully',
+          jobid: authJobResponse.jobid,
+          uuid: authJobResponse.uuid,
+          md_engine: authJobResponse.md_engine
         }
       : undefined
 

--- a/apps/ui/src/features/scoperjob/NewScoperJobForm.tsx
+++ b/apps/ui/src/features/scoperjob/NewScoperJobForm.tsx
@@ -60,10 +60,10 @@ const NewScoperJobForm = ({
   const authSuccessResponse =
     authJobResponse && mode === 'authenticated'
       ? {
-          message: 'Job submitted successfully',
-          jobid: authJobResponse.id,
-          uuid: authJobResponse.mongo.uuid,
-          md_engine: authJobResponse.mongo.md_engine
+          message: authJobResponse.message || 'Job submitted successfully',
+          jobid: authJobResponse.jobid,
+          uuid: authJobResponse.uuid,
+          md_engine: authJobResponse.md_engine
         }
       : undefined
 

--- a/apps/ui/src/slices/jobsApiSlice.ts
+++ b/apps/ui/src/slices/jobsApiSlice.ts
@@ -19,6 +19,14 @@ interface AutoRgResponse {
   [key: string]: unknown
 }
 
+interface JobCreationResponse {
+  message: string
+  jobid: string
+  uuid: string
+  md_engine: string
+  [key: string]: unknown
+}
+
 interface Af2PaeResponse {
   uuid: string
   status: string
@@ -80,7 +88,7 @@ export const jobsApiSlice = apiSlice.injectEndpoints({
       }),
       providesTags: (_, __, id) => [{ type: 'FoxsAnalysis', id }]
     }),
-    addNewJob: builder.mutation<BilboMDJobDTO, FormData>({
+    addNewJob: builder.mutation<JobCreationResponse, FormData>({
       query: (newJob) => ({
         url: '/jobs',
         method: 'POST',
@@ -139,7 +147,7 @@ export const jobsApiSlice = apiSlice.injectEndpoints({
         body: formData
       })
     }),
-    addNewAutoJob: builder.mutation<BilboMDJobDTO, FormData>({
+    addNewAutoJob: builder.mutation<JobCreationResponse, FormData>({
       query: (newJob) => ({
         url: '/jobs/bilbomd-auto',
         method: 'POST',
@@ -147,7 +155,7 @@ export const jobsApiSlice = apiSlice.injectEndpoints({
       }),
       invalidatesTags: [{ type: 'Job', id: 'LIST' }]
     }),
-    addNewAlphaFoldJob: builder.mutation<BilboMDJobDTO, FormData>({
+    addNewAlphaFoldJob: builder.mutation<JobCreationResponse, FormData>({
       query: (newJob) => ({
         url: '/jobs/bilbomd-alphafold',
         method: 'POST',
@@ -155,7 +163,7 @@ export const jobsApiSlice = apiSlice.injectEndpoints({
       }),
       invalidatesTags: [{ type: 'Job', id: 'LIST' }]
     }),
-    addNewSANSJob: builder.mutation<BilboMDJobDTO, FormData>({
+    addNewSANSJob: builder.mutation<JobCreationResponse, FormData>({
       query: (newJob) => ({
         url: '/jobs/bilbomd-sans',
         method: 'POST',
@@ -163,7 +171,7 @@ export const jobsApiSlice = apiSlice.injectEndpoints({
       }),
       invalidatesTags: [{ type: 'Job', id: 'LIST' }]
     }),
-    addNewScoperJob: builder.mutation<BilboMDJobDTO, FormData>({
+    addNewScoperJob: builder.mutation<JobCreationResponse, FormData>({
       query: (newJob) => ({
         url: '/jobs/bilbomd-scoper',
         method: 'POST',
@@ -171,7 +179,7 @@ export const jobsApiSlice = apiSlice.injectEndpoints({
       }),
       invalidatesTags: [{ type: 'Job', id: 'LIST' }]
     }),
-    addNewMultiJob: builder.mutation<BilboMDJobDTO, FormData>({
+    addNewMultiJob: builder.mutation<JobCreationResponse, FormData>({
       query: (newJob) => ({
         url: '/jobs/bilbomd-multi',
         method: 'POST',


### PR DESCRIPTION
## Summary

Fixed "Cannot read properties of undefined (reading 'uuid')" error that occurred when submitting new jobs through the web UI. 

The root cause was a type mismatch between the backend API response and frontend expectations:
- **Backend** returns: `{jobid, uuid, md_engine, message}` (flat structure)
- **Frontend** expected: `BilboMDJobDTO` with nested `mongo` field

### Changes Made

- Added `JobCreationResponse` interface to match actual backend response structure
- Updated all job creation mutations in `jobsApiSlice.ts` to use `JobCreationResponse`:
  - `addNewJob`
  - `addNewAutoJob`
  - `addNewAlphaFoldJob`
  - `addNewSANSJob`
  - `addNewScoperJob`
  - `addNewMultiJob`
- Fixed response handling in all job form components to access flat structure instead of nested `mongo` field

## Test plan

- [x] Linting passes: `pnpm -F @bilbomd/ui lint`
- [x] Build succeeds: `pnpm -F @bilbomd/ui build`
- [x] All tests pass: `pnpm -F @bilbomd/ui test` (483 tests)
- [ ] Manual testing: Submit new Classic job and verify success alert displays correctly
- [ ] Manual testing: Submit Auto, AlphaFold, SANS, and Scoper jobs to verify all job types work

🤖 Generated with [Claude Code](https://claude.com/claude-code)