### PR TITLE
ci: exclude worker base-image files from ci.yml triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
       - "docs/**/*.md"
       - "infra/**"
       - "test_scripts/**"
+      - "apps/worker/base-image-version"
+      - "apps/worker/bilbomd-worker-base.dockerfile"
   pull_request:
     branches: [main]
     paths-ignore:
@@ -15,6 +17,8 @@ on:
       - "docs/**/*.md"
       - "infra/**"
       - "test_scripts/**"
+      - "apps/worker/base-image-version"
+      - "apps/worker/bilbomd-worker-base.dockerfile"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Problem

After merging a PR that only changed `apps/worker/base-image-version`, both `worker-base-image.yml` (expected) and `ci.yml` (unexpected) fired.

`ci.yml` uses `paths-ignore` rather than an explicit `paths` allowlist, so it triggers on any push that touches a file not in the ignore list. `apps/worker/base-image-version` wasn't listed, causing the entire workflow to run. The `changes` job's `worker` filter (`apps/worker/**`) matched the file, setting `changes.outputs.worker == 'true'` and running the worker Docker build — rebuilding `bilbomd-worker.dockerfile` against the **old** base image. Wasteful and misleading.

The same problem applies to `bilbomd-worker-base.dockerfile`: it also matches `apps/worker/**` but is exclusively the domain of `worker-base-image.yml`.

## Fix

Add both files to `paths-ignore` in `ci.yml` under both `push` and `pull_request` triggers.

```yaml
- "apps/worker/base-image-version"
- "apps/worker/bilbomd-worker-base.dockerfile"
```

When a PR touches **only** these files, `ci.yml` is skipped entirely. When a PR touches these files **alongside** real worker source code, `ci.yml` still triggers correctly and `changes.outputs.worker` evaluates `true` from the other changed files.

## Test plan

- [ ] PR touching only `apps/worker/base-image-version` → `ci.yml` does not appear in Actions; `worker-base-image.yml` triggers
- [ ] PR touching only `apps/worker/bilbomd-worker-base.dockerfile` → same
- [ ] PR touching `apps/worker/base-image-version` + a file under `apps/worker/src/` → `ci.yml` triggers normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)