### PR TITLE
feat(worker): show non-protein entities as sticks/spheres in trajectory movies

### DIFF
--- a/.changeset/worker-movie-show-non-protein-entities.md
+++ b/.changeset/worker-movie-show-non-protein-entities.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': minor
+---
+
+Show non-protein entities (glycans, ligands, metal ions) in trajectory movies. Previously, PyMOL's cartoon representation left these atoms invisible; organic entities now render as sticks and inorganic atoms as spheres, both colored by element.

--- a/apps/worker/scripts/pymol/make_dcd_movie.py
+++ b/apps/worker/scripts/pymol/make_dcd_movie.py
@@ -410,6 +410,20 @@ def main():
         cmd.hide("everything", "mol")
         cmd.show("cartoon", "mol")
 
+        # Show organic non-protein entities (glycans, ligands) as sticks
+        organic_sel = "(mol) and organic"
+        if cmd.count_atoms(organic_sel) > 0:
+            cmd.show("sticks", organic_sel)
+            cmd.color("byelement", organic_sel)
+            print(f"[style] showing {cmd.count_atoms(organic_sel)} organic atoms as sticks")
+
+        # Show inorganic entities (metal ions) as spheres
+        inorganic_sel = "(mol) and inorganic"
+        if cmd.count_atoms(inorganic_sel) > 0:
+            cmd.show("spheres", inorganic_sel)
+            cmd.color("byelement", inorganic_sel)
+            print(f"[style] showing {cmd.count_atoms(inorganic_sel)} inorganic atoms as spheres")
+
         # apply coloring scheme
         _apply_coloring_scheme("mol", args, constraints_config)
 

--- a/apps/worker/scripts/pymol/make_dcd_movie.py
+++ b/apps/worker/scripts/pymol/make_dcd_movie.py
@@ -414,14 +414,14 @@ def main():
         organic_sel = "(mol) and organic"
         if cmd.count_atoms(organic_sel) > 0:
             cmd.show("sticks", organic_sel)
-            cmd.color("byelement", organic_sel)
+            cmd.util.cbaw(organic_sel)
             print(f"[style] showing {cmd.count_atoms(organic_sel)} organic atoms as sticks")
 
         # Show inorganic entities (metal ions) as spheres
         inorganic_sel = "(mol) and inorganic"
         if cmd.count_atoms(inorganic_sel) > 0:
             cmd.show("spheres", inorganic_sel)
-            cmd.color("byelement", inorganic_sel)
+            cmd.util.cbaw(inorganic_sel)
             print(f"[style] showing {cmd.count_atoms(inorganic_sel)} inorganic atoms as spheres")
 
         # apply coloring scheme


### PR DESCRIPTION
## Summary

- Glycans, ligands, and other non-protein organic entities were invisible in DCD movies because PyMOL's `cartoon` representation only renders backbone atoms
- Organic non-protein atoms (glycans, ligands) are now displayed as **sticks** with element-based coloring
- Inorganic atoms (metal ions, Mg²⁺, Zn²⁺, etc.) are now displayed as **spheres** with element-based coloring
- `count_atoms()` guards ensure protein-only trajectories are completely unaffected

## Test plan

- [x] Run pipeline against a glycoprotein trajectory (PDB + DCD with glycan chains) and verify glycan atoms appear as sticks in the rendered movie
- [x] Run pipeline against a protein-only trajectory and verify output is identical to before
- [x] Check `movie_<label>.log` for `[style] showing N organic atoms as sticks` lines confirming detection
- [x] Verify metal ion-containing structures render ions as spheres

🤖 Generated with [Claude Code](https://claude.com/claude-code)