### PR TITLE
fix: derive CORS allowed origins from env vars at runtime

### DIFF
--- a/.changeset/cors-dynamic-allowed-origins.md
+++ b/.changeset/cors-dynamic-allowed-origins.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/backend': patch
+---
+
+CORS allowed origins are now derived at runtime from `BILBOMD_URL` and `BILBOMD_UI_PORT`, fixing CORS errors for external users installing BilboMD on their own hardware. An optional `CORS_ALLOWED_ORIGINS` env var (comma-separated) is also supported for additional origins.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -281,6 +281,15 @@ docker compose --env-file .env.local -f docker-compose.local.yml -p bilbomd-loca
 
 ## Troubleshooting
 
+**CORS error in the backend logs (`Error: Not allowed by CORS`)**
+The backend derives the allowed UI origin automatically from `BILBOMD_URL` and
+`BILBOMD_UI_PORT`. Make sure these values in `.env.local` match the URL your
+browser uses to reach BilboMD. For example, if you access the UI at
+`http://192.168.1.50:3001`, set `BILBOMD_URL=http://192.168.1.50` and
+`BILBOMD_UI_PORT=3001`, then restart the backend container. To allow additional
+origins (e.g. a reverse proxy), set
+`CORS_ALLOWED_ORIGINS=http://host1:port,http://host2:port` in `.env.local`.
+
 **`BILBOMD_DEV_BIND_ADDR` or similar variable errors on startup**
 The compose file uses `${VAR:?err}` syntax which aborts if a variable is unset.
 Double-check that your `.env.local` has all required variables set.

--- a/apps/backend/src/config/allowedOrigins.ts
+++ b/apps/backend/src/config/allowedOrigins.ts
@@ -29,4 +29,25 @@ const allowedOrigins: AllowedOrigin[] = [
   'https://bilbomd-nersc.bl1231.als.lbl.gov'
 ]
 
+// Auto-derive the UI origin from BILBOMD_URL + BILBOMD_UI_PORT so external
+// installs work without hardcoding their host in the image.
+const bilbomdUrl = process.env.BILBOMD_URL
+const bilbomdUiPort = process.env.BILBOMD_UI_PORT
+if (bilbomdUrl) {
+  allowedOrigins.push(bilbomdUrl)
+  if (bilbomdUiPort) {
+    allowedOrigins.push(`${bilbomdUrl}:${bilbomdUiPort}`)
+  }
+}
+
+// Escape hatch for any additional origins (comma-separated).
+const extra = process.env.CORS_ALLOWED_ORIGINS
+if (extra) {
+  extra
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .forEach((o) => allowedOrigins.push(o))
+}
+
 export { allowedOrigins }

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -11,6 +11,9 @@ BILBOMD_DEV_BIND_ADDR=127.0.0.1
 BILBOMD_BACKEND_PORT=3501
 BILBOMD_URL=http://localhost
 BILBOMD_FQDN=localhost
+# CORS: the UI origin (BILBOMD_URL:BILBOMD_UI_PORT) is allowed automatically.
+# Add extra origins only if needed (comma-separated):
+# CORS_ALLOWED_ORIGINS=http://other-host:3001
 
 # 3001 for production on hyperion
 # This is the port that Apache/NGINX will be connecting to.


### PR DESCRIPTION
## Summary

- `allowedOrigins.ts` now reads `BILBOMD_URL` + `BILBOMD_UI_PORT` at startup and pushes the derived UI origin into the allowed list, so external installs work without hardcoding anything in the image
- Optional `CORS_ALLOWED_ORIGINS` env var (comma-separated) added as an escape hatch for edge cases like reverse proxies
- `infra/.env.example` and `INSTALL.md` updated with documentation and a new troubleshooting entry

Closes #600

## Test plan

- [ ] Set `BILBOMD_URL=http://127.0.0.1` and `BILBOMD_UI_PORT=3001` in `.env.local`, start backend, confirm no CORS error from `http://127.0.0.1:3001`
- [ ] Set `CORS_ALLOWED_ORIGINS=http://test.example.com:9999`, confirm that origin is allowed
- [ ] Confirm existing production origins (SIBYLS, NERSC) still work (hardcoded list unchanged)
- [ ] `pnpm -F @bilbomd/backend lint && build && test` — all pass (368 tests ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)