### PR TITLE
fix(security): harden .dockerignore files to prevent secrets leaking into images

### DIFF
--- a/apps/backend/.dockerignore
+++ b/apps/backend/.dockerignore
@@ -17,6 +17,19 @@ bilbomd-test-data
 uploads
 imp-2.18.0.tar.gz
 .env
+.env.*
+.env.local
 test
 !test_scripts/data/**
 test.rest
+
+# Private keys and certificates
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.cer
+id_rsa*
+id_ed25519*
+id_dsa*

--- a/apps/scoper/.dockerignore
+++ b/apps/scoper/.dockerignore
@@ -14,6 +14,22 @@ logs
 .eslintrc.yml
 bilbomd-test-data
 imp-2.18.0.tar.gz
+
+# Environment files
+.env
+.env.*
+.env.local
+
+# Private keys and certificates
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.cer
+id_rsa*
+id_ed25519*
+id_dsa*
 **/node_modules
 **/dist
 **/build

--- a/apps/ui/.dockerignore
+++ b/apps/ui/.dockerignore
@@ -14,7 +14,10 @@ out/
 .hg/
 .cvsignore
 
-# Configuration files
+# Environment files
+.env
+.env.*
+.env.local
 .env.development.local
 .env.test.local
 .env.production.local
@@ -40,3 +43,14 @@ yarn.lock
 
 # Optional eslint cache
 .eslintcache
+
+# Private keys and certificates
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.cer
+id_rsa*
+id_ed25519*
+id_dsa*

--- a/apps/worker/.dockerignore
+++ b/apps/worker/.dockerignore
@@ -14,3 +14,19 @@ logs
 .eslintrc.yml
 bilbomd-test-data
 imp-2.18.0.tar.gz
+
+# Environment files
+.env
+.env.*
+.env.local
+
+# Private keys and certificates
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.cer
+id_rsa*
+id_ed25519*
+id_dsa*


### PR DESCRIPTION
## Summary

- Add `.env.*` and `.env.local` patterns to `apps/backend/.dockerignore` (previously only `.env` was excluded)
- Add full env file + private key exclusions to `apps/worker/.dockerignore` (had no env protection at all)
- Add full env file + private key exclusions to `apps/scoper/.dockerignore` (had no env protection at all)
- Fix `apps/ui/.dockerignore` to exclude `.env` and `.env.*` — **critical**: `apps/ui/.env` exists on disk and was not excluded, meaning it could be baked into Docker image layers

Private key/certificate patterns added to all four files: `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.crt`, `*.cer`, `id_rsa*`, `id_ed25519*`, `id_dsa*`

The root `.dockerignore` uses a deny-all (`**`) approach and was not changed.

## Test plan

- [ ] Verify `docker build` for backend, worker, scoper, and ui no longer includes `.env` files in the build context
- [ ] Confirm containers still start correctly with env vars injected via `env_file:` in docker-compose (runtime injection is unaffected by `.dockerignore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)