### PR TITLE
fix(worker): set bomlev -2 in dcd2pdb templates to allow CGenFF NBFIX warnings

### DIFF
--- a/.changeset/worker-fix-dcd2pdb-bomlev.md
+++ b/.changeset/worker-fix-dcd2pdb-bomlev.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Fix dcd2pdb CHARMM scripts failing with fatal NBFIX error when reading CGenFF parameter files. Set bomlev -2 in dcd2pdb and dcd2pdb-sans templates to match the other MD step templates.

--- a/apps/worker/src/templates/bilbomd/dcd2pdb-sans.handlebars
+++ b/apps/worker/src/templates/bilbomd/dcd2pdb-sans.handlebars
@@ -4,7 +4,7 @@
 * AUTHOR: Scott Classen
 *
 
-bomlev 0
+bomlev -2
 
 ! Read Topology-Files
 STREAM {{charmm_topo_dir}}

--- a/apps/worker/src/templates/bilbomd/dcd2pdb.handlebars
+++ b/apps/worker/src/templates/bilbomd/dcd2pdb.handlebars
@@ -4,7 +4,7 @@
 * AUTHOR: Scott Classen
 *
 
-bomlev 0
+bomlev -2
 
 ! Read Topology-Files
 STREAM {{charmm_topo_dir}}


### PR DESCRIPTION
## Summary

- Set `bomlev -2` in `dcd2pdb.handlebars` and `dcd2pdb-sans.handlebars` to suppress fatal NBFIX errors when reading CGenFF parameter files
- Aligns these templates with the other MD step templates which already used `bomlev -2`

## Test plan

- [ ] Verify jobs using CGenFF force field parameters (with NBFIX terms) complete the dcd2pdb step without fatal error
- [ ] Confirm standard jobs (non-CGenFF) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)