### PR TITLE
ci: configure @claude GitHub bot to use LBNL API credentials

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,58 @@
+name: Claude Code
+
+on:
+    issue_comment:
+        types: [created]
+    pull_request_review_comment:
+        types: [created]
+    issues:
+        types: [opened, assigned]
+    pull_request_review:
+        types: [submitted]
+
+jobs:
+    claude:
+        if: |
+            (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+            (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+            (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+            (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+            issues: write
+            id-token: write
+            actions: read # Required for Claude to read CI results on PRs
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1
+
+            - name: Run Claude Code
+              id: claude
+              uses: anthropics/claude-code-action@v1
+              with:
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+                  # Optional: Customize the trigger phrase (default: @claude)
+                  # trigger_phrase: "/claude"
+
+                  # Optional: Trigger when specific user is assigned to an issue
+                  # assignee_trigger: "claude-bot"
+
+                  # Optional: Configure Claude's behavior with CLI arguments
+                  # claude_args: |
+                  #   --model claude-opus-4-1-20250805
+                  #   --max-turns 10
+                  #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+                  #   --system-prompt "Follow our coding standards. Ensure all new code has tests. Use TypeScript for new files."
+
+                  # Optional: Advanced settings configuration
+                  #   settings: |
+                  #     {
+                  #       "env": {
+                  #         "NODE_ENV": "test"
+                  #       }
+                  #     }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,8 +33,11 @@ jobs:
             - name: Run Claude Code
               id: claude
               uses: anthropics/claude-code-action@v1
+              env:
+                  ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+                  ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL }}
               with:
-                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
 
                   # Optional: Customize the trigger phrase (default: @claude)
                   # trigger_phrase: "/claude"

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -16,22 +16,22 @@ export default defineConfig({
     port: 3002,
     proxy: {
       '/api/v1': {
-        target: 'http://localhost:3502',
+        target: 'http://localhost:3501',
         changeOrigin: true,
         secure: false
       },
       '/admin/bullmq': {
-        target: 'http://localhost:3502',
+        target: 'http://localhost:3501',
         changeOrigin: true,
         secure: false
       },
       '/sfapi': {
-        target: 'http://localhost:3502',
+        target: 'http://localhost:3501',
         changeOrigin: true,
         secure: false
       },
       '/api-docs': {
-        target: 'http://localhost:3502',
+        target: 'http://localhost:3501',
         changeOrigin: true,
         secure: false
       }


### PR DESCRIPTION
## Summary

- Switch `anthropic_api_key` from `secrets.ANTHROPIC_API_KEY` to `secrets.ANTHROPIC_AUTH_TOKEN` (the LBNL-provided key)
- Inject `ANTHROPIC_BASE_URL` and `ANTHROPIC_MODEL` repo variables as env vars so the action routes through the LBNL API endpoint instead of the default Anthropic API

## Test plan

- [ ] Merge and trigger a `@claude` mention in an issue or PR comment to verify the bot responds using the LBNL API

🤖 Generated with [Claude Code](https://claude.com/claude-code)