### PR TITLE
feat(ui): add SAXS curve preview with Guinier region to Classic job form

### DIFF
--- a/.changeset/saxs-guinier-preview.md
+++ b/.changeset/saxs-guinier-preview.md
@@ -1,0 +1,6 @@
+---
+'@bilbomd/ui': minor
+'@bilbomd/backend': patch
+---
+
+Add SAXS curve preview with Guinier region highlight to the Classic job submission form.

--- a/apps/backend/src/controllers/jobs/utils/autoRg.ts
+++ b/apps/backend/src/controllers/jobs/utils/autoRg.ts
@@ -46,7 +46,9 @@ const getAutoRg = async (req: Request, res: Response) => {
           uuid: UUID,
           rg: autorgResults.rg,
           rg_min: autorgResults.rg_min,
-          rg_max: autorgResults.rg_max
+          rg_max: autorgResults.rg_max,
+          qmin: autorgResults.qmin,
+          qmax: autorgResults.qmax
         })
         // await new Promise((resolve) => setTimeout(resolve, 5000))
         // Not sure if this is a NetApp issue or a Docker issue, but sometimes this fails

--- a/apps/backend/src/types/bilbomd.d.ts
+++ b/apps/backend/src/types/bilbomd.d.ts
@@ -71,6 +71,8 @@ export type AutoRgResults = {
   rg: number
   rg_min: number
   rg_max: number
+  qmin: number
+  qmax: number
 }
 
 export type DispatchUser = {

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -23,6 +23,7 @@ import { useAddNewPublicJobMutation } from 'slices/publicJobsApiSlice'
 import SendIcon from '@mui/icons-material/Send'
 import { expdataSchema } from 'schemas/ExpdataSchema'
 import { BilboMDClassicJobSchema } from 'schemas/BilboMDClassicJobSchema'
+import SAXSGuinierPlot from './SAXSGuinierPlot'
 import HeaderBox from 'components/HeaderBox'
 import NerscStatusChecker from 'features/nersc/NerscStatusChecker'
 import FileSelect from './FileSelect'
@@ -89,6 +90,13 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const [autoRgError, setAutoRgError] = useState<string | null>(null)
   const [useExampleData, setUseExampleData] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [saxsData, setSaxsData] = useState<{ q: number; intensity: number }[]>(
+    []
+  )
+  const [guinierRegion, setGuinierRegion] = useState<{
+    qmin: number
+    qmax: number
+  } | null>(null)
 
   // RTK Query to fetch the configuration
   const {
@@ -673,18 +681,59 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                           isLoading={isLoading}
                           onFileChange={async (selectedFile: File) => {
                             setAutoRgError(null)
+                            setSaxsData([])
+                            setGuinierRegion(null)
+
+                            // Parse SAXS data in the browser for the preview plot
+                            try {
+                              const text = await selectedFile.text()
+                              const parsed = text
+                                .split('\n')
+                                .filter((line) => {
+                                  const trimmed = line.trim()
+                                  return (
+                                    trimmed.length > 0 &&
+                                    !trimmed.startsWith('#') &&
+                                    /^\d/.test(trimmed)
+                                  )
+                                })
+                                .map((line) => {
+                                  const cols = line.trim().split(/\s+/)
+                                  return {
+                                    q: parseFloat(cols[0] ?? '0'),
+                                    intensity: parseFloat(cols[1] ?? '0')
+                                  }
+                                })
+                                .filter(
+                                  (pt) =>
+                                    isFinite(pt.q) &&
+                                    isFinite(pt.intensity) &&
+                                    pt.intensity > 0
+                                )
+                              setSaxsData(parsed)
+                            } catch {
+                              // Non-fatal — plot just won't show
+                            }
+
                             const isExpdataValid =
                               await expdataSchema.isValid(selectedFile)
                             if (isExpdataValid) {
                               const formData = new FormData()
                               formData.append('dat_file', selectedFile)
                               try {
-                                const { rg, rg_min, rg_max } =
+                                const { rg, rg_min, rg_max, qmin, qmax } =
                                   await calculateAutoRg(formData).unwrap()
                                 void setFieldValue('rg', rg)
                                 void setFieldValue('rg_min', rg_min)
                                 void setFieldValue('rg_max', rg_max)
+                                if (
+                                  typeof qmin === 'number' &&
+                                  typeof qmax === 'number'
+                                ) {
+                                  setGuinierRegion({ qmin, qmax })
+                                }
                               } catch (error) {
+                                setSaxsData([])
                                 setAutoRgError(
                                   `Failed to calculate Rg from *.dat file. Please check the file format and try again. ${error}`
                                 )
@@ -692,6 +741,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                 void setFieldValue('rg_max', '')
                               }
                             } else {
+                              setSaxsData([])
                               setAutoRgError(
                                 `Invalid *.dat file format. Please check the file format and try again.`
                               )
@@ -705,6 +755,15 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                         />
                       </Grid>
                     </Grid>
+                    {saxsData.length > 0 && guinierRegion && (
+                      <Grid sx={{ width: '520px' }}>
+                        <SAXSGuinierPlot
+                          data={saxsData}
+                          qmin={guinierRegion.qmin}
+                          qmax={guinierRegion.qmax}
+                        />
+                      </Grid>
+                    )}
                     <Grid sx={{ display: 'flex', width: '520px' }}>
                       <Typography>
                         <b>Rg Min</b> and <b>Rg Max</b> will be calculated

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -353,6 +353,8 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                           variant={useExampleData ? 'outlined' : 'contained'}
                           onClick={() => {
                             setUseExampleData(!useExampleData)
+                            setSaxsData([])
+                            setGuinierRegion(null)
                             if (!useExampleData) {
                               // Switching to example data: reset file fields
                               if (values.bilbomd_mode === 'pdb') {

--- a/apps/ui/src/features/jobs/SAXSGuinierPlot.tsx
+++ b/apps/ui/src/features/jobs/SAXSGuinierPlot.tsx
@@ -1,0 +1,93 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceArea
+} from 'recharts'
+import { Typography, Box } from '@mui/material'
+
+interface SAXSDataPoint {
+  q: number
+  intensity: number
+}
+
+interface SAXSGuinierPlotProps {
+  data: SAXSDataPoint[]
+  qmin: number
+  qmax: number
+}
+
+const SAXSGuinierPlot = ({ data, qmin, qmax }: SAXSGuinierPlotProps) => {
+  if (data.length === 0) return null
+
+  return (
+    <Box sx={{ mt: 1, mb: 1 }}>
+      <Typography
+        variant="subtitle2"
+        sx={{ mb: 0.5 }}
+      >
+        SAXS Data Preview — highlighted region shows Guinier fit range (q:{' '}
+        {qmin.toFixed(4)}–{qmax.toFixed(4)} Å⁻¹)
+      </Typography>
+      <ResponsiveContainer
+        width="100%"
+        height={260}
+      >
+        <LineChart
+          data={data}
+          margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="q"
+            type="number"
+            scale="linear"
+            domain={['auto', 'auto']}
+            label={{ value: 'q (Å⁻¹)', position: 'insideBottomRight', offset: -5 }}
+            tickFormatter={(v: number) => v.toFixed(3)}
+          />
+          <YAxis
+            scale="log"
+            type="number"
+            domain={['auto', 'auto']}
+            label={{ value: 'I(q)', angle: -90, position: 'insideLeft' }}
+            tickFormatter={(v: number) => v.toExponential(1)}
+            width={70}
+          />
+          <Tooltip
+            formatter={(value) =>
+              typeof value === 'number'
+                ? [value.toExponential(3), 'I(q)']
+                : [String(value), 'I(q)']
+            }
+            labelFormatter={(label) => `q = ${Number(label).toFixed(4)} Å⁻¹`}
+          />
+          <Legend verticalAlign="bottom" />
+          <ReferenceArea
+            x1={qmin}
+            x2={qmax}
+            fill="rgba(255, 200, 0, 0.25)"
+            stroke="rgba(200, 150, 0, 0.6)"
+            strokeWidth={1}
+            label={{ value: 'Guinier', position: 'top', fontSize: 11 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="intensity"
+            name="Exp. Intensity"
+            stroke="#5b8dd9"
+            dot={false}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </Box>
+  )
+}
+
+export default SAXSGuinierPlot

--- a/apps/ui/src/features/jobs/SAXSGuinierPlot.tsx
+++ b/apps/ui/src/features/jobs/SAXSGuinierPlot.tsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
   ReferenceArea
 } from 'recharts'
-import { Typography, Box } from '@mui/material'
+import { Typography, Box, Table, TableBody, TableRow, TableCell } from '@mui/material'
 
 interface SAXSDataPoint {
   q: number
@@ -23,7 +23,20 @@ interface SAXSGuinierPlotProps {
 }
 
 const SAXSGuinierPlot = ({ data, qmin, qmax }: SAXSGuinierPlotProps) => {
-  if (data.length === 0) return null
+  const validData = data.filter((d) => d.intensity > 0)
+  if (validData.length === 0) return null
+
+  const qValues = validData.map((d) => d.q)
+  const intensities = validData.map((d) => d.intensity)
+
+  const xDomain: [number, number] = [Math.min(...qValues), Math.max(...qValues)]
+
+  const yMin = Math.min(...intensities)
+  const yMax = Math.max(...intensities)
+  const yDomain: [number, number] = [
+    Math.pow(10, Math.floor(Math.log10(yMin))),
+    Math.pow(10, Math.ceil(Math.log10(yMax)))
+  ]
 
   return (
     <Box sx={{ mt: 1, mb: 1 }}>
@@ -32,14 +45,14 @@ const SAXSGuinierPlot = ({ data, qmin, qmax }: SAXSGuinierPlotProps) => {
         sx={{ mb: 0.5 }}
       >
         SAXS Data Preview — highlighted region shows Guinier fit range (q:{' '}
-        {qmin.toFixed(4)}–{qmax.toFixed(4)} Å⁻¹)
+        {qmin.toFixed(4)}–{qmax.toFixed(4)} Å⁻¹) used for Rg calculation.
       </Typography>
       <ResponsiveContainer
         width="100%"
         height={260}
       >
         <LineChart
-          data={data}
+          data={validData}
           margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
         >
           <CartesianGrid strokeDasharray="3 3" />
@@ -47,14 +60,18 @@ const SAXSGuinierPlot = ({ data, qmin, qmax }: SAXSGuinierPlotProps) => {
             dataKey="q"
             type="number"
             scale="linear"
-            domain={['auto', 'auto']}
-            label={{ value: 'q (Å⁻¹)', position: 'insideBottomRight', offset: -5 }}
+            domain={xDomain}
+            label={{
+              value: 'q (Å⁻¹)',
+              position: 'insideBottomRight',
+              offset: -5
+            }}
             tickFormatter={(v: number) => v.toFixed(3)}
           />
           <YAxis
             scale="log"
             type="number"
-            domain={['auto', 'auto']}
+            domain={yDomain}
             label={{ value: 'I(q)', angle: -90, position: 'insideLeft' }}
             tickFormatter={(v: number) => v.toExponential(1)}
             width={70}
@@ -86,6 +103,25 @@ const SAXSGuinierPlot = ({ data, qmin, qmax }: SAXSGuinierPlotProps) => {
           />
         </LineChart>
       </ResponsiveContainer>
+      <Table
+        size="small"
+        sx={{ mt: 1, width: 'auto' }}
+      >
+        <TableBody>
+          <TableRow>
+            <TableCell sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}>q min</TableCell>
+            <TableCell sx={{ py: 0.25, pr: 3, border: 0, fontSize: '0.75rem' }}>{xDomain[0].toFixed(4)} Å⁻¹</TableCell>
+            <TableCell sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}>I(q) min</TableCell>
+            <TableCell sx={{ py: 0.25, border: 0, fontSize: '0.75rem' }}>{yMin.toExponential(2)}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}>q max</TableCell>
+            <TableCell sx={{ py: 0.25, pr: 3, border: 0, fontSize: '0.75rem' }}>{xDomain[1].toFixed(4)} Å⁻¹</TableCell>
+            <TableCell sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}>I(q) max</TableCell>
+            <TableCell sx={{ py: 0.25, border: 0, fontSize: '0.75rem' }}>{yMax.toExponential(2)}</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
     </Box>
   )
 }

--- a/apps/ui/src/slices/jobsApiSlice.ts
+++ b/apps/ui/src/slices/jobsApiSlice.ts
@@ -15,6 +15,10 @@ interface FoxsData {
 
 interface AutoRgResponse {
   rg?: number
+  rg_min?: number
+  rg_max?: number
+  qmin?: number
+  qmax?: number
   i0?: number
   [key: string]: unknown
 }

--- a/tools/python/autorg.py
+++ b/tools/python/autorg.py
@@ -125,7 +125,13 @@ def calculate_rg(file_path, output_file):
         rg_max = max(10, min(100, rg_max))
 
         # Create a dictionary with the results
-        result_dict = {"rg": round(rg), "rg_min": rg_min, "rg_max": rg_max}
+        result_dict = {
+            "rg": round(rg),
+            "rg_min": rg_min,
+            "rg_max": rg_max,
+            "qmin": qmin,
+            "qmax": qmax,
+        }
 
         # Write the results to the output file
         with open(output_file, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

Closes #435

- Parse the uploaded `.dat` file in the browser (q, I columns) the moment the user selects it — no extra round-trip needed
- Extend `autorg.py` output and the backend `/autorg` response to include `qmin`/`qmax` (the q-range actually used by the Guinier fit)
- Add a new `SAXSGuinierPlot` component (Recharts log-scale `LineChart` + `ReferenceArea` highlight) that renders directly below the SAXS data file selector in the Classic job form
- Plot only appears after a valid `.dat` file is selected and AutoRg completes successfully; clears on error or file reset

## Files changed

| File | Change |
|------|--------|
| `tools/python/autorg.py` | Add `qmin`/`qmax` to output JSON |
| `apps/backend/src/types/bilbomd.d.ts` | Extend `AutoRgResults` with `qmin`/`qmax` |
| `apps/backend/src/controllers/jobs/utils/autoRg.ts` | Pass `qmin`/`qmax` through in API response |
| `apps/ui/src/slices/jobsApiSlice.ts` | Update `AutoRgResponse` interface |
| `apps/ui/src/features/jobs/SAXSGuinierPlot.tsx` | **New** — log-scale SAXS preview chart with Guinier region |
| `apps/ui/src/features/jobs/NewJobForm.tsx` | Parse `.dat` in browser, manage state, render plot |
| `.changeset/saxs-guinier-preview.md` | Changeset (`@bilbomd/ui` minor, `@bilbomd/backend` patch) |

## Test plan

- [ ] Upload a valid SAXS `.dat` file in the Classic job form — verify the preview chart appears below the file selector showing the full SAXS curve and a highlighted Guinier region
- [ ] Verify the Rg Min / Rg Max fields are still populated automatically as before
- [ ] Upload an invalid file — verify the chart does not appear and the existing error alert is shown
- [ ] Confirm `pnpm lint`, `pnpm build`, and `pnpm test` all pass (117 test files, 957 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)