### PR TITLE
fix(worker): normalize CHARMM DNA residue names before OpenMM PDBFixer

### DIFF
--- a/.changeset/fix-openmm-charmm-dna-residue-names.md
+++ b/.changeset/fix-openmm-charmm-dna-residue-names.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Normalize CHARMM-style DNA residue names (ADE/GUA/CYT) to standard PDB names (DA/DG/DC) before PDBFixer runs. OpenMM's pdbNames.xml maps ADE/GUA/CYT to RNA residues, causing PDBFixer to add spurious O2' atoms to DNA chains. DNA is detected by absence of the O2' ribose atom.

--- a/apps/worker/scripts/openmm/minimize.py
+++ b/apps/worker/scripts/openmm/minimize.py
@@ -5,6 +5,8 @@ This module provides functionality for energy minimization of a molecular system
 import os
 import sys
 import yaml
+from collections import defaultdict
+from io import StringIO
 from pdbfixer import PDBFixer
 from openmm.app import (
     ForceField,
@@ -16,6 +18,47 @@ from openmm.app import (
 )
 from openmm import LangevinIntegrator
 from openmm.unit import kelvin, picoseconds, nanometer
+
+def _normalize_charmm_nucleic_names(pdb_text: str) -> str:
+    """Rename CHARMM-style DNA residue names to standard PDB convention.
+
+    pdb2crd.py emits ADE/GUA/CYT for DNA, but OpenMM's pdbNames.xml maps
+    ADE->RNA A, GUA->RNA G, CYT->RNA C, causing PDBFixer to add spurious
+    O2' atoms and subsequent createSystem failures. We detect DNA by the
+    absence of the O2' ribose atom and rename to DA/DG/DC before PDBFixer.
+    THY is already handled correctly by pdbNames.xml (THY->DT).
+    """
+    CHARMM_DNA_MAP = {"ADE": "DA ", "GUA": "DG ", "CYT": "DC "}
+
+    lines = pdb_text.splitlines(keepends=True)
+
+    residue_lines: dict = defaultdict(list)
+    for i, line in enumerate(lines):
+        if not line.startswith(("ATOM", "HETATM")):
+            continue
+        resname = line[17:20].strip()
+        if resname in CHARMM_DNA_MAP:
+            key = (line[21], line[22:26], resname)
+            residue_lines[key].append(i)
+
+    rename: dict = {}
+    for (chain_id, resseq, resname), indices in residue_lines.items():
+        atom_names = {lines[i][12:16].strip() for i in indices}
+        if "O2'" not in atom_names and "O2*" not in atom_names:
+            new_name = CHARMM_DNA_MAP[resname]
+            for i in indices:
+                rename[i] = new_name
+
+    if not rename:
+        return pdb_text
+
+    result = []
+    for i, line in enumerate(lines):
+        if i in rename:
+            line = line[:17] + rename[i] + line[20:]
+        result.append(line)
+    return "".join(result)
+
 
 # Load the YAML configuration file
 if len(sys.argv) != 2:
@@ -40,7 +83,10 @@ for d in [output_dir, min_dir, heat_dir, md_dir]:
         os.makedirs(d)
 
 # Step 1: Load and fix the PDB
-fixer = PDBFixer(filename=initial_pdb_file)
+with open(initial_pdb_file, "r", encoding="utf-8") as f:
+    raw_pdb = f.read()
+normalized_pdb = _normalize_charmm_nucleic_names(raw_pdb)
+fixer = PDBFixer(pdbfile=StringIO(normalized_pdb))
 fixer.findMissingResidues()
 fixer.findMissingAtoms()
 fixer.addMissingAtoms()


### PR DESCRIPTION
## Summary

- Adds `_normalize_charmm_nucleic_names()` preprocessing step in `minimize.py` that runs before `PDBFixer`
- Detects CHARMM-style DNA residue names (`ADE`, `GUA`, `CYT`) and renames them to standard PDB convention (`DA`, `DG`, `DC`) before PDBFixer processes the file
- DNA is detected by the absence of the `O2'` ribose hydroxyl atom (present in RNA, absent in DNA)
- `THY` is left alone — `pdbNames.xml` already maps it correctly to `DT`

## Problem

`pdb2crd.py` (CHARMM) renames DNA residues from standard PDB convention to CHARMM convention. Users may submit PDB files containing these CHARMM-style names. OpenMM's `pdbNames.xml` then maps `ADE`→RNA `A`, `GUA`→RNA `G`, `CYT`→RNA `C`, causing PDBFixer to treat DNA chains as RNA and add spurious `O2'` atoms. The subsequent `forcefield.createSystem()` call fails with a template mismatch.

Closes #649

## Test plan

- [ ] Submit an OpenMM job with a PDB where DNA residues use CHARMM names (`ADE`/`GUA`/`CYT`/`THY`) — should run without template mismatch errors
- [ ] Submit an OpenMM job with standard PDB DNA names (`DA`/`DG`/`DC`/`DT`) — no regression
- [ ] Protein-only OpenMM job — no regression
- [ ] RNA OpenMM job — `A`/`G`/`C`/`U` residues (with `O2'`) remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)