### PR TITLE
fix(ui): replace cofactor strip warning with GAFF2 info/warning split

### DIFF
--- a/.changeset/fix-ui-gaff-cofactor-warning.md
+++ b/.changeset/fix-ui-gaff-cofactor-warning.md
@@ -1,0 +1,6 @@
+---
+'@bilbomd/ui': patch
+'@bilbomd/bilbomd-types': patch
+---
+
+Fix UI cofactor alerts to reflect GAFF2 support for organic small molecules. Split STRIPPABLE_COFACTORS into GAFF_COFACTORS (organic, now parameterized via GAFF2) and METAL_COFACTORS (heme/porphyrins, still removed). FAD and similar molecules now show a blue info alert instead of a yellow warning.

--- a/apps/backend/src/controllers/jobs/__tests__/jobQuotaChecking.test.ts
+++ b/apps/backend/src/controllers/jobs/__tests__/jobQuotaChecking.test.ts
@@ -7,7 +7,8 @@ import {
   BilboMdSANSJob,
   BilboMdScoperJob,
   MultiJob,
-  JobStatus
+  JobStatus,
+  AccessMode
 } from '@bilbomd/mongodb-schema'
 
 // Mock the mongoose models
@@ -91,7 +92,7 @@ describe('Job Quota Checking Logic', () => {
       const quotaQuery = {
         client_ip_hash: mockClientIpHash,
         status: { $in: activeStatuses },
-        access_mode: 'anonymous'
+        access_mode: AccessMode.Anonymous
       }
 
       const counts = await Promise.all([
@@ -230,7 +231,7 @@ describe('Job Quota Checking Logic', () => {
       const quotaQuery = {
         client_ip_hash: mockClientIpHash,
         status: { $in: activeStatuses },
-        access_mode: 'anonymous'
+        access_mode: AccessMode.Anonymous
       }
 
       vi.mocked(BilboMdPDBJob.countDocuments).mockResolvedValue(0)

--- a/apps/backend/src/controllers/jobs/createJob.ts
+++ b/apps/backend/src/controllers/jobs/createJob.ts
@@ -23,7 +23,8 @@ import {
   BilboMdSANSJob,
   BilboMdScoperJob,
   MultiJob,
-  JobStatus
+  JobStatus,
+  AccessMode
 } from '@bilbomd/mongodb-schema'
 import { getEnvVar } from '../../config/config.js'
 
@@ -225,7 +226,7 @@ const createPublicJob = async (req: Request, res: Response) => {
         const quotaQuery = {
           client_ip_hash,
           status: { $in: activeStatuses },
-          access_mode: 'anonymous'
+          access_mode: AccessMode.Anonymous
         }
         const counts = await Promise.all([
           BilboMdPDBJob.countDocuments(quotaQuery),

--- a/apps/backend/src/controllers/jobs/sansJobController.ts
+++ b/apps/backend/src/controllers/jobs/sansJobController.ts
@@ -12,7 +12,8 @@ import {
   BilboMdSANSJob,
   BilboMdScoperJob,
   MultiJob,
-  JobStatus
+  JobStatus,
+  AccessMode
 } from '@bilbomd/mongodb-schema'
 import { Request, Response } from 'express'
 import { BilboMDDispatchContext } from '../../types/bilbomd.js'
@@ -169,7 +170,7 @@ const createPublicSANSJob = async (req: Request, res: Response) => {
         const quotaQuery = {
           client_ip_hash,
           status: { $in: activeStatuses },
-          access_mode: 'anonymous'
+          access_mode: AccessMode.Anonymous
         }
         const counts = await Promise.all([
           BilboMdPDBJob.countDocuments(quotaQuery),

--- a/apps/ui/src/features/autojob/NewAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/NewAutoJobForm.tsx
@@ -8,7 +8,10 @@ import { useAddNewPublicJobMutation } from 'slices/publicJobsApiSlice'
 import SendIcon from '@mui/icons-material/Send'
 import NewAutoJobFormInstructions from './AutoJobFormInstructions'
 import { BilboMDAutoJobSchema } from 'schemas/BilboMDAutoJobSchema'
-import { detectStrippableCofactors } from 'schemas/ValidationFunctions'
+import {
+  detectGaffCofactors,
+  detectMetalCofactors
+} from 'schemas/ValidationFunctions'
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
 import HeaderBox from 'components/HeaderBox'
@@ -72,6 +75,7 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const [useExampleData, setUseExampleData] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [pdbWarning, setPdbWarning] = useState<string>('')
+  const [pdbInfo, setPdbInfo] = useState<string>('')
 
   // RTK Query to fetch the configuration
   const {
@@ -274,16 +278,23 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             setMdEngine(val)
                             if (val === 'charmm') {
                               setPdbWarning('')
+                              setPdbInfo('')
                             } else if (
                               val === 'openmm' &&
                               values.pdb_file instanceof File
                             ) {
-                              void detectStrippableCofactors(
-                                values.pdb_file
-                              ).then((found) => {
+                              void Promise.all([
+                                detectGaffCofactors(values.pdb_file),
+                                detectMetalCofactors(values.pdb_file)
+                              ]).then(([gaffFound, metalFound]) => {
+                                setPdbInfo(
+                                  gaffFound.length > 0
+                                    ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                    : ''
+                                )
                                 setPdbWarning(
-                                  found.length > 0
-                                    ? `The following residues have no Amber force-field parameters and will be removed before MD: ${found.join(', ')}`
+                                  metalFound.length > 0
+                                    ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
                                     : ''
                                 )
                               })
@@ -323,6 +334,7 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                           setFieldTouched={setFieldTouched}
                           error={errors.pdb_file && touched.pdb_file}
                           errorMessage={errors.pdb_file ? errors.pdb_file : ''}
+                          infoMessage={pdbInfo}
                           warningMessage={pdbWarning}
                           fileType="AlphaFold *.pdb or *.cif"
                           fileExt=".pdb,.cif"
@@ -331,13 +343,22 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                           }
                           onFileChange={async (file: File) => {
                             if (mdEngine !== 'openmm') {
+                              setPdbInfo('')
                               setPdbWarning('')
                               return
                             }
-                            const found = await detectStrippableCofactors(file)
+                            const [gaffFound, metalFound] = await Promise.all([
+                              detectGaffCofactors(file),
+                              detectMetalCofactors(file)
+                            ])
+                            setPdbInfo(
+                              gaffFound.length > 0
+                                ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                : ''
+                            )
                             setPdbWarning(
-                              found.length > 0
-                                ? `The following residues have no Amber force-field parameters and will be removed before MD: ${found.join(', ')}`
+                              metalFound.length > 0
+                                ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
                                 : ''
                             )
                           }}

--- a/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
@@ -20,7 +20,10 @@ import {
 import SendIcon from '@mui/icons-material/Send'
 import AutoJobFormInstructions from './AutoJobFormInstructions'
 import { BilboMDAutoJobSchema } from 'schemas/BilboMDAutoJobSchema'
-import { detectStrippableCofactors } from 'schemas/ValidationFunctions'
+import {
+  detectGaffCofactors,
+  detectMetalCofactors
+} from 'schemas/ValidationFunctions'
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
 import HeaderBox from 'components/HeaderBox'
@@ -50,6 +53,7 @@ const ResubmitAutoJobForm = () => {
   }
   const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('charmm')
   const [pdbWarning, setPdbWarning] = useState<string>('')
+  const [pdbInfo, setPdbInfo] = useState<string>('')
 
   // RTK Query to fetch the configuration
   const {
@@ -263,16 +267,23 @@ const ResubmitAutoJobForm = () => {
                           setMdEngine(val)
                           if (val === 'charmm') {
                             setPdbWarning('')
+                            setPdbInfo('')
                           } else if (
                             val === 'openmm' &&
                             values.pdb_file instanceof File
                           ) {
-                            void detectStrippableCofactors(
-                              values.pdb_file
-                            ).then((found) => {
+                            void Promise.all([
+                              detectGaffCofactors(values.pdb_file),
+                              detectMetalCofactors(values.pdb_file)
+                            ]).then(([gaffFound, metalFound]) => {
+                              setPdbInfo(
+                                gaffFound.length > 0
+                                  ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                  : ''
+                              )
                               setPdbWarning(
-                                found.length > 0
-                                  ? `The following residues have no Amber force-field parameters and will be removed before MD: ${found.join(', ')}`
+                                metalFound.length > 0
+                                  ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
                                   : ''
                               )
                             })
@@ -299,18 +310,28 @@ const ResubmitAutoJobForm = () => {
                         setFieldTouched={setFieldTouched}
                         error={errors.pdb_file && touched.pdb_file}
                         errorMessage={errors.pdb_file ? errors.pdb_file : ''}
+                        infoMessage={pdbInfo}
                         warningMessage={pdbWarning}
                         fileType="AlphaFold2 *.pdb"
                         fileExt=".pdb"
                         onFileChange={async (file: File) => {
                           if (mdEngine !== 'openmm') {
+                            setPdbInfo('')
                             setPdbWarning('')
                             return
                           }
-                          const found = await detectStrippableCofactors(file)
+                          const [gaffFound, metalFound] = await Promise.all([
+                            detectGaffCofactors(file),
+                            detectMetalCofactors(file)
+                          ])
+                          setPdbInfo(
+                            gaffFound.length > 0
+                              ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                              : ''
+                          )
                           setPdbWarning(
-                            found.length > 0
-                              ? `The following residues have no Amber force-field parameters and will be removed before MD: ${found.join(', ')}`
+                            metalFound.length > 0
+                              ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
                               : ''
                           )
                         }}

--- a/apps/ui/src/features/jobs/FileSelect.tsx
+++ b/apps/ui/src/features/jobs/FileSelect.tsx
@@ -19,6 +19,7 @@ interface FileSelectProps extends FormControlProps {
   error: boolean
   errorMessage?: string
   warningMessage?: string
+  infoMessage?: string
   existingFileName?: string
   setFieldValue: (field: string, value: File, shouldValidate?: boolean) => void
   onFileChange: (file: File) => void
@@ -116,6 +117,14 @@ const FileSelect = (props: FileSelectProps) => {
               sx={{ py: 0 }}
             >
               {props.errorMessage}
+            </Alert>
+          ) : null}
+          {!props.error && props.infoMessage ? (
+            <Alert
+              severity="info"
+              sx={{ mt: 1 }}
+            >
+              {props.infoMessage}
             </Alert>
           ) : null}
           {!props.error && props.warningMessage ? (

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -23,7 +23,10 @@ import { useAddNewPublicJobMutation } from 'slices/publicJobsApiSlice'
 import SendIcon from '@mui/icons-material/Send'
 import { expdataSchema } from 'schemas/ExpdataSchema'
 import { BilboMDClassicJobSchema } from 'schemas/BilboMDClassicJobSchema'
-import { detectStrippableCofactors } from 'schemas/ValidationFunctions'
+import {
+  detectGaffCofactors,
+  detectMetalCofactors
+} from 'schemas/ValidationFunctions'
 import SAXSGuinierPlot from './SAXSGuinierPlot'
 import HeaderBox from 'components/HeaderBox'
 import NerscStatusChecker from 'features/nersc/NerscStatusChecker'
@@ -92,6 +95,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const [useExampleData, setUseExampleData] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [pdbWarning, setPdbWarning] = useState<string>('')
+  const [pdbInfo, setPdbInfo] = useState<string>('')
   const [saxsData, setSaxsData] = useState<
     { q: number; intensity: number; error: number }[]
   >([])
@@ -488,16 +492,23 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             }
                             if (val === 'charmm') {
                               setPdbWarning('')
+                              setPdbInfo('')
                             } else if (
                               val === 'openmm' &&
                               values.pdb_file instanceof File
                             ) {
-                              void detectStrippableCofactors(
-                                values.pdb_file
-                              ).then((found) => {
+                              void Promise.all([
+                                detectGaffCofactors(values.pdb_file),
+                                detectMetalCofactors(values.pdb_file)
+                              ]).then(([gaffFound, metalFound]) => {
+                                setPdbInfo(
+                                  gaffFound.length > 0
+                                    ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                    : ''
+                                )
                                 setPdbWarning(
-                                  found.length > 0
-                                    ? `The following residues have no Amber force-field parameters and will be removed before MD: ${found.join(', ')}`
+                                  metalFound.length > 0
+                                    ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
                                     : ''
                                 )
                               })
@@ -599,6 +610,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                               errorMessage={
                                 errors.pdb_file ? errors.pdb_file : ''
                               }
+                              infoMessage={pdbInfo}
                               warningMessage={pdbWarning}
                               fileType=" *.pdb or *.cif"
                               fileExt=".pdb,.cif"
@@ -607,14 +619,23 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                               }
                               onFileChange={async (file: File) => {
                                 if (mdEngine !== 'openmm') {
+                                  setPdbInfo('')
                                   setPdbWarning('')
                                   return
                                 }
-                                const found =
-                                  await detectStrippableCofactors(file)
+                                const [gaffFound, metalFound] =
+                                  await Promise.all([
+                                    detectGaffCofactors(file),
+                                    detectMetalCofactors(file)
+                                  ])
+                                setPdbInfo(
+                                  gaffFound.length > 0
+                                    ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                    : ''
+                                )
                                 setPdbWarning(
-                                  found.length > 0
-                                    ? `The following residues have no Amber force-field parameters and will be removed before MD: ${found.join(', ')}`
+                                  metalFound.length > 0
+                                    ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
                                     : ''
                                 )
                               }}

--- a/apps/ui/src/features/jobs/ResubmitJobForm.tsx
+++ b/apps/ui/src/features/jobs/ResubmitJobForm.tsx
@@ -33,7 +33,10 @@ import {
 import SendIcon from '@mui/icons-material/Send'
 import { expdataSchema } from 'schemas/ExpdataSchema'
 import { BilboMDClassicJobSchema } from 'schemas/BilboMDClassicJobSchema'
-import { detectStrippableCofactors } from 'schemas/ValidationFunctions'
+import {
+  detectGaffCofactors,
+  detectMetalCofactors
+} from 'schemas/ValidationFunctions'
 import HeaderBox from 'components/HeaderBox'
 import useTitle from 'hooks/useTitle'
 import NerscStatusChecker from 'features/nersc/NerscStatusChecker'
@@ -65,6 +68,7 @@ const ResubmitJobForm = () => {
   }
   const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('charmm')
   const [pdbWarning, setPdbWarning] = useState<string>('')
+  const [pdbInfo, setPdbInfo] = useState<string>('')
 
   // RTK Query to fetch the configuration
   const {
@@ -461,16 +465,23 @@ const ResubmitJobForm = () => {
                             setMdEngine(val)
                             if (val === 'charmm') {
                               setPdbWarning('')
+                              setPdbInfo('')
                             } else if (
                               val === 'openmm' &&
                               values.pdb_file instanceof File
                             ) {
-                              void detectStrippableCofactors(
-                                values.pdb_file
-                              ).then((found) => {
+                              void Promise.all([
+                                detectGaffCofactors(values.pdb_file),
+                                detectMetalCofactors(values.pdb_file)
+                              ]).then(([gaffFound, metalFound]) => {
+                                setPdbInfo(
+                                  gaffFound.length > 0
+                                    ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                    : ''
+                                )
                                 setPdbWarning(
-                                  found.length > 0
-                                    ? `The following residues have no Amber force-field parameters and will be removed before MD: ${found.join(', ')}`
+                                  metalFound.length > 0
+                                    ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
                                     : ''
                                 )
                               })
@@ -577,19 +588,29 @@ const ResubmitJobForm = () => {
                                 errorMessage={
                                   errors.pdb_file ? errors.pdb_file : ''
                                 }
+                                infoMessage={pdbInfo}
                                 warningMessage={pdbWarning}
                                 fileType=" *.pdb"
                                 fileExt=".pdb"
                                 onFileChange={async (file: File) => {
                                   if (mdEngine !== 'openmm') {
+                                    setPdbInfo('')
                                     setPdbWarning('')
                                     return
                                   }
-                                  const found =
-                                    await detectStrippableCofactors(file)
+                                  const [gaffFound, metalFound] =
+                                    await Promise.all([
+                                      detectGaffCofactors(file),
+                                      detectMetalCofactors(file)
+                                    ])
+                                  setPdbInfo(
+                                    gaffFound.length > 0
+                                      ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                      : ''
+                                  )
                                   setPdbWarning(
-                                    found.length > 0
-                                      ? `The following residues have no Amber force-field parameters and will be removed before MD: ${found.join(', ')}`
+                                    metalFound.length > 0
+                                      ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
                                       : ''
                                   )
                                 }}

--- a/apps/ui/src/schemas/ValidationFunctions.ts
+++ b/apps/ui/src/schemas/ValidationFunctions.ts
@@ -1,6 +1,7 @@
 import {
   SUPPORTED_PDB_RESIDUES,
-  STRIPPABLE_COFACTORS,
+  GAFF_COFACTORS,
+  METAL_COFACTORS,
   parseCifAtomSite,
   cifContainsChainId as cifContainsChainIdUtil,
   cifHasAllowedResiduesOnly as cifHasAllowedResiduesOnlyUtil,
@@ -561,7 +562,7 @@ const cifIsSingleModel = (file: File): Promise<boolean> => {
   })
 }
 
-const detectStrippableCofactors = (file: File): Promise<string[]> => {
+const _detectResiduesFromSet = (file: File, residueSet: Set<string>): Promise<string[]> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
     reader.onload = (e) => {
@@ -574,7 +575,7 @@ const detectStrippableCofactors = (file: File): Promise<string[]> => {
       for (const line of text.split(/\r?\n/)) {
         if (line.startsWith('ATOM') || line.startsWith('HETATM')) {
           const resName = line.substring(17, 20).trim().toUpperCase()
-          if (STRIPPABLE_COFACTORS.has(resName)) found.add(resName)
+          if (residueSet.has(resName)) found.add(resName)
         }
       }
       resolve(Array.from(found).sort())
@@ -583,6 +584,12 @@ const detectStrippableCofactors = (file: File): Promise<string[]> => {
     reader.readAsText(file)
   })
 }
+
+const detectGaffCofactors = (file: File): Promise<string[]> =>
+  _detectResiduesFromSet(file, GAFF_COFACTORS)
+
+const detectMetalCofactors = (file: File): Promise<string[]> =>
+  _detectResiduesFromSet(file, METAL_COFACTORS)
 
 export {
   fromCharmmGui,
@@ -600,6 +607,7 @@ export {
   noLeadingSpaceOnPDBLines,
   isValidConstInpFile,
   hasAllowedResiduesOnly,
-  detectStrippableCofactors
+  detectGaffCofactors,
+  detectMetalCofactors
 }
 export type { SaxsQualityResult }

--- a/apps/ui/src/schemas/__tests__/ValidationFunctions.test.ts
+++ b/apps/ui/src/schemas/__tests__/ValidationFunctions.test.ts
@@ -13,7 +13,8 @@ import {
   cifContainsChainId,
   cifHasAllowedResiduesOnly,
   noLeadingSpaceOnPDBLines,
-  detectStrippableCofactors
+  detectGaffCofactors,
+  detectMetalCofactors
 } from '../ValidationFunctions'
 
 const makeFile = (name: string, content: string, type = 'text/plain') => {
@@ -70,7 +71,7 @@ describe('ValidationFunctions', () => {
     expect(result.valid).toBe(true)
   })
 
-  it('hasAllowedResiduesOnly returns valid for strippable cofactors (PCA, FAD, HEM)', async () => {
+  it('hasAllowedResiduesOnly returns valid for GAFF and metal cofactors (PCA, FAD, HEM)', async () => {
     const content = [
       'HETATM    1  C   PCA A   1',
       'HETATM    2  N   FAD A   2',
@@ -182,10 +183,10 @@ describe('ValidationFunctions', () => {
   })
 })
 
-describe('detectStrippableCofactors', () => {
-  it('returns empty array when no strippable cofactors are present', async () => {
+describe('detectGaffCofactors', () => {
+  it('returns empty array when no GAFF cofactors are present', async () => {
     const content = `ATOM      1  N   MET A   1\nATOM      2  CA  GLY A   2\nEND\n`
-    const result = await detectStrippableCofactors(makeFile('model.pdb', content))
+    const result = await detectGaffCofactors(makeFile('model.pdb', content))
     expect(result).toHaveLength(0)
   })
 
@@ -195,19 +196,19 @@ describe('detectStrippableCofactors', () => {
       'HETATM    2  C   PCA A   2',
       'END'
     ].join('\n')
-    const result = await detectStrippableCofactors(makeFile('pca.pdb', content))
+    const result = await detectGaffCofactors(makeFile('pca.pdb', content))
     expect(result).toContain('PCA')
     expect(result).toHaveLength(1)
   })
 
-  it('detects FAD and HEM together and returns sorted list', async () => {
+  it('detects FAD and returns sorted list', async () => {
     const content = [
-      'HETATM    1  FE  HEM A   1',
-      'HETATM    2  N   FAD A   2',
+      'HETATM    1  N1  FAD A   1',
+      'HETATM    2  C   NAD A   2',
       'END'
     ].join('\n')
-    const result = await detectStrippableCofactors(makeFile('multi.pdb', content))
-    expect(result).toEqual(['FAD', 'HEM'])
+    const result = await detectGaffCofactors(makeFile('gaff.pdb', content))
+    expect(result).toEqual(['FAD', 'NAD'])
   })
 
   it('deduplicates repeated cofactor entries', async () => {
@@ -217,13 +218,56 @@ describe('detectStrippableCofactors', () => {
       'HETATM    3  C3  PCA A   1',
       'END'
     ].join('\n')
-    const result = await detectStrippableCofactors(makeFile('dup.pdb', content))
+    const result = await detectGaffCofactors(makeFile('dup.pdb', content))
     expect(result).toEqual(['PCA'])
   })
 
-  it('does not flag truly unsupported residues (UNK)', async () => {
-    const content = `ATOM      1  CA  UNK A   1\nEND\n`
-    const result = await detectStrippableCofactors(makeFile('unk.pdb', content))
+  it('does not flag HEM (metal cofactor) or unknown residues', async () => {
+    const content = [
+      'HETATM    1  FE  HEM A   1',
+      'ATOM      2  CA  UNK A   2',
+      'END'
+    ].join('\n')
+    const result = await detectGaffCofactors(makeFile('hem-unk.pdb', content))
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe('detectMetalCofactors', () => {
+  it('returns empty array when no metal cofactors are present', async () => {
+    const content = `ATOM      1  N   MET A   1\nHETATM    2  N   FAD A   2\nEND\n`
+    const result = await detectMetalCofactors(makeFile('model.pdb', content))
+    expect(result).toHaveLength(0)
+  })
+
+  it('detects HEM in HETATM lines', async () => {
+    const content = [
+      'ATOM      1  N   GLN A   1',
+      'HETATM    2  FE  HEM A   2',
+      'END'
+    ].join('\n')
+    const result = await detectMetalCofactors(makeFile('hem.pdb', content))
+    expect(result).toContain('HEM')
+    expect(result).toHaveLength(1)
+  })
+
+  it('detects all heme variants and returns sorted list', async () => {
+    const content = [
+      'HETATM    1  FE  HEB A   1',
+      'HETATM    2  FE  HEM A   2',
+      'END'
+    ].join('\n')
+    const result = await detectMetalCofactors(makeFile('hemes.pdb', content))
+    expect(result).toEqual(['HEB', 'HEM'])
+  })
+
+  it('does not flag FAD (GAFF cofactor) or unknown residues', async () => {
+    const content = [
+      'HETATM    1  N   FAD A   1',
+      'ATOM      2  CA  UNK A   2',
+      'END'
+    ].join('\n')
+    const result = await detectMetalCofactors(makeFile('fad-unk.pdb', content))
     expect(result).toHaveLength(0)
   })
 })

--- a/packages/bilbomd-types/src/pdbResidues.ts
+++ b/packages/bilbomd-types/src/pdbResidues.ts
@@ -32,14 +32,11 @@ export const CARBOHYDRATE_RESIDUES = new Set<string>([
   'AMA', 'BGL',
 ])
 
-// Cofactors that have no Amber/GLYCAM force-field parameters and are stripped
-// automatically before OpenMM MD. Keep in sync with UNSUPPORTED_COFACTORS in
-// apps/worker/scripts/strip_cofactors.py.
-export const STRIPPABLE_COFACTORS = new Set<string>([
+// Organic cofactors parameterized via GAFF2 by openmmforcefields at runtime.
+// model_prep.py downloads their SDF from RCSB and registers GAFF2 templates.
+export const GAFF_COFACTORS = new Set<string>([
   // Flavin cofactors
   'FAD', 'FMN', 'RBF',
-  // Heme / porphyrins
-  'HEM', 'HEC', 'HEA', 'HEB',
   // Nicotinamide cofactors
   'NAD', 'NAP', 'NDP',
   // Pyridoxal phosphate
@@ -56,6 +53,13 @@ export const STRIPPABLE_COFACTORS = new Set<string>([
   'SAH', 'SAM', 'HBI',
 ])
 
+// Metal-containing cofactors excluded from the GAFF2 path (model_prep.py
+// _has_metal_atoms check). These are still removed before OpenMM MD.
+export const METAL_COFACTORS = new Set<string>([
+  // Heme / porphyrins (contain Fe)
+  'HEM', 'HEC', 'HEA', 'HEB',
+])
+
 export const SUPPORTED_PDB_RESIDUES = new Set<string>([
   ...PROTEIN_RESIDUES,
   ...DNA_RESIDUES,
@@ -63,8 +67,9 @@ export const SUPPORTED_PDB_RESIDUES = new Set<string>([
   // Nucleotide aliases recognised by pdb_utils (post-rename CHARMM names)
   'ADE', 'CYT', 'GUA', 'THY',
   ...CARBOHYDRATE_RESIDUES,
-  // Cofactors stripped before OpenMM MD — allowed through validation
-  ...STRIPPABLE_COFACTORS,
+  // Cofactors handled before OpenMM MD — allowed through validation
+  ...GAFF_COFACTORS,
+  ...METAL_COFACTORS,
   // Water — removed by pdb2crd.py, not an error
   'HOH',
   // Common ions — passed through or stripped without error


### PR DESCRIPTION
## Summary

- **UI**: Split `STRIPPABLE_COFACTORS` into `GAFF_COFACTORS` and `METAL_COFACTORS` — organic cofactors like FAD now show a blue info alert ("will be parameterized via GAFF2") instead of a yellow strip warning; heme/porphyrins (HEM, HEC, HEA, HEB) still show a yellow warning since they're excluded from the GAFF2 path
- **UI**: Added `infoMessage` prop to `FileSelect` (rendered as `severity="info"` Alert); form components now run both detections in parallel and show alerts independently
- **Backend**: Fixed `TS2769` build errors in `createJob.ts`, `sansJobController.ts`, and `jobQuotaChecking.test.ts` caused by mongoose 9.6.0 tightening `countDocuments` filter types — `access_mode: 'anonymous'` replaced with `AccessMode.Anonymous`

## Test plan

- [x] `pnpm build` passes with zero errors
- [x] `pnpm -F @bilbomd/ui test` passes (1023 tests)
- [x] Upload a PDB containing FAD with OpenMM engine selected → blue info alert appears
- [x] Upload a PDB containing HEM with OpenMM engine selected → yellow warning appears
- [x] Upload a PDB with both FAD and HEM → both alerts shown
- [x] Switch engine to CHARMM → both alerts clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)