### PR TITLE
feat: admin-only BullMQ dashboard access

### DIFF
--- a/.changeset/admin-bullmq-dashboard.md
+++ b/.changeset/admin-bullmq-dashboard.md
@@ -1,0 +1,6 @@
+---
+'@bilbomd/backend': minor
+'@bilbomd/ui': minor
+---
+
+Add admin-only BullMQ dashboard access. Admins can now open the bull-board queue dashboard via a new sidebar link. Protected by nginx auth_request using the session cookie, so no unauthenticated access is possible.

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -9,6 +9,7 @@ import { logger, requestLogger, assignRequestId } from './middleware/loggers.js'
 import cookieParser from 'cookie-parser'
 import session from 'express-session'
 import { router as adminRoutes } from './routes/admin.js'
+import { bullmqAuthCheck } from './controllers/admin/bullmqAuthCheck.js'
 import mongoose from 'mongoose'
 import { connectDB } from './config/dbConn.js'
 import { initOrcidClient } from './controllers/auth/orcidClientConfig.js'
@@ -89,6 +90,8 @@ app.use(
 
 // Serve static files
 app.use('/', express.static('public'))
+
+app.get('/api/v1/admin/bullmq-auth', bullmqAuthCheck)
 
 app.use('/admin/bullmq', adminRoutes)
 

--- a/apps/backend/src/controllers/admin/bullmqAuthCheck.ts
+++ b/apps/backend/src/controllers/admin/bullmqAuthCheck.ts
@@ -1,0 +1,33 @@
+import jwt from 'jsonwebtoken'
+import { Request, Response } from 'express'
+import { getEnvVar } from '../../config/config.js'
+
+interface BilboMDJwtPayload {
+  username: string
+  roles: string[]
+  email: string
+}
+
+const refreshTokenSecret = getEnvVar('REFRESH_TOKEN_SECRET')
+
+const bullmqAuthCheck = (req: Request, res: Response) => {
+  const cookies = req.cookies
+  if (!cookies?.jwt) {
+    res.status(401).json({ message: 'Unauthorized' })
+    return
+  }
+  try {
+    const decoded = jwt.verify(cookies.jwt, refreshTokenSecret, {
+      algorithms: ['HS256']
+    }) as BilboMDJwtPayload
+    if (!decoded.roles?.includes('Admin')) {
+      res.status(403).json({ message: 'Forbidden' })
+      return
+    }
+    res.status(200).json({ message: 'OK' })
+  } catch {
+    res.status(401).json({ message: 'Unauthorized' })
+  }
+}
+
+export { bullmqAuthCheck }

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -25,6 +25,7 @@ const redis = new Redis(redisOptions)
 const bilbomdQueue = new QueueMQ('bilbomd', { connection: redis })
 const bilbomdScoperQueue = new QueueMQ('bilbomd-scoper', { connection: redis })
 const multimdQueue = new QueueMQ('multimd', { connection: redis })
+const deleteBilbomdQueue = new QueueMQ('delete-bilbomd', { connection: redis })
 
 const serverAdapter = new ExpressAdapter()
 serverAdapter.setBasePath(basePath)
@@ -33,7 +34,8 @@ createBullBoard({
   queues: [
     new BullMQAdapter(bilbomdQueue),
     new BullMQAdapter(bilbomdScoperQueue),
-    new BullMQAdapter(multimdQueue)
+    new BullMQAdapter(multimdQueue),
+    new BullMQAdapter(deleteBilbomdQueue)
   ],
   serverAdapter: serverAdapter
 })

--- a/apps/ui/nginx/nginx.default.conf
+++ b/apps/ui/nginx/nginx.default.conf
@@ -56,6 +56,9 @@ server {
     }
 
     location /admin/bullmq {
+        auth_request /internal/bullmq-auth;
+        error_page 401 403 =302 /login;
+
         client_max_body_size 2M;
         proxy_pass http://backend:3500;
         proxy_set_header Host $host;
@@ -67,6 +70,14 @@ server {
         # Ensure that the path is correctly forwarded to Express
         proxy_redirect off;
         proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location = /internal/bullmq-auth {
+        internal;
+        proxy_pass http://backend:3500/api/v1/admin/bullmq-auth;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
     }
 
     location /sfapi {

--- a/apps/ui/src/layout/MainLayout/index.tsx
+++ b/apps/ui/src/layout/MainLayout/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/icons-material'
 import SettingsIcon from '@mui/icons-material/Settings'
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings'
+import SpeedIcon from '@mui/icons-material/Speed'
 import { Outlet, useLocation, useNavigate } from 'react-router'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import useAuth from 'hooks/useAuth'
@@ -153,6 +154,13 @@ export default function ClippedDrawer() {
       icon: <AdminPanelSettingsIcon />,
       path: '/admin',
       onclick: () => navigate('admin'),
+      roles: ['admin']
+    },
+    {
+      text: 'BullMQ',
+      icon: <SpeedIcon />,
+      path: '/admin/bullmq',
+      onclick: () => window.open('/admin/bullmq', '_blank'),
       roles: ['admin']
     },
     {

--- a/apps/ui/src/layout/MainLayout/index.tsx
+++ b/apps/ui/src/layout/MainLayout/index.tsx
@@ -21,6 +21,7 @@ import {
 import SettingsIcon from '@mui/icons-material/Settings'
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings'
 import SpeedIcon from '@mui/icons-material/Speed'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import { Outlet, useLocation, useNavigate } from 'react-router'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import useAuth from 'hooks/useAuth'
@@ -159,6 +160,7 @@ export default function ClippedDrawer() {
     {
       text: 'BullMQ',
       icon: <SpeedIcon />,
+      endIcon: <OpenInNewIcon fontSize='inherit' />,
       path: '/admin/bullmq',
       onclick: () => window.open('/admin/bullmq', '_blank'),
       roles: ['admin']
@@ -217,6 +219,7 @@ export default function ClippedDrawer() {
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
                 <ListItemText sx={{ ml: 1 }}>{item.text}</ListItemText>
+                {'endIcon' in item && item.endIcon}
               </ListItemButton>
             </ListItem>
           ))}


### PR DESCRIPTION
## Summary

- Adds `bullmqAuthCheck` controller that validates the httpOnly `jwt` refresh-token cookie and checks for Admin role — used by nginx as an auth subrequest gate
- Mounts `GET /api/v1/admin/bullmq-auth` in the backend (no Bearer middleware required, reads cookie directly)
- Updates nginx `nginx.default.conf` to protect `/admin/bullmq` with `auth_request`; unauthenticated users are redirected to `/login`
- Adds a "BullMQ" sidebar nav item (Admin-only, opens in new tab) to the BilboMD UI

## Test plan

- [x] Log in as Admin → "BullMQ" appears in sidebar → click opens bull-board dashboard in new tab
- [x] Log in as non-Admin → "BullMQ" sidebar item is hidden
- [x] Open `/admin/bullmq` in a private/unauthenticated browser window → redirected to `/login`
- [x] Verify backend and UI Docker images build successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)