### PR TITLE
Fix Molstar viewer not showing non-protein entities on initial load

### DIFF
--- a/.changeset/ui-molstar-non-protein-entities.md
+++ b/.changeset/ui-molstar-non-protein-entities.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Fix Molstar viewer not showing glycans, cofactors, and ions on initial load. Apply StructurePreset to all ensemble structures and add branched entity support to display presets.

--- a/apps/ui/src/features/molstar/Viewer.tsx
+++ b/apps/ui/src/features/molstar/Viewer.tsx
@@ -371,29 +371,16 @@ const MolstarViewer = ({
             refs.push(struct.ref)
             ensembleStructureRefs.current.set(ensembleSize, refs)
           }
-          if (jobType === 'scoper') {
-            // For Scoper, apply StructurePreset so Mg ions (and polymer) are shown
-            const plugin = window.molstar
-            const allStructs =
-              plugin.managers.structure.hierarchy.current.structures
-            const structureRef = allStructs.find(
-              (s) => s.cell.transform.ref === struct.ref
-            )
-            if (structureRef) {
-              await plugin.managers.structure.component.applyPreset(
-                [structureRef],
-                StructurePreset
-              )
-            }
-          } else {
-            await window.molstar.builders.structure.representation.addRepresentation(
-              struct,
-              {
-                type: 'cartoon',
-                color: 'structure-index',
-                size: 'uniform',
-                sizeParams: { value: 1.0 }
-              }
+          const plugin = window.molstar
+          const allStructs =
+            plugin.managers.structure.hierarchy.current.structures
+          const structureRef = allStructs.find(
+            (s) => s.cell.transform.ref === struct.ref
+          )
+          if (structureRef) {
+            await plugin.managers.structure.component.applyPreset(
+              [structureRef],
+              StructurePreset
             )
           }
         }

--- a/apps/ui/src/features/molstar/presets.ts
+++ b/apps/ui/src/features/molstar/presets.ts
@@ -111,7 +111,8 @@ export const StructurePreset = StructureRepresentationPresetProvider({
     const components = {
       ligand: await presetStaticComponent(plugin, structureCell, 'ligand'),
       polymer: await presetStaticComponent(plugin, structureCell, 'polymer'),
-      ions: await presetStaticComponent(plugin, structureCell, 'ion')
+      ions: await presetStaticComponent(plugin, structureCell, 'ion'),
+      branched: await presetStaticComponent(plugin, structureCell, 'branched')
     }
 
     const { update, builder, typeParams } =
@@ -150,6 +151,17 @@ export const StructurePreset = StructureRepresentationPresetProvider({
           colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
         },
         { tag: 'ions' }
+      ),
+      branched: builder.buildRepresentation(
+        update,
+        components.branched,
+        {
+          type: 'ball-and-stick',
+          typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.35 },
+          color: 'element-symbol',
+          colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
+        },
+        { tag: 'branched' }
       )
     }
 
@@ -172,7 +184,8 @@ export const IllustrativePreset = StructureRepresentationPresetProvider({
     const components = {
       ligand: await presetStaticComponent(plugin, structureCell, 'ligand'),
       polymer: await presetStaticComponent(plugin, structureCell, 'polymer'),
-      ions: await presetStaticComponent(plugin, structureCell, 'ion')
+      ions: await presetStaticComponent(plugin, structureCell, 'ion'),
+      branched: await presetStaticComponent(plugin, structureCell, 'branched')
     }
 
     const { update, builder, typeParams } =
@@ -211,6 +224,17 @@ export const IllustrativePreset = StructureRepresentationPresetProvider({
           colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
         },
         { tag: 'ions' }
+      ),
+      branched: builder.buildRepresentation(
+        update,
+        components.branched,
+        {
+          type: 'spacefill',
+          typeParams: { ...typeParams, ignoreLight: true },
+          color: 'element-symbol',
+          colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
+        },
+        { tag: 'branched' }
       )
     }
 
@@ -234,7 +258,8 @@ export const SurfacePreset = StructureRepresentationPresetProvider({
     const components = {
       ligand: await presetStaticComponent(plugin, structureCell, 'ligand'),
       polymer: await presetStaticComponent(plugin, structureCell, 'polymer'),
-      ions: await presetStaticComponent(plugin, structureCell, 'ion')
+      ions: await presetStaticComponent(plugin, structureCell, 'ion'),
+      branched: await presetStaticComponent(plugin, structureCell, 'branched')
     }
 
     const { update, builder, typeParams } =
@@ -277,6 +302,17 @@ export const SurfacePreset = StructureRepresentationPresetProvider({
           colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
         },
         { tag: 'ions' }
+      ),
+      branched: builder.buildRepresentation(
+        update,
+        components.branched,
+        {
+          type: 'ball-and-stick',
+          typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.35 },
+          color: 'element-symbol',
+          colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
+        },
+        { tag: 'branched' }
       )
     }
 


### PR DESCRIPTION
## Summary

- Apply `StructurePreset` to all ensemble structures (pdb, crd, auto, alphafold) instead of a bare `cartoon` representation — ensures ions, cofactors, and ligands are visible from the start
- Unify the scoper and ensemble code paths: both now go through `plugin.managers.structure.component.applyPreset`
- Add a `branched` component (ball-and-stick) to `StructurePreset`, `IllustrativePreset`, and `SurfacePreset` so glycans/carbohydrates are rendered in all three display modes

Closes #659

## Test plan

- [ ] Load a job with glycans and verify they appear on initial Molstar load
- [ ] Load a job with cofactors/ions and verify they appear on initial load
- [ ] Confirm all three presets (Structure, Illustrative, Surface) display branched entities
- [ ] Confirm scoper jobs still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)