### PR TITLE
chore: remove eslint major block from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,6 @@
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
       "groupSlug": "github-actions"
-    },
-    {
-      "description": "Block eslint major upgrades — waiting for plugin ecosystem v10 support",
-      "matchPackageNames": ["eslint"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Removes the `eslint` major version block from `renovate.json`

The block was added as a precaution while waiting for the eslint plugin ecosystem to support v10. The repo has since migrated to eslint v10, so the rule is no longer needed. Renovate will now propose eslint major upgrades like any other package.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)