### PR TITLE
fix(worker): preserve original chain IDs in all OpenMM output PDB files

### DIFF
--- a/.changeset/fix-openmm-preserve-chain-ids.md
+++ b/.changeset/fix-openmm-preserve-chain-ids.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Fix non-protein atoms (glycans, FAD, cofactors) being reassigned to Chain B in OpenMM output PDB files. Added `keepIds=True` to all `PDBFile.writeFile` calls in heat.py, md.py, and pdb_writer.py so chain IDs from the input structure are preserved throughout the pipeline.

--- a/apps/worker/scripts/openmm/heat.py
+++ b/apps/worker/scripts/openmm/heat.py
@@ -109,7 +109,7 @@ positions = simulation.context.getState(getPositions=True).getPositions()
 with open(
     os.path.join(heat_dir, output_pdb_file_name), "w", encoding="utf-8"
 ) as out_pdb:
-    PDBFile.writeFile(simulation.topology, positions, out_pdb)
+    PDBFile.writeFile(simulation.topology, positions, out_pdb, keepIds=True)
 
 # Save restart file
 with open(os.path.join(heat_dir, output_restart_file_name), "w", encoding="utf-8") as f:

--- a/apps/worker/scripts/openmm/md.py
+++ b/apps/worker/scripts/openmm/md.py
@@ -175,7 +175,7 @@ def run_md_for_rg(rg, config_path, gpu_id=None):
     with open(
         os.path.join(rg_md_dir, output_pdb_file_name), "w", encoding="utf-8"
     ) as out_pdb:
-        PDBFile.writeFile(simulation.topology, final_state.getPositions(), out_pdb)
+        PDBFile.writeFile(simulation.topology, final_state.getPositions(), out_pdb, keepIds=True)
 
     print(f"[GPU {gpu_id}] ✅ Completed MD with Rg {rg}. Results in {rg_md_dir}")
 

--- a/apps/worker/scripts/openmm/utils/pdb_writer.py
+++ b/apps/worker/scripts/openmm/utils/pdb_writer.py
@@ -33,5 +33,5 @@ class PDBFrameWriter:
         fname = f"{self._base}_{int(step):09d}.pdb"
         out_path = os.path.join(self._dir, fname)
         with open(out_path, "w", encoding="utf-8") as fh:
-            PDBFile.writeFile(simulation.topology, state.getPositions(), fh)
+            PDBFile.writeFile(simulation.topology, state.getPositions(), fh, keepIds=True)
         self._count += 1


### PR DESCRIPTION
## Summary

- `heat.py`, `md.py`, and `pdb_writer.py` were calling `PDBFile.writeFile()` without `keepIds=True`, causing OpenMM to assign sequential chain letters (A, B, …) instead of retaining the IDs from the input structure
- Non-protein residues (glycans, FAD, cofactors) sharing Chain A with the protein were silently moved to Chain B in every output file produced after minimization
- `minimize.py` already used `keepIds=True` correctly — this fix brings the other three writers into line

## Test plan

- [x] Run a glycoprotein job end-to-end and confirm `heated.pdb`, `md.pdb`, and MD frame PDBs all retain Chain A for cofactors/glycans
- [x] Run a standard (non-glycoprotein) job to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)