### PR TITLE
fix(worker): strip all H atoms before addHydrogens in OpenMM minimize

### DIFF
--- a/.changeset/fix-openmm-strip-h-before-addhydrogens.md
+++ b/.changeset/fix-openmm-strip-h-before-addhydrogens.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Fix OpenMM minimize crash for DNA/RNA complexes by stripping all H atoms before calling addHydrogens. PDBFixer can partially hydrogenate DNA/RNA residues, leaving them in a state that fails forcefield template matching. Stripping all H first lets addHydrogens place them correctly from forcefield templates.

--- a/apps/worker/scripts/openmm/minimize.py
+++ b/apps/worker/scripts/openmm/minimize.py
@@ -57,9 +57,16 @@ else:
 forcefield = ForceField(*config["input"]["forcefield"])
 modeller = Modeller(fixer.topology, fixer.positions)
 
-# PDBFixer.addMissingHydrogens can miss H atoms on DNA/RNA residues;
-# Modeller.addHydrogens uses forcefield templates to fill any remaining gaps.
-modeller.addHydrogens(forcefield)
+# PDBFixer.addMissingHydrogens can leave DNA/RNA residues partially hydrogenated
+# (some H present but not all), causing addHydrogens to fail template matching.
+# Strip all H atoms first so addHydrogens can place them from forcefield templates.
+h_atoms = [
+    atom
+    for atom in modeller.topology.atoms()
+    if atom.element is not None and atom.element.symbol == "H"
+]
+modeller.delete(h_atoms)
+modeller.addHydrogens(forcefield, pH=7.0)
 
 # ⚙️ Build system
 system = forcefield.createSystem(


### PR DESCRIPTION
## Summary

- The previous fix (`modeller.addHydrogens(forcefield)` after PDBFixer) was itself crashing for protein+DNA complexes
- Root cause: `PDBFixer.addMissingHydrogens()` partially hydrogenates DNA/RNA residues (e.g. DT gets some but not all H atoms), leaving them in a state that matches no forcefield template by heavy atoms alone
- When `addHydrogens` then calls `createSystem` internally to verify its additions, it raises: `ValueError: No template found for residue 203 (DT). The set of heavy atoms matches ABAC, but the residue is missing 2 H atoms`
- Fix: delete all existing H atoms from the Modeller topology after PDBFixer runs, then call `addHydrogens(forcefield, pH=7.0)` so every H atom is placed from a clean state using forcefield templates

## Test plan

- [ ] Submit a BilboMD classic PDB job with a protein+DNA complex using OpenMM engine
- [ ] Confirm `minimize.py` runs to completion without `ValueError: No template found for residue (DT)`
- [ ] Confirm output minimized PDB is written to `min/` directory
- [ ] Confirm protein-only jobs continue to work (H atoms stripped and re-added cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)