### PR TITLE
feat(ui): enhance SAXS preview — green Guinier region + low-SNR warning bands

### DIFF
--- a/.changeset/saxs-preview-snr-warning-bands.md
+++ b/.changeset/saxs-preview-snr-warning-bands.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': minor
+---
+
+Enhance SAXS Data Preview plot with green Guinier region and low-SNR warning bands. The Guinier fit region is now highlighted in green, and any q-ranges where σ(q) > I(q) (SNR < 1) are highlighted in red so users can see at a glance which portions of their experimental data may be unreliable.

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -90,9 +90,9 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const [autoRgError, setAutoRgError] = useState<string | null>(null)
   const [useExampleData, setUseExampleData] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
-  const [saxsData, setSaxsData] = useState<{ q: number; intensity: number }[]>(
-    []
-  )
+  const [saxsData, setSaxsData] = useState<
+    { q: number; intensity: number; error: number }[]
+  >([])
   const [guinierRegion, setGuinierRegion] = useState<{
     qmin: number
     qmax: number
@@ -703,7 +703,8 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                   const cols = line.trim().split(/\s+/)
                                   return {
                                     q: parseFloat(cols[0] ?? '0'),
-                                    intensity: parseFloat(cols[1] ?? '0')
+                                    intensity: parseFloat(cols[1] ?? '0'),
+                                    error: parseFloat(cols[2] ?? '0')
                                   }
                                 })
                                 .filter(

--- a/apps/ui/src/features/jobs/SAXSGuinierPlot.tsx
+++ b/apps/ui/src/features/jobs/SAXSGuinierPlot.tsx
@@ -14,6 +14,7 @@ import { Typography, Box, Table, TableBody, TableRow, TableCell } from '@mui/mat
 interface SAXSDataPoint {
   q: number
   intensity: number
+  error?: number
 }
 
 interface SAXSGuinierPlotProps {
@@ -21,6 +22,8 @@ interface SAXSGuinierPlotProps {
   qmin: number
   qmax: number
 }
+
+type Segment = { x1: number; x2: number }
 
 const SAXSGuinierPlot = ({ data, qmin, qmax }: SAXSGuinierPlotProps) => {
   const validData = data.filter((d) => d.intensity > 0)
@@ -38,14 +41,40 @@ const SAXSGuinierPlot = ({ data, qmin, qmax }: SAXSGuinierPlotProps) => {
     Math.pow(10, Math.ceil(Math.log10(yMax)))
   ]
 
+  // Find contiguous q-ranges where SNR < 1 (σ > I)
+  const lowSnrSegments: Segment[] = []
+  let segStart: number | null = null
+  for (let i = 0; i < validData.length; i++) {
+    const pt = validData[i]
+    const snrLow =
+      pt.error !== undefined &&
+      isFinite(pt.error) &&
+      pt.error > 0 &&
+      pt.error >= pt.intensity
+
+    if (snrLow) {
+      if (segStart === null) segStart = pt.q
+    } else {
+      if (segStart !== null) {
+        lowSnrSegments.push({ x1: segStart, x2: validData[i - 1].q })
+        segStart = null
+      }
+    }
+  }
+  if (segStart !== null) {
+    lowSnrSegments.push({ x1: segStart, x2: validData[validData.length - 1].q })
+  }
+
   return (
     <Box sx={{ mt: 1, mb: 1 }}>
       <Typography
         variant="subtitle2"
         sx={{ mb: 0.5 }}
       >
-        SAXS Data Preview — highlighted region shows Guinier fit range (q:{' '}
+        SAXS Data Preview — green region: Guinier fit range (q:{' '}
         {qmin.toFixed(4)}–{qmax.toFixed(4)} Å⁻¹) used for Rg calculation.
+        {lowSnrSegments.length > 0 &&
+          ' Red region(s): low signal-to-noise (σ > I) — data may be unreliable.'}
       </Typography>
       <ResponsiveContainer
         width="100%"
@@ -88,11 +117,26 @@ const SAXSGuinierPlot = ({ data, qmin, qmax }: SAXSGuinierPlotProps) => {
           <ReferenceArea
             x1={qmin}
             x2={qmax}
-            fill="rgba(255, 200, 0, 0.25)"
-            stroke="rgba(200, 150, 0, 0.6)"
+            fill="rgba(40, 180, 80, 0.2)"
+            stroke="rgba(20, 140, 50, 0.5)"
             strokeWidth={1}
             label={{ value: 'Guinier', position: 'top', fontSize: 11 }}
           />
+          {lowSnrSegments.map((seg, i) => (
+            <ReferenceArea
+              key={`snr-${i}`}
+              x1={seg.x1}
+              x2={seg.x2}
+              fill="rgba(220, 60, 60, 0.2)"
+              stroke="rgba(200, 0, 0, 0.4)"
+              strokeWidth={1}
+              label={
+                i === 0
+                  ? { value: 'Low SNR', position: 'top', fontSize: 11 }
+                  : undefined
+              }
+            />
+          ))}
           <Line
             type="monotone"
             dataKey="intensity"


### PR DESCRIPTION
## Summary

- Change the Guinier fit region highlight in the SAXS Data Preview from amber to green
- Add red shaded warning bands over any contiguous q-ranges where σ(q) > I(q) (SNR < 1), making unreliable portions of the experimental curve immediately visible before job submission
- Subtitle text updates conditionally to mention low-SNR regions when present

Closes #575

## Changes

**`apps/ui/src/features/jobs/NewJobForm.tsx`**
- Parse `cols[2]` (the σ/error column) from the `.dat` file in the browser-side parser — previously discarded
- Extend `saxsData` state type to `{ q, intensity, error }`

**`apps/ui/src/features/jobs/SAXSGuinierPlot.tsx`**
- Add `error?: number` to `SAXSDataPoint` interface
- Guinier `ReferenceArea`: amber → green (`rgba(40, 180, 80, 0.2)` / `rgba(20, 140, 50, 0.5)`)
- Compute contiguous q-ranges where `error >= intensity` (SNR < 1)
- Render a red `ReferenceArea` (`rgba(220, 60, 60, 0.2)`) per low-SNR segment, with "Low SNR" label on the first
- Subtitle text conditionally appends low-SNR warning message

## Test plan

- [x] Upload a SAXS `.dat` file in the Classic new job form — confirm Guinier region renders green
- [x] Upload a file with poor high-q data (σ > I in the tail) — confirm red warning band(s) appear
- [x] Upload a clean file with no low-SNR points — confirm no red bands appear and subtitle shows only the Guinier description
- [x] `pnpm -F @bilbomd/ui lint` — passes clean
- [x] `pnpm -F @bilbomd/ui build` — passes clean
- [x] `pnpm -F @bilbomd/ui test` — 122 files, 994 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)