### PR TITLE
fix: handle DNA/RNA chains in CHARMM constraints and OpenMM minimization

### DIFF
--- a/.changeset/fix-dna-constraints-and-openmm-hydrogens.md
+++ b/.changeset/fix-dna-constraints-and-openmm-hydrogens.md
@@ -1,0 +1,11 @@
+---
+'@bilbomd/worker': patch
+'@bilbomd/backend': patch
+'@bilbomd/md-utils': patch
+---
+
+Fix DNA/RNA residue handling in both CHARMM and OpenMM pipelines.
+
+OpenMM: `minimize.py` now calls `Modeller.addHydrogens(forcefield)` after PDBFixer so that DNA/RNA residues get all required hydrogen atoms (PDBFixer alone misses some, causing a "No template found" crash at system creation).
+
+CHARMM: `constraintUtils.ts` segment-ID mapping now correctly handles DNA/RNA chains. `parseInpConstraints` strips the mol-type prefix (PRO/DNA/RNA/CAR/CAL) to extract the real chain ID from pdb2crd segids (e.g. `DNAD` → `D`). `generateInpFromConstraints`/`convertYamlToInp` accept an optional `chainSegidMap` built by the new `buildChainSegidMap` utility, so YAML→INP conversion emits the correct segid for each chain instead of always defaulting to `PRO{chain}`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
               - 'package.json'
             md-utils:
               - 'packages/md-utils/**'
+              - 'packages/bilbomd-types/**'
               - 'packages/mongodb-schema/**'
               - 'packages/eslint-config/**'
               - 'pnpm-workspace.yaml'
@@ -642,7 +643,9 @@ jobs:
           fi
 
       - name: Build dependencies
-        run: pnpm -C packages/mongodb-schema run build
+        run: |
+          pnpm -C packages/bilbomd-types run build
+          pnpm -C packages/mongodb-schema run build
 
       - name: Build md-utils
         run: pnpm -C packages/md-utils run build

--- a/apps/backend/bilbomd-backend.dockerfile
+++ b/apps/backend/bilbomd-backend.dockerfile
@@ -36,6 +36,7 @@ RUN corepack enable \
 
 # Only copy what's needed to resolve workspaces (good cache behavior)
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/bilbomd-types/package.json packages/bilbomd-types/package.json
 COPY packages/mongodb-schema/package.json packages/mongodb-schema/package.json
 COPY packages/md-utils/package.json packages/md-utils/package.json
 COPY packages/eslint-config/ packages/eslint-config/
@@ -67,9 +68,9 @@ COPY . .
 
 # Install deterministically from lockfile and build
 RUN pnpm install --frozen-lockfile
+RUN pnpm -C packages/bilbomd-types run build
 RUN pnpm -C packages/mongodb-schema run build
 RUN pnpm -C packages/md-utils run build
-RUN pnpm -C packages/bilbomd-types run build
 RUN pnpm -C apps/backend run build
 
 # Produce a minimal deployable bundle for just the backend

--- a/apps/backend/src/controllers/jobs/handleBilboMDClassicPDB.ts
+++ b/apps/backend/src/controllers/jobs/handleBilboMDClassicPDB.ts
@@ -25,7 +25,8 @@ import {
   convertYamlToInp,
   validateYamlConstraints,
   validateInpConstraints,
-  extractConstraintsFromYaml
+  extractConstraintsFromYaml,
+  buildChainSegidMap
 } from '@bilbomd/md-utils'
 import { buildOpenMMParameters } from './utils/openmmParams.js'
 import { buildCHARMMParameters } from './utils/charmmParams.js'
@@ -207,7 +208,8 @@ const handleBilboMDClassicPDB = async (
         md_engine,
         jobDir,
         inpFile,
-        inpFileName
+        inpFileName,
+        pdbFilePath: path.join(jobDir, pdbFileName)
       })
       // Update inpFileName to reflect the standardized output filename
       inpFileName = standardizedFileName
@@ -399,12 +401,14 @@ async function processConstraintFile({
   md_engine,
   jobDir,
   inpFile,
-  inpFileName
+  inpFileName,
+  pdbFilePath
 }: {
   md_engine: 'CHARMM' | 'OpenMM'
   jobDir: string
   inpFile: Express.Multer.File
   inpFileName: string
+  pdbFilePath: string
 }): Promise<string> {
   const filePath = inpFile.path // Use the actual uploaded file path
 
@@ -447,7 +451,11 @@ async function processConstraintFile({
       // Convert YAML to INP for CHARMM
       logger.info('Converting YAML file to INP for CHARMM')
       await validateYamlConstraints(filePath)
-      const inpContent = await convertYamlToInp(filePath)
+      // Build chain→segid map from the PDB so DNA/RNA chains get the correct
+      // pdb2crd-style segid (e.g. "DNAD") rather than defaulting to "PROD".
+      const chainSegidMap = await buildChainSegidMap(pdbFilePath)
+      logger.info(`Chain→segid map: ${JSON.stringify(chainSegidMap)}`)
+      const inpContent = await convertYamlToInp(filePath, logger, chainSegidMap)
 
       // Write INP content to standardized filename
       await fs.writeFile(finalPath, inpContent)

--- a/apps/worker/bilbomd-worker.dockerfile
+++ b/apps/worker/bilbomd-worker.dockerfile
@@ -9,6 +9,7 @@ RUN corepack enable
 
 # Copy only files needed to resolve workspace dependencies (better cache)
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/bilbomd-types/package.json packages/bilbomd-types/package.json
 COPY packages/mongodb-schema/package.json packages/mongodb-schema/package.json
 COPY packages/md-utils/package.json packages/md-utils/package.json
 COPY packages/eslint-config/ packages/eslint-config/
@@ -34,6 +35,7 @@ COPY . .
 RUN pnpm install --frozen-lockfile
 
 # Build shared packages first, then the worker
+RUN pnpm -C packages/bilbomd-types run build
 RUN pnpm -C packages/mongodb-schema run build
 RUN pnpm -C packages/md-utils run build
 RUN pnpm -C apps/worker run build

--- a/apps/worker/scripts/openmm/minimize.py
+++ b/apps/worker/scripts/openmm/minimize.py
@@ -57,6 +57,10 @@ else:
 forcefield = ForceField(*config["input"]["forcefield"])
 modeller = Modeller(fixer.topology, fixer.positions)
 
+# PDBFixer.addMissingHydrogens can miss H atoms on DNA/RNA residues;
+# Modeller.addHydrogens uses forcefield templates to fill any remaining gaps.
+modeller.addHydrogens(forcefield)
+
 # ⚙️ Build system
 system = forcefield.createSystem(
     modeller.topology,

--- a/packages/bilbomd-types/src/pdbResidues.ts
+++ b/packages/bilbomd-types/src/pdbResidues.ts
@@ -1,7 +1,8 @@
 // Authoritative list of residues and ions that BilboMD's PDB validation accepts.
 // This is the single source of truth shared by the frontend and backend.
 // When pdb2crd.py gains support for a new residue, add it here only.
-export const SUPPORTED_PDB_RESIDUES = new Set<string>([
+
+export const PROTEIN_RESIDUES = new Set<string>([
   // Standard amino acids
   'ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY', 'HIS',
   'ILE', 'LEU', 'LYS', 'MET', 'PHE', 'PRO', 'SER', 'THR', 'TRP', 'TYR', 'VAL',
@@ -9,17 +10,33 @@ export const SUPPORTED_PDB_RESIDUES = new Set<string>([
   'SEP', 'TPO', 'PTR',
   // CHARMM internal HIS variant — may appear in PDB files previously processed by CHARMM
   'HSD',
-  // DNA nucleotides
+])
+
+export const DNA_RESIDUES = new Set<string>([
+  // Standard PDB DNA nucleotides
   'DA', 'DC', 'DG', 'DT', 'DI',
-  // RNA nucleotides
+])
+
+export const RNA_RESIDUES = new Set<string>([
+  // Standard PDB RNA nucleotides
   'A', 'C', 'G', 'U', 'I',
-  // Nucleotide aliases recognised by pdb_utils
-  'ADE', 'CYT', 'GUA', 'THY',
+])
+
+export const CARBOHYDRATE_RESIDUES = new Set<string>([
   // Carbohydrates (backend-authoritative: union of pdb_utils.py + pdb2crd.py rename map)
   'AFL', 'ALL', 'ALT', 'BMA', 'BGC', 'BOG', 'FCA', 'FCB', 'FMF',
   'FUC', 'FUL', 'G4S', 'GAL', 'GLA', 'GLB', 'GLC', 'GLS', 'GSA',
   'GUL', 'IDO', 'LAK', 'LAT', 'MAF', 'MAL', 'MAN', 'NAG', 'NAN',
   'NGA', 'RHM', 'RIB', 'SIA', 'SLB', 'TAL', 'XYL',
+])
+
+export const SUPPORTED_PDB_RESIDUES = new Set<string>([
+  ...PROTEIN_RESIDUES,
+  ...DNA_RESIDUES,
+  ...RNA_RESIDUES,
+  // Nucleotide aliases recognised by pdb_utils (post-rename CHARMM names)
+  'ADE', 'CYT', 'GUA', 'THY',
+  ...CARBOHYDRATE_RESIDUES,
   // Other supported ligands
   'HEM',
   // Water — removed by pdb2crd.py, not an error

--- a/packages/md-utils/package.json
+++ b/packages/md-utils/package.json
@@ -25,6 +25,7 @@
     "openmm"
   ],
   "dependencies": {
+    "@bilbomd/bilbomd-types": "workspace:*",
     "@bilbomd/mongodb-schema": "workspace:*",
     "fs-extra": "^11.3.4",
     "yaml": "^2.8.3"

--- a/packages/md-utils/src/constraintUtils.ts
+++ b/packages/md-utils/src/constraintUtils.ts
@@ -6,6 +6,12 @@ import {
   IFixedBody,
   IRigidBody
 } from '@bilbomd/mongodb-schema'
+import {
+  PROTEIN_RESIDUES,
+  DNA_RESIDUES,
+  RNA_RESIDUES,
+  CARBOHYDRATE_RESIDUES
+} from '@bilbomd/bilbomd-types'
 import type { Logger } from './index.js'
 
 // Create a default no-op logger for when none is provided
@@ -36,20 +42,63 @@ export function extractConstraintsFromYaml(
   }
 }
 
-// Mapping from CHARMM segment IDs to chain IDs
-const SEGMENT_TO_CHAIN_MAP: Record<string, string> = {
-  PROA: 'A',
-  PROB: 'B',
-  PROC: 'C',
-  PROD: 'D',
-  PROE: 'E'
-  // Add more mappings as needed
+// pdb2crd assigns segids as {MOL_TYPE}{chain_id} where MOL_TYPE is one of these prefixes.
+// Carbohydrates use CAR (uppercase chain) or CAL (lowercase chain).
+const MOL_TYPE_PREFIXES = ['PRO', 'DNA', 'RNA', 'CAR', 'CAL'] as const
+
+function classifyResidue(name: string): 'PRO' | 'DNA' | 'RNA' | 'CAR' | null {
+  if (PROTEIN_RESIDUES.has(name)) return 'PRO'
+  if (DNA_RESIDUES.has(name)) return 'DNA'
+  if (RNA_RESIDUES.has(name)) return 'RNA'
+  if (CARBOHYDRATE_RESIDUES.has(name)) return 'CAR'
+  return null
 }
 
-// Reverse mapping for YAML to INP conversion
-const CHAIN_TO_SEGMENT_MAP: Record<string, string> = Object.fromEntries(
-  Object.entries(SEGMENT_TO_CHAIN_MAP).map(([seg, chain]) => [chain, seg])
-)
+/**
+ * Reads a PDB file and returns a map of chain_id → CHARMM segid, mirroring
+ * pdb2crd.py's naming convention ({MOL_TYPE}{chain_id}).
+ * Used when converting YAML constraints → CHARMM INP so that DNA/RNA chains
+ * get the correct segid (e.g. "DNAD") rather than defaulting to "PROD".
+ */
+export async function buildChainSegidMap(
+  pdbFilePath: string
+): Promise<Record<string, string>> {
+  const content = await fs.readFile(pdbFilePath, 'utf8')
+  const chainFirstType: Record<string, 'PRO' | 'DNA' | 'RNA' | 'CAR'> = {}
+
+  for (const line of content.split('\n')) {
+    if (!line.startsWith('ATOM') && !line.startsWith('HETATM')) continue
+    const chainId = line[21]
+    if (!chainId || chainId === ' ') continue
+    if (chainId in chainFirstType) continue
+
+    const resName = line.slice(17, 20).trim()
+    const molType = classifyResidue(resName)
+    if (molType) {
+      chainFirstType[chainId] = molType
+    }
+  }
+
+  const result: Record<string, string> = {}
+  for (const [chainId, molType] of Object.entries(chainFirstType)) {
+    result[chainId] = `${molType}${chainId}`
+  }
+  return result
+}
+
+/**
+ * Extracts the PDB chain ID from a pdb2crd-style CHARMM segid.
+ * e.g. "DNAD" → "D", "PROP" → "P", "RNAB" → "B", "CARG" → "G"
+ * Falls back to the raw segid if no known prefix matches.
+ */
+function segidToChainId(segid: string): string {
+  for (const prefix of MOL_TYPE_PREFIXES) {
+    if (segid.startsWith(prefix) && segid.length > prefix.length) {
+      return segid.slice(prefix.length)
+    }
+  }
+  return segid
+}
 
 /**
  * Converts CHARMM INP constraint file to YAML format for OpenMM
@@ -84,11 +133,17 @@ export async function convertInpToYaml(
 }
 
 /**
- * Converts YAML constraint file to CHARMM INP format
+ * Converts YAML constraint file to CHARMM INP format.
+ *
+ * @param chainSegidMap - Optional map of chain_id → CHARMM segid (e.g. {"D": "DNAD", "P": "PROP"}).
+ *   Build this from the PDB file when chains include DNA/RNA so that the generated
+ *   segids match what pdb2crd will produce.  Without it, all chains are assumed to
+ *   be protein (segid = "PRO" + chain_id).
  */
 export async function convertYamlToInp(
   yamlFilePath: string,
-  logger: Logger = defaultLogger
+  logger: Logger = defaultLogger,
+  chainSegidMap?: Record<string, string>
 ): Promise<string> {
   try {
     const yamlContent = await fs.readFile(yamlFilePath, 'utf8')
@@ -107,7 +162,7 @@ export async function convertYamlToInp(
       constraints = parsed as IMDConstraints
     }
 
-    const inpContent = generateInpFromConstraints(constraints)
+    const inpContent = generateInpFromConstraints(constraints, chainSegidMap)
 
     logger.info('Successfully converted YAML to INP')
     return inpContent
@@ -337,7 +392,7 @@ function parseSelectionExpression(
     const definition = definitions[defName]
     if (definition) {
       for (const def of definition) {
-        const chainId = SEGMENT_TO_CHAIN_MAP[def.segid] || def.segid
+        const chainId = segidToChainId(def.segid)
         const [start, stop] = def.resid.split(':').map(Number)
 
         segments.push({
@@ -352,11 +407,17 @@ function parseSelectionExpression(
 }
 
 // Helper function to generate INP from constraints object
-function generateInpFromConstraints(constraints: IMDConstraints): string {
+function generateInpFromConstraints(
+  constraints: IMDConstraints,
+  chainSegidMap?: Record<string, string>
+): string {
   const lines: string[] = ['! Generated constraint file']
   let defCounter = 1
 
   const { fixed_bodies, rigid_bodies } = constraints
+
+  const resolveSegid = (chain_id: string): string =>
+    chainSegidMap?.[chain_id] ?? `PRO${chain_id}`
 
   // Generate definitions and fixed constraints
   if (fixed_bodies && fixed_bodies.length > 0) {
@@ -364,8 +425,7 @@ function generateInpFromConstraints(constraints: IMDConstraints): string {
 
     for (const body of fixed_bodies) {
       for (const segment of body.segments) {
-        const segid =
-          CHAIN_TO_SEGMENT_MAP[segment.chain_id] || `PRO${segment.chain_id}`
+        const segid = resolveSegid(segment.chain_id)
         const defName = `fixed${defCounter++}`
 
         lines.push(
@@ -389,8 +449,7 @@ function generateInpFromConstraints(constraints: IMDConstraints): string {
       const defNames: string[] = []
 
       for (const segment of body.segments) {
-        const segid =
-          CHAIN_TO_SEGMENT_MAP[segment.chain_id] || `PRO${segment.chain_id}`
+        const segid = resolveSegid(segment.chain_id)
         const defName = `rigid${defCounter++}`
 
         lines.push(

--- a/packages/md-utils/src/index.ts
+++ b/packages/md-utils/src/index.ts
@@ -3,7 +3,8 @@ export {
   convertYamlToInp,
   validateYamlConstraints,
   validateInpConstraints,
-  extractConstraintsFromYaml
+  extractConstraintsFromYaml,
+  buildChainSegidMap
 } from './constraintUtils.js'
 
 export { toPipeline, discriminatorToPipeline } from './pipelineUtils.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,9 @@ importers:
 
   packages/md-utils:
     dependencies:
+      '@bilbomd/bilbomd-types':
+        specifier: workspace:*
+        version: link:../bilbomd-types
       '@bilbomd/mongodb-schema':
         specifier: workspace:*
         version: link:../mongodb-schema


### PR DESCRIPTION
Closes #644

## Summary

- **OpenMM**: `minimize.py` now calls `Modeller.addHydrogens(forcefield)` after PDBFixer. PDBFixer misses some H atoms on DNA/RNA nucleotides (e.g. DT was missing 2 H atoms), causing a hard crash at `forcefield.createSystem()`.
- **CHARMM constraints**: `constraintUtils.ts` previously used static protein-only segment maps (`PROA`/`PROB`/…), so DNA chains were silently un-restrained. Replaced with `segidToChainId()` (strips the pdb2crd mol-type prefix) and `buildChainSegidMap()` (reads the PDB to produce the correct `chain→segid` map). The backend now passes this map when converting a YAML constraint file to CHARMM INP.
- **`bilbomd-types`**: split `SUPPORTED_PDB_RESIDUES` into typed sub-sets (`PROTEIN_RESIDUES`, `DNA_RESIDUES`, `RNA_RESIDUES`, `CARBOHYDRATE_RESIDUES`) — single source of truth for residue classification, imported by `md-utils` instead of duplicating the lists inline.

## Files changed

| File | Change |
|------|--------|
| `apps/worker/scripts/openmm/minimize.py` | Add `modeller.addHydrogens(forcefield)` |
| `packages/bilbomd-types/src/pdbResidues.ts` | Add per-type residue set exports |
| `packages/md-utils/src/constraintUtils.ts` | Fix segid↔chainId mapping for DNA/RNA; add `buildChainSegidMap()` |
| `packages/md-utils/src/index.ts` | Export `buildChainSegidMap` |
| `packages/md-utils/package.json` | Add `@bilbomd/bilbomd-types` dependency |
| `apps/backend/src/controllers/jobs/handleBilboMDClassicPDB.ts` | Pass PDB path + chain segid map when converting YAML→INP |

## Test plan

- [ ] Submit a classic PDB job with a protein+DNA complex using the **OpenMM** engine — minimization should complete without "No template found" error
- [ ] Submit the same job using the **CHARMM** engine with a YAML constraint file — DNA chain atoms should be restrained as specified
- [ ] Submit with a CHARMM INP constraint file + OpenMM engine — chain IDs in the generated YAML should be single letters (e.g. `D`), not raw segids (e.g. `DNAD`)
- [ ] All existing tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)