### PR TITLE
fix(security): harden root .dockerignore against sensitive file leakage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,26 +1,49 @@
 # Ignore everything by default
 **
 
-# Re-include only what the backend build needs
+# Root manifests needed by all services
 !pnpm-workspace.yaml
 !pnpm-lock.yaml
 !package.json
 !LICENSE.txt
 
-# Unignore dirs so we can include subpaths
+# Re-include entire dirs — !apps and !packages bring in ALL contents.
+# Docker rule: a ! pattern matching a directory re-includes all its files.
+# The explicit per-path lines below are kept for documentation clarity only.
 !apps
 !packages
 
-# Include backend app code
+# All service source trees (redundant with !apps above, but explicit)
 !apps/backend/**
-# Include the schema package used by backend
-!packages/mongodb-schema/**
+!apps/ui/**
+!apps/worker/**
+!apps/scoper/**
 
-# If you have shared config packages that backend needs, include them too:
+# All shared packages (redundant with !packages above, but explicit)
+!packages/mongodb-schema/**
+!packages/md-utils/**
+!packages/bilbomd-types/**
 !packages/tsconfig/**
 !packages/eslint-config/**
+
+# Shared runtime assets
 !tools/python/**
 !example-data/**
+
+# Deny sensitive files that survive the broad !apps / !packages re-includes.
+# Last-match-wins: these take precedence over the directory re-includes above.
+**/.env
+**/.env.*
+**/.env.local
+**/*.pem
+**/*.key
+**/*.p12
+**/*.pfx
+**/*.crt
+**/*.cer
+**/id_rsa*
+**/id_ed25519*
+**/id_dsa*
 
 # Keep these ignored even if matched above
 .git/


### PR DESCRIPTION
## Summary

- The root `.dockerignore` is the one actually used by all four CI Docker builds (`context: .`) — plain `.dockerignore` files in Dockerfile subdirectories get no special treatment from Docker/BuildKit
- The broad `!apps` and `!packages` re-includes bring in **all** contents of those directories (Docker re-includes all files when a `!` pattern matches a directory)
- This caused `apps/ui/.env` and any other sensitive files under `apps/` or `packages/` to be present in every build context, potentially landing in intermediate image layers via `COPY . .`
- Fix: add `**/.env`, `**/.env.*`, and private key/certificate patterns **after** the re-include block — last-match-wins excludes them despite the directory re-includes
- Also expanded the explicit per-service and per-package documentation lines (previously listed backend only) and fixed the misleading comment

## Test plan

- [ ] Confirm all four Docker build jobs pass in CI
- [ ] Verify `apps/ui/.env` is not present in the UI build context: `docker build -f apps/ui/bilbomd-ui.dockerfile . --progress=plain 2>&1 | grep -i env`
- [ ] Confirm `tools/python/` and `example-data/` are still present in the backend image: `docker run --rm <image> ls /app/scripts && ls /app/examples`

🤖 Generated with [Claude Code](https://claude.com/claude-code)