### PR TITLE
Update BilboMD citation to published NAR 2026 paper

### DIFF
--- a/.changeset/engine-driven-input-mode.md
+++ b/.changeset/engine-driven-input-mode.md
@@ -2,4 +2,4 @@
 '@bilbomd/ui': minor
 ---
 
-Enforce engine-driven input mode across all job forms. Classic form: MD engine selection now drives input format (CHARMM requires CRD/PSF from CHARMM-GUI, OpenMM accepts PDB/CIF). Auto, AlphaFold, and SANS forms: CHARMM engine option hidden, defaulting to OpenMM. Prevents PDB-to-CRD/PSF conversion failures with non-standard residues.
+Enforce engine-driven input mode across all job forms. Classic form: MD engine selection now drives input format (CHARMM requires CRD/PSF from CHARMM-GUI, OpenMM accepts PDB/CIF). Auto, AlphaFold, and SANS forms: CHARMM engine option hidden, defaulting to OpenMM. Prevents PDB-to-CRD/PSF conversion failures with non-standard residues. Metal cofactor warning now suggests CHARMM-GUI with inline link button. Fix Classic form regressions: Conformations per Rg defaults to 600 for OpenMM, auto-Rg validation no longer requires manual field interaction. Fix Help page pipeline schematic images for dark mode support.

--- a/.changeset/engine-driven-input-mode.md
+++ b/.changeset/engine-driven-input-mode.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': minor
+---
+
+Enforce engine-driven input mode across all job forms. Classic form: MD engine selection now drives input format (CHARMM requires CRD/PSF from CHARMM-GUI, OpenMM accepts PDB/CIF). Auto, AlphaFold, and SANS forms: CHARMM engine option hidden, defaulting to OpenMM. Prevents PDB-to-CRD/PSF conversion failures with non-standard residues.

--- a/.changeset/ui-update-bilbomd-citation.md
+++ b/.changeset/ui-update-bilbomd-citation.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Update BilboMD citation to the published NAR 2026 paper. Replaces the Pelikan et al. 2009 Gen Physiol Biophys reference with Classen et al. 2026 Nucleic Acids Research (doi: 10.1093/nar/gkag377) across the Home, About, Help, and Acknowledgments pages.

--- a/apps/ui/src/components/Home.tsx
+++ b/apps/ui/src/components/Home.tsx
@@ -218,21 +218,21 @@ const Home = ({ title = 'BilboMD' }) => {
             variant="body2"
             sx={{ mx: 5, my: 2 }}
           >
-            Pelikan M, Hura GL, Hammel M.{' '}
+            Classen S, Del Mundo J, Kulkarni D, Prabhakar S, Hicks A, Hammel
+            M.{' '}
             <b>
-              Structure and flexibility within proteins as identified through
-              small angle X-ray scattering.
+              BilboMD: a web-accessible SAXS and AlphaFold-guided modeling
+              pipeline.
             </b>{' '}
-            Gen Physiol Biophys. 2009 Jun;28(2):174-89. doi:
-            10.4149/gpb_2009_02_174. PMID:{' '}
+            Nucleic Acids Research. 2026; gkag377. doi:{' '}
             <Link
-              href="https://pubmed.ncbi.nlm.nih.gov/19592714/"
+              href="https://doi.org/10.1093/nar/gkag377"
               target="_blank"
               rel="noopener noreferrer"
             >
-              19592714
+              10.1093/nar/gkag377
             </Link>
-            ; PMCID: PMC3773563.
+            .
           </Typography>
         </Introduction>
 

--- a/apps/ui/src/components/MdEngineField.tsx
+++ b/apps/ui/src/components/MdEngineField.tsx
@@ -34,15 +34,15 @@ const MdEngineField = ({
       name="md_engine"
     >
       <FormControlLabel
+        value="openmm"
+        control={<Radio />}
+        label="OpenMM"
+      />
+      <FormControlLabel
         value="charmm"
         control={<Radio />}
         label="CHARMM"
         disabled={disableCharmm}
-      />
-      <FormControlLabel
-        value="openmm"
-        control={<Radio />}
-        label="OpenMM"
       />
     </RadioGroup>
   </FormControl>

--- a/apps/ui/src/components/__tests__/MdEngineField.test.tsx
+++ b/apps/ui/src/components/__tests__/MdEngineField.test.tsx
@@ -1,0 +1,180 @@
+// apps/ui/src/components/__tests__/MdEngineField.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import MdEngineField from '../MdEngineField'
+
+describe('MdEngineField', () => {
+  const noop = vi.fn()
+
+  describe('rendering', () => {
+    it('renders both OpenMM and CHARMM radio options', () => {
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={noop}
+        />
+      )
+      expect(screen.getByLabelText(/OpenMM/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/CHARMM/i)).toBeInTheDocument()
+    })
+
+    it('renders the MD Engine label', () => {
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={noop}
+        />
+      )
+      expect(screen.getByText('MD Engine')).toBeInTheDocument()
+    })
+
+    it('OpenMM appears before CHARMM in the DOM', () => {
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={noop}
+        />
+      )
+      const radios = screen.getAllByRole('radio')
+      expect(radios).toHaveLength(2)
+      // First radio should be OpenMM, second should be CHARMM
+      expect(radios[0]).toHaveAttribute('value', 'openmm')
+      expect(radios[1]).toHaveAttribute('value', 'charmm')
+    })
+  })
+
+  describe('controlled value', () => {
+    it('shows OpenMM as checked when value is openmm', () => {
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={noop}
+        />
+      )
+      const openmm = screen.getByLabelText(/OpenMM/i) as HTMLInputElement
+      const charmm = screen.getByLabelText(/CHARMM/i) as HTMLInputElement
+      expect(openmm.checked).toBe(true)
+      expect(charmm.checked).toBe(false)
+    })
+
+    it('shows CHARMM as checked when value is charmm', () => {
+      render(
+        <MdEngineField
+          value="charmm"
+          onChange={noop}
+        />
+      )
+      const openmm = screen.getByLabelText(/OpenMM/i) as HTMLInputElement
+      const charmm = screen.getByLabelText(/CHARMM/i) as HTMLInputElement
+      expect(charmm.checked).toBe(true)
+      expect(openmm.checked).toBe(false)
+    })
+  })
+
+  describe('onChange callback', () => {
+    it('calls onChange with charmm when CHARMM radio is clicked', async () => {
+      const handleChange = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={handleChange}
+        />
+      )
+      await user.click(screen.getByLabelText(/CHARMM/i))
+      expect(handleChange).toHaveBeenCalledOnce()
+      expect(handleChange).toHaveBeenCalledWith('charmm')
+    })
+
+    it('calls onChange with openmm when OpenMM radio is clicked', async () => {
+      const handleChange = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <MdEngineField
+          value="charmm"
+          onChange={handleChange}
+        />
+      )
+      await user.click(screen.getByLabelText(/OpenMM/i))
+      expect(handleChange).toHaveBeenCalledOnce()
+      expect(handleChange).toHaveBeenCalledWith('openmm')
+    })
+  })
+
+  describe('disabled states', () => {
+    it('disables the CHARMM radio when disableCharmm is true', () => {
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={noop}
+          disableCharmm
+        />
+      )
+      expect(screen.getByLabelText(/CHARMM/i)).toBeDisabled()
+      expect(screen.getByLabelText(/OpenMM/i)).not.toBeDisabled()
+    })
+
+    it('does not disable CHARMM when disableCharmm is false', () => {
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={noop}
+          disableCharmm={false}
+        />
+      )
+      expect(screen.getByLabelText(/CHARMM/i)).not.toBeDisabled()
+    })
+
+    it('disables both radios when disabled is true', () => {
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={noop}
+          disabled
+        />
+      )
+      expect(screen.getByLabelText(/OpenMM/i)).toBeDisabled()
+      expect(screen.getByLabelText(/CHARMM/i)).toBeDisabled()
+    })
+
+    it('does not change the checked state when the fieldset is disabled', async () => {
+      const handleChange = vi.fn()
+      // MUI applies pointer-events: none to disabled radio inputs, which
+      // prevents userEvent from dispatching pointer events. We verify the
+      // disabled constraint via the DOM attribute and confirm the value is
+      // unchanged — the two existing assertions above already prove that
+      // the disabled prop correctly sets the underlying input's disabled
+      // attribute, which is the browser mechanism that prevents onChange.
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={handleChange}
+          disabled
+        />
+      )
+      const openmm = screen.getByLabelText(/OpenMM/i) as HTMLInputElement
+      const charmm = screen.getByLabelText(/CHARMM/i) as HTMLInputElement
+      expect(openmm).toBeDisabled()
+      expect(charmm).toBeDisabled()
+      // With all inputs disabled, onChange was never called
+      expect(handleChange).not.toHaveBeenCalled()
+    })
+
+    it('does not change the checked state when only CHARMM is disabled', async () => {
+      const handleChange = vi.fn()
+      render(
+        <MdEngineField
+          value="openmm"
+          onChange={handleChange}
+          disableCharmm
+        />
+      )
+      const charmm = screen.getByLabelText(/CHARMM/i) as HTMLInputElement
+      // Verify disabled — the native disabled attribute is the DOM contract
+      // preventing the change event from being fired and reaching onChange.
+      expect(charmm).toBeDisabled()
+      expect(handleChange).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/ui/src/features/about/About.tsx
+++ b/apps/ui/src/features/about/About.tsx
@@ -188,21 +188,21 @@ const About = ({ title = 'BilboMD: About' }) => {
           .Details of the implementation and integration of these tools into{' '}
           <b>BilboMD</b> are described in the following manuscript:
           <Typography variant='body2' sx={{ mx: 5, my: 2 }}>
-            Pelikan M, Hura GL, Hammel M.{' '}
+            Classen S, Del Mundo J, Kulkarni D, Prabhakar S, Hicks A, Hammel
+            M.{' '}
             <b>
-              Structure and flexibility within proteins as identified through
-              small angle X-ray scattering.
+              BilboMD: a web-accessible SAXS and AlphaFold-guided modeling
+              pipeline.
             </b>{' '}
-            Gen Physiol Biophys. 2009 Jun;28(2):174-89. doi:
-            10.4149/gpb_2009_02_174. PMID:{' '}
+            Nucleic Acids Research. 2026; gkag377. doi:{' '}
             <Link
-              href='https://pubmed.ncbi.nlm.nih.gov/19592714/'
+              href='https://doi.org/10.1093/nar/gkag377'
               target='_blank'
               rel='noopener noreferrer'
             >
-              19592714
+              10.1093/nar/gkag377
             </Link>
-            ; PMCID: PMC3773563.
+            .
           </Typography>
         </Introduction>
 

--- a/apps/ui/src/features/about/Acknowledgments.tsx
+++ b/apps/ui/src/features/about/Acknowledgments.tsx
@@ -20,21 +20,20 @@ const Acknowledgments: React.FC = () => {
           variant="body2"
           sx={{ mx: 2, my: 2 }}
         >
-          Pelikan M, Hura GL, Hammel M.{' '}
+          Classen S, Del Mundo J, Kulkarni D, Prabhakar S, Hicks A, Hammel M.{' '}
           <b>
-            Structure and flexibility within proteins as identified through
-            small angle X-ray scattering.
+            BilboMD: a web-accessible SAXS and AlphaFold-guided modeling
+            pipeline.
           </b>{' '}
-          Gen Physiol Biophys. 2009 Jun;28(2):174-89. doi:
-          10.4149/gpb_2009_02_174. PMID:{' '}
+          Nucleic Acids Research. 2026; gkag377. doi:{' '}
           <Link
-            href="https://pubmed.ncbi.nlm.nih.gov/19592714/"
+            href="https://doi.org/10.1093/nar/gkag377"
             target="_blank"
             rel="noopener noreferrer"
           >
-            19592714
+            10.1093/nar/gkag377
           </Link>
-          ; PMCID: PMC3773563.
+          .
         </Typography>
       </Grid>
       <Grid size={8}>

--- a/apps/ui/src/features/about/__tests__/Acknowledgments.test.tsx
+++ b/apps/ui/src/features/about/__tests__/Acknowledgments.test.tsx
@@ -9,9 +9,11 @@ describe('Acknowledgments', () => {
     expect(screen.getByText(/Referencing BilboMD:/i)).toBeInTheDocument()
   })
 
-  it('includes manuscript citation with PubMed link', () => {
+  it('includes manuscript citation with DOI link', () => {
     renderWithProviders(<Acknowledgments />)
-    expect(screen.getByRole('link', { name: /19592714/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /10\.1093\/nar\/gkag377/i })
+    ).toBeInTheDocument()
   })
 
   it('lists external tools and citations', () => {

--- a/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
+++ b/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
@@ -39,7 +39,6 @@ import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import { useTheme } from '@mui/material/styles'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
-import MdEngineField from 'components/MdEngineField'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -485,7 +484,7 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const handleStatusCheck = (isUnavailable: boolean) => {
     setIsPerlmutterUnavailable(isUnavailable)
   }
-  const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('charmm')
+  const [mdEngine] = useState<'charmm' | 'openmm'>('openmm')
   const [useExampleData, setUseExampleData] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
@@ -504,7 +503,7 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
 
   const useAlphaFold = config.enableBilboMdAlphaFold?.toLowerCase() === 'true'
   const useNersc = config.useNersc?.toLowerCase() === 'true'
-  const charmmEnabled = config.enableCharmmEngine?.toLowerCase() !== 'false'
+
 
   const initialValues: NewAlphaFoldJobFormValues = {
     title: '',
@@ -519,7 +518,7 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
         seq_length: 0
       }
     ],
-    md_engine: charmmEnabled ? 'charmm' : 'openmm'
+    md_engine: 'openmm'
   }
 
   const onSubmit = async (values: NewAlphaFoldJobFormValues) => {
@@ -730,18 +729,6 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
                       </Box>
                     </Box>
 
-                    {/* MD Engine selection */}
-                    <Grid sx={{ width: '520px' }}>
-                      <MdEngineField
-                        value={values.md_engine as 'charmm' | 'openmm'}
-                        onChange={(val) => {
-                          void setFieldValue('md_engine', val)
-                          setMdEngine(val)
-                        }}
-                        disabled={isSubmitting}
-                        disableCharmm={!charmmEnabled}
-                      />
-                    </Grid>
                     {useExampleData && (
                       <Alert
                         severity="warning"

--- a/apps/ui/src/features/alphafoldjob/__tests__/NewAlphaFoldJobForm.mdengine.test.tsx
+++ b/apps/ui/src/features/alphafoldjob/__tests__/NewAlphaFoldJobForm.mdengine.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import NewAlphaFoldJob from '../NewAlphaFoldJobForm'
 
@@ -27,20 +26,9 @@ vi.mock('../../../slices/configsApiSlice', () => ({
 }))
 
 describe('NewAlphaFoldJobForm md_engine', () => {
-  it('renders CHARMM and OpenMM options and defaults to CHARMM', async () => {
+  it('does not render engine selection radio buttons', () => {
     render(<NewAlphaFoldJob />)
-    const charmm = screen.getByLabelText(/CHARMM/i)
-    const openmm = screen.getByLabelText(/OpenMM/i)
-    expect(charmm).toBeInTheDocument()
-    expect(openmm).toBeInTheDocument()
-    expect((charmm as HTMLInputElement).checked).toBe(true)
-  })
-
-  it('allows selecting OpenMM', async () => {
-    const user = userEvent.setup()
-    render(<NewAlphaFoldJob />)
-    const openmm = screen.getByLabelText(/OpenMM/i)
-    await user.click(openmm)
-    expect((openmm as HTMLInputElement).checked).toBe(true)
+    expect(screen.queryByLabelText(/CHARMM/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/OpenMM/i)).not.toBeInTheDocument()
   })
 })

--- a/apps/ui/src/features/autojob/NewAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/NewAutoJobForm.tsx
@@ -1,5 +1,13 @@
-import { useState } from 'react'
-import { Box, Button, TextField, Typography, Alert, Paper } from '@mui/material'
+import { ReactNode, useState } from 'react'
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  Alert,
+  Paper
+} from '@mui/material'
+import LaunchIcon from '@mui/icons-material/Launch'
 import Grid from '@mui/material/Grid'
 import { Form, Formik, Field } from 'formik'
 import FileSelect from 'features/jobs/FileSelect'
@@ -73,7 +81,7 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const [mdEngine] = useState<'charmm' | 'openmm'>('openmm')
   const [useExampleData, setUseExampleData] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
-  const [pdbWarning, setPdbWarning] = useState<string>('')
+  const [pdbWarning, setPdbWarning] = useState<ReactNode>('')
   const [pdbInfo, setPdbInfo] = useState<string>('')
 
   // RTK Query to fetch the configuration
@@ -91,7 +99,6 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
 
   // Are we running on NERSC?
   const useNersc = config.useNersc?.toLowerCase() === 'true'
-
 
   const initialValues: BilboMDAutoJobFormValues = {
     bilbomd_mode: 'auto',
@@ -311,13 +318,47 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             ])
                             setPdbInfo(
                               gaffFound.length > 0
-                                ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM: ${gaffFound.join(', ')}`
                                 : ''
                             )
                             setPdbWarning(
-                              metalFound.length > 0
-                                ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
-                                : ''
+                              metalFound.length > 0 ? (
+                                <>
+                                  The following metal-containing
+                                  residues have no force-field
+                                  parameters and will be removed
+                                  before MD:{' '}
+                                  {metalFound.join(', ')}. If these
+                                  residues are important for your
+                                  system, consider using{' '}
+                                  <Button
+                                    href="https://charmm-gui.org/"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    size="small"
+                                    variant="outlined"
+                                    color="info"
+                                    endIcon={<LaunchIcon />}
+                                    sx={{
+                                      textTransform: 'none',
+                                      py: 0,
+                                      px: 0.75,
+                                      minHeight: 0,
+                                      fontSize: 'inherit',
+                                      lineHeight: 'inherit',
+                                      verticalAlign: 'baseline'
+                                    }}
+                                  >
+                                    CHARMM-GUI
+                                  </Button>{' '}
+                                  to properly parameterize your
+                                  structure, then submit a Classic job
+                                  with CRD and PSF files using the
+                                  CHARMM engine option.
+                                </>
+                              ) : (
+                                ''
+                              )
                             )
                           }}
                         />

--- a/apps/ui/src/features/autojob/NewAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/NewAutoJobForm.tsx
@@ -21,7 +21,6 @@ import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import { useTheme } from '@mui/material/styles'
 import PipelineSchematic from './PipelineSchematic'
 import { BilboMDAutoJobFormValues } from '../../types/autoJobForm'
-import MdEngineField from 'components/MdEngineField'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
 
@@ -71,7 +70,7 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const handleStatusCheck = (isUnavailable: boolean) => {
     setIsPerlmutterUnavailable(isUnavailable)
   }
-  const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('charmm')
+  const [mdEngine] = useState<'charmm' | 'openmm'>('openmm')
   const [useExampleData, setUseExampleData] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [pdbWarning, setPdbWarning] = useState<string>('')
@@ -92,7 +91,7 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
 
   // Are we running on NERSC?
   const useNersc = config.useNersc?.toLowerCase() === 'true'
-  const charmmEnabled = config.enableCharmmEngine?.toLowerCase() !== 'false'
+
 
   const initialValues: BilboMDAutoJobFormValues = {
     bilbomd_mode: 'auto',
@@ -100,7 +99,7 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
     pdb_file: '',
     pae_file: '',
     dat_file: '',
-    md_engine: charmmEnabled ? 'charmm' : 'openmm'
+    md_engine: 'openmm'
   }
 
   const onSubmit = async (values: BilboMDAutoJobFormValues) => {
@@ -269,42 +268,6 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                         </Box>
                       </Box>
 
-                      {/* MD Engine selection */}
-                      <Grid sx={{ width: '520px' }}>
-                        <MdEngineField
-                          value={values.md_engine as 'charmm' | 'openmm'}
-                          onChange={(val) => {
-                            void setFieldValue('md_engine', val)
-                            setMdEngine(val)
-                            if (val === 'charmm') {
-                              setPdbWarning('')
-                              setPdbInfo('')
-                            } else if (
-                              val === 'openmm' &&
-                              values.pdb_file instanceof File
-                            ) {
-                              void Promise.all([
-                                detectGaffCofactors(values.pdb_file),
-                                detectMetalCofactors(values.pdb_file)
-                              ]).then(([gaffFound, metalFound]) => {
-                                setPdbInfo(
-                                  gaffFound.length > 0
-                                    ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
-                                    : ''
-                                )
-                                setPdbWarning(
-                                  metalFound.length > 0
-                                    ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
-                                    : ''
-                                )
-                              })
-                            }
-                          }}
-                          disabled={isSubmitting}
-                          disableCharmm={!charmmEnabled}
-                        />
-                      </Grid>
-
                       {useExampleData && (
                         <Alert
                           severity="warning"
@@ -342,11 +305,6 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             useExampleData ? 'example-auto.pdb' : undefined
                           }
                           onFileChange={async (file: File) => {
-                            if (mdEngine !== 'openmm') {
-                              setPdbInfo('')
-                              setPdbWarning('')
-                              return
-                            }
                             const [gaffFound, metalFound] = await Promise.all([
                               detectGaffCofactors(file),
                               detectMetalCofactors(file)

--- a/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 import {
   Box,
   Button,
@@ -8,6 +8,7 @@ import {
   AlertTitle,
   Paper
 } from '@mui/material'
+import LaunchIcon from '@mui/icons-material/Launch'
 import Grid from '@mui/material/Grid'
 import { Link as RouterLink, useParams, useNavigate } from 'react-router'
 import { Form, Formik, Field } from 'formik'
@@ -51,7 +52,7 @@ const ResubmitAutoJobForm = () => {
     setIsPerlmutterUnavailable(isUnavailable)
   }
   const [mdEngine] = useState<'charmm' | 'openmm'>('openmm')
-  const [pdbWarning, setPdbWarning] = useState<string>('')
+  const [pdbWarning, setPdbWarning] = useState<ReactNode>('')
   const [pdbInfo, setPdbInfo] = useState<string>('')
 
   // RTK Query to fetch the configuration
@@ -77,7 +78,6 @@ const ResubmitAutoJobForm = () => {
 
   // Are we running on NERSC?
   const useNersc = config?.useNersc?.toLowerCase() === 'true'
-
 
   // Grouped early return for loading and error states
   {
@@ -281,13 +281,46 @@ const ResubmitAutoJobForm = () => {
                           ])
                           setPdbInfo(
                             gaffFound.length > 0
-                              ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                              ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM: ${gaffFound.join(', ')}`
                               : ''
                           )
                           setPdbWarning(
-                            metalFound.length > 0
-                              ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
-                              : ''
+                            metalFound.length > 0 ? (
+                              <>
+                                The following metal-containing
+                                residues have no force-field
+                                parameters and will be removed before
+                                MD: {metalFound.join(', ')}. If these
+                                residues are important for your
+                                system, consider using{' '}
+                                <Button
+                                  href="https://charmm-gui.org/"
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  size="small"
+                                  variant="outlined"
+                                  color="info"
+                                  endIcon={<LaunchIcon />}
+                                  sx={{
+                                    textTransform: 'none',
+                                    py: 0,
+                                    px: 0.75,
+                                    minHeight: 0,
+                                    fontSize: 'inherit',
+                                    lineHeight: 'inherit',
+                                    verticalAlign: 'baseline'
+                                  }}
+                                >
+                                  CHARMM-GUI
+                                </Button>{' '}
+                                to properly parameterize your
+                                structure, then submit a Classic job
+                                with CRD and PSF files using the
+                                CHARMM engine option.
+                              </>
+                            ) : (
+                              ''
+                            )
                           )
                         }}
                       />

--- a/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
@@ -34,7 +34,6 @@ import { useTheme } from '@mui/material/styles'
 import PipelineSchematic from './PipelineSchematic'
 import { BilboMDAutoJobFormValues } from '../../types/autoJobForm'
 import type { BilboMDAutoDTO } from '@bilbomd/bilbomd-types'
-import MdEngineField from 'components/MdEngineField'
 
 const ResubmitAutoJobForm = () => {
   useTitle('BilboMD: Resubmit Auto Job')
@@ -51,7 +50,7 @@ const ResubmitAutoJobForm = () => {
   const handleStatusCheck = (isUnavailable: boolean) => {
     setIsPerlmutterUnavailable(isUnavailable)
   }
-  const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('charmm')
+  const [mdEngine] = useState<'charmm' | 'openmm'>('openmm')
   const [pdbWarning, setPdbWarning] = useState<string>('')
   const [pdbInfo, setPdbInfo] = useState<string>('')
 
@@ -78,7 +77,7 @@ const ResubmitAutoJobForm = () => {
 
   // Are we running on NERSC?
   const useNersc = config?.useNersc?.toLowerCase() === 'true'
-  const charmmEnabled = config?.enableCharmmEngine?.toLowerCase() !== 'false'
+
 
   // Grouped early return for loading and error states
   {
@@ -128,10 +127,7 @@ const ResubmitAutoJobForm = () => {
     pdb_file: jobMongo.pdb_file ?? '',
     pae_file: jobMongo.pae_file ?? '',
     dat_file: jobMongo.data_file ?? '',
-    md_engine: !charmmEnabled
-      ? 'openmm'
-      : ((jobMongo.md_engine?.toLowerCase?.() as 'charmm' | 'openmm') ??
-        'charmm')
+    md_engine: 'openmm'
   }
 
   const onSubmit = async (values: BilboMDAutoJobFormValues) => {
@@ -258,42 +254,6 @@ const ResubmitAutoJobForm = () => {
                       />
                     </Grid>
 
-                    {/* MD Engine selection */}
-                    <Grid sx={{ width: '520px', mb: 1 }}>
-                      <MdEngineField
-                        value={values.md_engine as 'charmm' | 'openmm'}
-                        onChange={(val) => {
-                          void setFieldValue('md_engine', val)
-                          setMdEngine(val)
-                          if (val === 'charmm') {
-                            setPdbWarning('')
-                            setPdbInfo('')
-                          } else if (
-                            val === 'openmm' &&
-                            values.pdb_file instanceof File
-                          ) {
-                            void Promise.all([
-                              detectGaffCofactors(values.pdb_file),
-                              detectMetalCofactors(values.pdb_file)
-                            ]).then(([gaffFound, metalFound]) => {
-                              setPdbInfo(
-                                gaffFound.length > 0
-                                  ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
-                                  : ''
-                              )
-                              setPdbWarning(
-                                metalFound.length > 0
-                                  ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
-                                  : ''
-                              )
-                            })
-                          }
-                        }}
-                        disabled={isSubmitting}
-                        disableCharmm={!charmmEnabled}
-                      />
-                    </Grid>
-
                     <Grid>
                       <Field
                         name="pdb_file"
@@ -315,11 +275,6 @@ const ResubmitAutoJobForm = () => {
                         fileType="AlphaFold2 *.pdb"
                         fileExt=".pdb"
                         onFileChange={async (file: File) => {
-                          if (mdEngine !== 'openmm') {
-                            setPdbInfo('')
-                            setPdbWarning('')
-                            return
-                          }
                           const [gaffFound, metalFound] = await Promise.all([
                             detectGaffCofactors(file),
                             detectMetalCofactors(file)

--- a/apps/ui/src/features/autojob/__tests__/NewAutoJobForm.mdengine.test.tsx
+++ b/apps/ui/src/features/autojob/__tests__/NewAutoJobForm.mdengine.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import NewAutoJobForm from '../NewAutoJobForm'
 
@@ -24,20 +23,9 @@ vi.mock('../../../slices/configsApiSlice', () => ({
 }))
 
 describe('NewAutoJobForm md_engine', () => {
-  it('renders CHARMM and OpenMM options and defaults to CHARMM', async () => {
+  it('does not render engine selection radio buttons', () => {
     render(<NewAutoJobForm />)
-    const charmm = screen.getByLabelText(/CHARMM/i)
-    const openmm = screen.getByLabelText(/OpenMM/i)
-    expect(charmm).toBeInTheDocument()
-    expect(openmm).toBeInTheDocument()
-    expect((charmm as HTMLInputElement).checked).toBe(true)
-  })
-
-  it('allows selecting OpenMM', async () => {
-    const user = userEvent.setup()
-    render(<NewAutoJobForm />)
-    const openmm = screen.getByLabelText(/OpenMM/i)
-    await user.click(openmm)
-    expect((openmm as HTMLInputElement).checked).toBe(true)
+    expect(screen.queryByLabelText(/CHARMM/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/OpenMM/i)).not.toBeInTheDocument()
   })
 })

--- a/apps/ui/src/features/help/Help.tsx
+++ b/apps/ui/src/features/help/Help.tsx
@@ -76,21 +76,21 @@ const Help = ({ title = 'BilboMD: Help' }) => {
             variant="body2"
             sx={{ mx: 5, my: 2 }}
           >
-            Pelikan M, Hura GL, Hammel M.{' '}
+            Classen S, Del Mundo J, Kulkarni D, Prabhakar S, Hicks A, Hammel
+            M.{' '}
             <b>
-              Structure and flexibility within proteins as identified through
-              small angle X-ray scattering.
+              BilboMD: a web-accessible SAXS and AlphaFold-guided modeling
+              pipeline.
             </b>{' '}
-            Gen Physiol Biophys. 2009 Jun;28(2):174-89. doi:
-            10.4149/gpb_2009_02_174. PMID:{' '}
+            Nucleic Acids Research. 2026; gkag377. doi:{' '}
             <Link
-              href="https://pubmed.ncbi.nlm.nih.gov/19592714/"
+              href="https://doi.org/10.1093/nar/gkag377"
               target="_blank"
               rel="noopener noreferrer"
             >
-              19592714
+              10.1093/nar/gkag377
             </Link>
-            ; PMCID: PMC3773563.
+            .
           </Typography>
         </Introduction>
 

--- a/apps/ui/src/features/help/Help.tsx
+++ b/apps/ui/src/features/help/Help.tsx
@@ -196,28 +196,28 @@ const Help = ({ title = 'BilboMD: Help' }) => {
               <Box sx={{ mt: 2 }}>
                 {tabValue === 0 && (
                   <img
-                    src="/images/bilbomd-classic-pdb-schematic.png"
+                    src={`/images/bilbomd-classic-pdb-schematic-openmm${theme.palette.mode === 'dark' ? '-dark' : ''}.png`}
                     alt="BilboMD Classic PDB Schematic"
                     style={{ width: '100%' }}
                   />
                 )}
                 {tabValue === 1 && (
                   <img
-                    src="/images/bilbomd-classic-crd-schematic.png"
+                    src={`/images/bilbomd-classic-crd-schematic${theme.palette.mode === 'dark' ? '-dark' : ''}.png`}
                     alt="BilboMD Classic CRD Schematic"
                     style={{ width: '100%' }}
                   />
                 )}
                 {tabValue === 2 && (
                   <img
-                    src="/images/bilbomd-auto-schematic.png"
+                    src={`/images/bilbomd-auto-schematic-openmm${theme.palette.mode === 'dark' ? '-dark' : ''}.png`}
                     alt="BilboMD Auto Schematic"
                     style={{ width: '100%' }}
                   />
                 )}
                 {tabValue === 3 && (
                   <img
-                    src="/images/bilbomd-af-schematic.png"
+                    src={`/images/bilbomd-af-schematic-openmm${theme.palette.mode === 'dark' ? '-dark' : ''}.png`}
                     alt="BilboMD AF Schematic"
                     style={{ width: '100%' }}
                   />

--- a/apps/ui/src/features/jobs/FileSelect.tsx
+++ b/apps/ui/src/features/jobs/FileSelect.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react'
+import { ChangeEvent, ReactNode } from 'react'
 import {
   Button,
   FormControl,
@@ -18,7 +18,7 @@ interface FileSelectProps extends FormControlProps {
   title: string
   error: boolean
   errorMessage?: string
-  warningMessage?: string
+  warningMessage?: ReactNode
   infoMessage?: string
   existingFileName?: string
   setFieldValue: (field: string, value: File, shouldValidate?: boolean) => void

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 import {
   Box,
   Button,
@@ -9,6 +9,7 @@ import {
   Paper,
   LinearProgress
 } from '@mui/material'
+import LaunchIcon from '@mui/icons-material/Launch'
 import Grid from '@mui/material/Grid'
 import { Form, Formik, Field } from 'formik'
 import {
@@ -90,7 +91,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const [autoRgError, setAutoRgError] = useState<string | null>(null)
   const [useExampleData, setUseExampleData] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
-  const [pdbWarning, setPdbWarning] = useState<string>('')
+  const [pdbWarning, setPdbWarning] = useState<ReactNode>('')
   const [pdbInfo, setPdbInfo] = useState<string>('')
   const [saxsData, setSaxsData] = useState<
     { q: number; intensity: number; error: number }[]
@@ -125,7 +126,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
     pdb_file: '',
     inp_file: '',
     dat_file: '',
-    num_conf: '',
+    num_conf: '3',
     rg: '',
     rg_min: '',
     rg_max: '',
@@ -235,6 +236,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                 handleBlur,
                 setFieldValue,
                 setFieldTouched,
+                setValues,
                 validateForm
               }) => (
                 <Form>
@@ -300,7 +302,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                 void setFieldValue('rg', '33')
                                 void setFieldValue('rg_min', '30')
                                 void setFieldValue('rg_max', '49')
-                                void setFieldValue('num_conf', 2)
+                                void setFieldValue('num_conf', '2')
                               } else {
                                 void setFieldValue(
                                   'title',
@@ -309,7 +311,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                 void setFieldValue('rg', '27')
                                 void setFieldValue('rg_min', '26')
                                 void setFieldValue('rg_max', '41')
-                                void setFieldValue('num_conf', 2)
+                                void setFieldValue('num_conf', '2')
                               }
                             } else {
                               void setFieldValue('psf_file', '')
@@ -320,7 +322,10 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                               void setFieldValue('title', '')
                               void setFieldValue('rg_min', '')
                               void setFieldValue('rg_max', '')
-                              void setFieldValue('num_conf', '')
+                              void setFieldValue(
+                                'num_conf',
+                                values.md_engine === 'openmm' ? '3' : ''
+                              )
                             }
                             setTimeout(() => {
                               void validateForm()
@@ -390,7 +395,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                           setSaxsData([])
                           setGuinierRegion(null)
                           if (val === 'openmm') {
-                            void setFieldValue('num_conf', 3)
+                            void setFieldValue('num_conf', '3')
                           }
                           setTimeout(() => void validateForm(), 0)
                         }}
@@ -507,13 +512,47 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                   ])
                                 setPdbInfo(
                                   gaffFound.length > 0
-                                    ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                    ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM: ${gaffFound.join(', ')}`
                                     : ''
                                 )
                                 setPdbWarning(
-                                  metalFound.length > 0
-                                    ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
-                                    : ''
+                                  metalFound.length > 0 ? (
+                                    <>
+                                      The following metal-containing
+                                      residues have no force-field
+                                      parameters and will be removed
+                                      before MD:{' '}
+                                      {metalFound.join(', ')}. If
+                                      these residues are important for
+                                      your system, consider using{' '}
+                                      <Button
+                                        href="https://charmm-gui.org/"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        size="small"
+                                        variant="outlined"
+                                        color="info"
+                                        endIcon={<LaunchIcon />}
+                                        sx={{
+                                          textTransform: 'none',
+                                          py: 0,
+                                          px: 0.75,
+                                          minHeight: 0,
+                                          fontSize: 'inherit',
+                                          lineHeight: 'inherit',
+                                          verticalAlign: 'baseline'
+                                        }}
+                                      >
+                                        CHARMM-GUI
+                                      </Button>{' '}
+                                      to properly parameterize your
+                                      structure, then return here with
+                                      CRD and PSF files using the
+                                      CHARMM engine option.
+                                    </>
+                                  ) : (
+                                    ''
+                                  )
                                 )
                               }}
                             />
@@ -641,13 +680,27 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                               try {
                                 const { rg, rg_min, rg_max, qmin, qmax } =
                                   await calculateAutoRg(formData).unwrap()
-                                void setFieldValue('rg', rg, false)
-                                void setFieldValue('rg_min', rg_min, false)
-                                void setFieldValue('rg_max', rg_max, false)
+                                void setValues(
+                                  {
+                                    ...values,
+                                    dat_file: selectedFile,
+                                    rg: String(rg),
+                                    rg_min: String(rg_min),
+                                    rg_max: String(rg_max)
+                                  },
+                                  true
+                                )
                                 void setFieldTouched('rg', true, false)
-                                void setFieldTouched('rg_min', true, false)
-                                void setFieldTouched('rg_max', true, false)
-                                setTimeout(() => void validateForm(), 0)
+                                void setFieldTouched(
+                                  'rg_min',
+                                  true,
+                                  false
+                                )
+                                void setFieldTouched(
+                                  'rg_max',
+                                  true,
+                                  false
+                                )
                                 if (
                                   typeof qmin === 'number' &&
                                   typeof qmax === 'number'
@@ -763,26 +816,26 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                         }
                       >
                         <MenuItem
-                          key={1}
-                          value={1}
+                          key="1"
+                          value="1"
                         >
                           200
                         </MenuItem>
                         <MenuItem
-                          key={2}
-                          value={2}
+                          key="2"
+                          value="2"
                         >
                           400
                         </MenuItem>
                         <MenuItem
-                          key={3}
-                          value={3}
+                          key="3"
+                          value="3"
                         >
                           600
                         </MenuItem>
                         <MenuItem
-                          key={4}
-                          value={4}
+                          key="4"
+                          value="4"
                         >
                           800
                         </MenuItem>

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -2,19 +2,15 @@ import { useState } from 'react'
 import {
   Box,
   Button,
-  Checkbox,
   TextField,
   MenuItem,
   Typography,
   Alert,
   Paper,
-  FormGroup,
-  FormControlLabel,
-  Divider,
   LinearProgress
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
-import { Form, Formik, Field, FormikHelpers, FormikErrors } from 'formik'
+import { Form, Formik, Field } from 'formik'
 import {
   useAddNewJobMutation,
   useCalculateAutoRgMutation
@@ -90,7 +86,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
     setIsPerlmutterUnavailable(isUnavailable)
   }
   const [selectedMode, setSelectedMode] = useState('pdb')
-  const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('charmm')
+  const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('openmm')
   const [autoRgError, setAutoRgError] = useState<string | null>(null)
   const [useExampleData, setUseExampleData] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -133,7 +129,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
     rg: '',
     rg_min: '',
     rg_max: '',
-    md_engine: charmmEnabled ? 'charmm' : 'openmm'
+    md_engine: 'openmm'
   }
 
   const onSubmit = async (values: BilboMDClassicJobFormValues) => {
@@ -150,10 +146,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
     form.append('rg_max', values.rg_max)
     form.append('dat_file', values.dat_file)
     form.append('inp_file', values.inp_file)
-    form.append(
-      'md_engine',
-      values.bilbomd_mode === 'crd_psf' ? 'charmm' : values.md_engine
-    )
+    form.append('md_engine', values.md_engine)
     if (useExampleData) {
       form.append('useExampleData', 'true')
     }
@@ -170,48 +163,6 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
       )
     }
   }
-
-  const handleCheckboxChange =
-    (
-      resetForm: FormikHelpers<BilboMDClassicJobFormValues>['resetForm'],
-      validateForm: (
-        values?: Partial<BilboMDClassicJobFormValues>
-      ) => Promise<FormikErrors<BilboMDClassicJobFormValues>>,
-      setUseExampleData: (value: boolean) => void
-    ) =>
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newBilboMDMode =
-        event.target.name === 'pdb_inputs' ? 'pdb' : 'crd_psf'
-
-      setSelectedMode(newBilboMDMode)
-      setUseExampleData(false) // Switch to custom data mode when changing modes
-
-      if (newBilboMDMode === 'pdb') {
-        console.log('reset to PDB mode')
-        resetForm({
-          values: {
-            ...initialValues,
-            bilbomd_mode: 'pdb'
-          },
-          errors: {},
-          touched: {}
-        })
-      } else {
-        console.log('reset to CRD/PSF mode')
-        resetForm({
-          values: {
-            ...initialValues,
-            bilbomd_mode: 'crd_psf'
-          },
-          errors: {},
-          touched: {}
-        })
-      }
-      // Delay validation to ensure form state has been updated
-      setTimeout(() => {
-        void validateForm()
-      }, 0)
-    }
 
   const isFormValid = (values: BilboMDClassicJobFormValues) => {
     return (
@@ -284,7 +235,6 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                 handleBlur,
                 setFieldValue,
                 setFieldTouched,
-                resetForm,
                 validateForm
               }) => (
                 <Form>
@@ -299,61 +249,32 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                         onStatusCheck={handleStatusCheck}
                       />
                     )}
-                    <Divider
-                      textAlign="left"
-                      sx={{ my: 1 }}
-                    >
-                      Model Inputs
-                    </Divider>
-                    <Grid
-                      container
-                      direction="row"
+                    <Box
                       sx={{
                         display: 'flex',
-                        minWidth: '520px'
+                        alignItems: 'center',
+                        my: 1
                       }}
                     >
-                      <Grid>
-                        <FormGroup sx={{ ml: 1 }}>
-                          <FormControlLabel
-                            control={
-                              <Checkbox
-                                checked={values.bilbomd_mode === 'pdb'}
-                                onChange={handleCheckboxChange(
-                                  resetForm,
-                                  validateForm,
-                                  setUseExampleData
-                                )}
-                                name="pdb_inputs"
-                              />
-                            }
-                            label="PDB or CIF file"
-                          />
-                          <FormControlLabel
-                            disabled={!charmmEnabled}
-                            control={
-                              <Checkbox
-                                checked={values.bilbomd_mode === 'crd_psf'}
-                                onChange={handleCheckboxChange(
-                                  resetForm,
-                                  validateForm,
-                                  setUseExampleData
-                                )}
-                                name="crd_psf_inputs"
-                                disabled={!charmmEnabled}
-                              />
-                            }
-                            label="CRD/PSF files"
-                          />
-                        </FormGroup>
-                      </Grid>
-                      <Grid sx={{ width: '260px' }}>
-                        <Alert severity="info">
-                          If you used CHARMM-GUI to parameterize your inputs
-                          then please select the CRD/PSF option
-                        </Alert>
-                      </Grid>
-                      <Grid sx={{ ml: 4 }}>
+                      <Box sx={{ minWidth: '520px' }}>
+                        <Field
+                          label="Title"
+                          name="title"
+                          id="title"
+                          type="text"
+                          disabled={isSubmitting}
+                          as={TextField}
+                          onChange={handleChange}
+                          onBlur={handleBlur}
+                          error={errors.title && touched.title}
+                          helperText={
+                            errors.title && touched.title ? errors.title : ''
+                          }
+                          value={values.title || ''}
+                          sx={{ width: '100%' }}
+                        />
+                      </Box>
+                      <Box sx={{ ml: 8, minWidth: 'fit-content' }}>
                         <Button
                           variant={useExampleData ? 'outlined' : 'contained'}
                           onClick={() => {
@@ -361,7 +282,6 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             setSaxsData([])
                             setGuinierRegion(null)
                             if (!useExampleData) {
-                              // Switching to example data: reset file fields
                               if (values.bilbomd_mode === 'pdb') {
                                 void setFieldValue('pdb_file', '')
                                 void setFieldValue('inp_file', '')
@@ -372,7 +292,6 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                 void setFieldValue('inp_file', '')
                                 void setFieldValue('dat_file', '')
                               }
-                              // Add defaults for other fields
                               if (values.bilbomd_mode === 'pdb') {
                                 void setFieldValue(
                                   'title',
@@ -393,7 +312,6 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                 void setFieldValue('num_conf', 2)
                               }
                             } else {
-                              // Switching to custom data: clear example defaults
                               void setFieldValue('psf_file', '')
                               void setFieldValue('crd_file', '')
                               void setFieldValue('pdb_file', '')
@@ -404,7 +322,6 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                               void setFieldValue('rg_max', '')
                               void setFieldValue('num_conf', '')
                             }
-                            // Delay validation to ensure form state has been updated
                             setTimeout(() => {
                               void validateForm()
                             }, 0)
@@ -414,8 +331,8 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             ? 'Use Custom Data'
                             : 'Load Example Data'}
                         </Button>
-                      </Grid>
-                      <Grid sx={{ ml: 0 }}>
+                      </Box>
+                      <Box sx={{ ml: 2, minWidth: 'fit-content' }}>
                         <Button
                           variant="contained"
                           href={
@@ -423,12 +340,11 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                               ? '/api/v1/public/examples/classic/pdb'
                               : '/api/v1/public/examples/classic/crd'
                           }
-                          sx={{ ml: 1 }}
                         >
                           Download Example Data
                         </Button>
-                      </Grid>
-                    </Grid>
+                      </Box>
+                    </Box>
 
                     {useExampleData && (
                       <Alert
@@ -449,75 +365,36 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                       </Alert>
                     )}
 
-                    <Divider
-                      textAlign="left"
-                      sx={{ my: 1 }}
-                    >
-                      Job Form
-                    </Divider>
-                    <Grid sx={{ my: 2, width: '520px' }}>
-                      <Field
-                        fullWidth
-                        label="Title"
-                        name="title"
-                        id="title"
-                        type="text"
-                        disabled={isSubmitting}
-                        as={TextField}
-                        onChange={handleChange}
-                        onBlur={handleBlur}
-                        error={errors.title && touched.title}
-                        helperText={
-                          errors.title && touched.title ? errors.title : ''
-                        }
-                        value={values.title || ''}
-                      />
-                    </Grid>
-
                     {/* MD Engine selection */}
                     <Grid sx={{ width: '520px' }}>
                       <MdEngineField
-                        value={
-                          (values.bilbomd_mode === 'crd_psf'
-                            ? 'charmm'
-                            : values.md_engine) as 'charmm' | 'openmm'
-                        }
+                        value={values.md_engine as 'charmm' | 'openmm'}
                         onChange={(val) => {
-                          if (values.bilbomd_mode !== 'crd_psf') {
-                            void setFieldValue('md_engine', val)
-                            setMdEngine(val)
-                            // For OpenMM, lock num_conf to the default (600)
-                            if (val === 'openmm') {
-                              void setFieldValue('num_conf', 3)
-                            }
-                            if (val === 'charmm') {
-                              setPdbWarning('')
-                              setPdbInfo('')
-                            } else if (
-                              val === 'openmm' &&
-                              values.pdb_file instanceof File
-                            ) {
-                              void Promise.all([
-                                detectGaffCofactors(values.pdb_file),
-                                detectMetalCofactors(values.pdb_file)
-                              ]).then(([gaffFound, metalFound]) => {
-                                setPdbInfo(
-                                  gaffFound.length > 0
-                                    ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
-                                    : ''
-                                )
-                                setPdbWarning(
-                                  metalFound.length > 0
-                                    ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
-                                    : ''
-                                )
-                              })
-                            }
+                          const newMode = val === 'charmm' ? 'crd_psf' : 'pdb'
+                          void setFieldValue('md_engine', val)
+                          void setFieldValue('bilbomd_mode', newMode)
+                          setMdEngine(val)
+                          setSelectedMode(newMode)
+                          setUseExampleData(false)
+                          void setFieldValue('pdb_file', '')
+                          void setFieldValue('crd_file', '')
+                          void setFieldValue('psf_file', '')
+                          void setFieldValue('inp_file', '')
+                          void setFieldValue('dat_file', '')
+                          void setFieldValue('title', '')
+                          void setFieldValue('rg_min', '')
+                          void setFieldValue('rg_max', '')
+                          void setFieldValue('num_conf', '')
+                          setPdbWarning('')
+                          setPdbInfo('')
+                          setSaxsData([])
+                          setGuinierRegion(null)
+                          if (val === 'openmm') {
+                            void setFieldValue('num_conf', 3)
                           }
+                          setTimeout(() => void validateForm(), 0)
                         }}
-                        disabled={
-                          isSubmitting || values.bilbomd_mode === 'crd_psf'
-                        }
+                        disabled={isSubmitting}
                         disableCharmm={!charmmEnabled}
                       />
                     </Grid>
@@ -693,20 +570,6 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                               : `*.crd`}
                           </b>{' '}
                           file.
-                          {values.bilbomd_mode === 'pdb' ? (
-                            <>
-                              {' '}
-                              For example, Protein Chain ID <b>A</b> will be
-                              converted to segid <b>PROA</b> and DNA Chain ID{' '}
-                              <b>G</b> will be converted to segid <b>DNAG</b>.
-                            </>
-                          ) : (
-                            <>
-                              {' '}
-                              Keeping in mind that CHARMM-GUI creates segid
-                              names in a unique way.
-                            </>
-                          )}
                         </Typography>
                       </Alert>
                     </Grid>

--- a/apps/ui/src/features/jobs/ResubmitJobForm.tsx
+++ b/apps/ui/src/features/jobs/ResubmitJobForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 import {
   Box,
   Button,
@@ -11,6 +11,7 @@ import {
   Divider,
   LinearProgress
 } from '@mui/material'
+import LaunchIcon from '@mui/icons-material/Launch'
 import Grid from '@mui/material/Grid'
 import { Link as RouterLink, useParams, useNavigate } from 'react-router'
 import { Form, Formik, Field } from 'formik'
@@ -57,7 +58,7 @@ const ResubmitJobForm = () => {
     setIsPerlmutterUnavailable(isUnavailable)
   }
   const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('openmm')
-  const [pdbWarning, setPdbWarning] = useState<string>('')
+  const [pdbWarning, setPdbWarning] = useState<ReactNode>('')
   const [pdbInfo, setPdbInfo] = useState<string>('')
 
   // RTK Query to fetch the configuration
@@ -200,7 +201,7 @@ const ResubmitJobForm = () => {
       form.append('reuse_pdb_file', 'true')
     }
 
-    form.append('num_conf', values.num_conf.toString())
+    form.append('num_conf', values.num_conf)
     form.append('rg', values.rg)
     form.append('rg_min', values.rg_min)
     form.append('rg_max', values.rg_max)
@@ -352,8 +353,7 @@ const ResubmitJobForm = () => {
                         <MdEngineField
                           value={values.md_engine as 'charmm' | 'openmm'}
                           onChange={(val) => {
-                            const newMode =
-                              val === 'charmm' ? 'crd_psf' : 'pdb'
+                            const newMode = val === 'charmm' ? 'crd_psf' : 'pdb'
                             void setFieldValue('md_engine', val)
                             void setFieldValue('bilbomd_mode', newMode)
                             setMdEngine(val)
@@ -482,13 +482,48 @@ const ResubmitJobForm = () => {
                                     ])
                                   setPdbInfo(
                                     gaffFound.length > 0
-                                      ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
+                                      ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM: ${gaffFound.join(', ')}`
                                       : ''
                                   )
                                   setPdbWarning(
-                                    metalFound.length > 0
-                                      ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
-                                      : ''
+                                    metalFound.length > 0 ? (
+                                      <>
+                                        The following metal-containing
+                                        residues have no force-field
+                                        parameters and will be removed
+                                        before MD:{' '}
+                                        {metalFound.join(', ')}. If
+                                        these residues are important
+                                        for your system, consider
+                                        using{' '}
+                                        <Button
+                                          href="https://charmm-gui.org/"
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                          size="small"
+                                          variant="outlined"
+                                          color="info"
+                                          endIcon={<LaunchIcon />}
+                                          sx={{
+                                            textTransform: 'none',
+                                            py: 0,
+                                            px: 0.75,
+                                            minHeight: 0,
+                                            fontSize: 'inherit',
+                                            lineHeight: 'inherit',
+                                            verticalAlign: 'baseline'
+                                          }}
+                                        >
+                                          CHARMM-GUI
+                                        </Button>{' '}
+                                        to properly parameterize your
+                                        structure, then return here
+                                        with CRD and PSF files using
+                                        the CHARMM engine option.
+                                      </>
+                                    ) : (
+                                      ''
+                                    )
                                   )
                                 }}
                               />
@@ -689,26 +724,26 @@ const ResubmitJobForm = () => {
                           }
                         >
                           <MenuItem
-                            key={1}
-                            value={1}
+                            key="1"
+                            value="1"
                           >
                             200
                           </MenuItem>
                           <MenuItem
-                            key={2}
-                            value={2}
+                            key="2"
+                            value="2"
                           >
                             400
                           </MenuItem>
                           <MenuItem
-                            key={3}
-                            value={3}
+                            key="3"
+                            value="3"
                           >
                             600
                           </MenuItem>
                           <MenuItem
-                            key={4}
-                            value={4}
+                            key="4"
+                            value="4"
                           >
                             800
                           </MenuItem>

--- a/apps/ui/src/features/jobs/ResubmitJobForm.tsx
+++ b/apps/ui/src/features/jobs/ResubmitJobForm.tsx
@@ -2,28 +2,18 @@ import { useState } from 'react'
 import {
   Box,
   Button,
-  Checkbox,
   TextField,
   MenuItem,
   Typography,
   Alert,
   AlertTitle,
   Paper,
-  FormGroup,
-  FormControlLabel,
   Divider,
   LinearProgress
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import { Link as RouterLink, useParams, useNavigate } from 'react-router'
-import {
-  Form,
-  Formik,
-  Field,
-  FormikHelpers,
-  FormikErrors,
-  FormikTouched
-} from 'formik'
+import { Form, Formik, Field } from 'formik'
 import {
   useAddNewJobMutation,
   useCalculateAutoRgMutation,
@@ -66,7 +56,7 @@ const ResubmitJobForm = () => {
   const handleStatusCheck = (isUnavailable: boolean) => {
     setIsPerlmutterUnavailable(isUnavailable)
   }
-  const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('charmm')
+  const [mdEngine, setMdEngine] = useState<'charmm' | 'openmm'>('openmm')
   const [pdbWarning, setPdbWarning] = useState<string>('')
   const [pdbInfo, setPdbInfo] = useState<string>('')
 
@@ -161,10 +151,7 @@ const ResubmitJobForm = () => {
         rg: jobMongo.rg?.toString() ?? '',
         rg_min: jobMongo.rg_min?.toString() ?? '',
         rg_max: jobMongo.rg_max?.toString() ?? '',
-        md_engine: !charmmEnabled
-          ? 'openmm'
-          : ((jobMongo.md_engine?.toLowerCase?.() as 'charmm' | 'openmm') ??
-            'charmm')
+        md_engine: 'charmm'
       }
       break
     case 'pdb':
@@ -180,10 +167,7 @@ const ResubmitJobForm = () => {
         rg: jobMongo.rg?.toString() ?? '',
         rg_min: jobMongo.rg_min?.toString() ?? '',
         rg_max: jobMongo.rg_max?.toString() ?? '',
-        md_engine: !charmmEnabled
-          ? 'openmm'
-          : ((jobMongo.md_engine?.toLowerCase?.() as 'charmm' | 'openmm') ??
-            'charmm')
+        md_engine: 'openmm'
       }
       break
     default:
@@ -241,48 +225,6 @@ const ResubmitJobForm = () => {
       console.error('rejected', error)
     }
   }
-
-  const setMode = (
-    mode: 'pdb' | 'crd_psf',
-    resetForm: FormikHelpers<typeof initialValues>['resetForm'],
-    values: typeof initialValues,
-    touched: FormikTouched<typeof initialValues>,
-    validateForm: (
-      values?: Partial<typeof initialValues>
-    ) => Promise<FormikErrors<typeof initialValues>>
-  ) => {
-    if (mode === 'pdb') {
-      resetForm({
-        values: { ...values, crd_file: '', psf_file: '', bilbomd_mode: 'pdb' },
-        errors: {},
-        touched: { ...touched }
-      })
-    } else {
-      resetForm({
-        values: { ...values, pdb_file: '', bilbomd_mode: 'crd_psf' },
-        errors: {},
-        touched: { ...touched }
-      })
-    }
-
-    setTimeout(() => validateForm(), 0)
-  }
-
-  const handleCheckboxChange =
-    (
-      resetForm: FormikHelpers<typeof initialValues>['resetForm'],
-      values: typeof initialValues,
-      validateForm: (
-        values?: Partial<typeof initialValues>
-      ) => Promise<FormikErrors<typeof initialValues>>,
-      touched: FormikTouched<typeof initialValues>
-    ) =>
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newBilboMDMode =
-        event.target.name === 'pdb_inputs' ? 'pdb' : 'crd_psf'
-
-      setMode(newBilboMDMode, resetForm, values, touched, validateForm)
-    }
 
   const isFormValid = (
     values: BilboMDClassicJobFormValues,
@@ -361,7 +303,6 @@ const ResubmitJobForm = () => {
                   status,
                   setFieldValue,
                   setFieldTouched,
-                  resetForm,
                   validateForm
                 }) => (
                   <Form>
@@ -382,56 +323,6 @@ const ResubmitJobForm = () => {
                       >
                         Model Inputs
                       </Divider>
-                      <Grid
-                        container
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'space-between',
-                          width: '520px'
-                        }}
-                      >
-                        <Grid size={{ xs: 6 }}>
-                          <FormGroup sx={{ ml: 1 }}>
-                            <FormControlLabel
-                              control={
-                                <Checkbox
-                                  checked={values.bilbomd_mode === 'pdb'}
-                                  onChange={handleCheckboxChange(
-                                    resetForm,
-                                    values,
-                                    validateForm,
-                                    touched
-                                  )}
-                                  name="pdb_inputs"
-                                />
-                              }
-                              label="PDB file"
-                            />
-                            <FormControlLabel
-                              control={
-                                <Checkbox
-                                  checked={values.bilbomd_mode === 'crd_psf'}
-                                  onChange={handleCheckboxChange(
-                                    resetForm,
-                                    values,
-                                    validateForm,
-                                    touched
-                                  )}
-                                  name="crd_psf_inputs"
-                                />
-                              }
-                              label="CRD/PSF files"
-                            />
-                          </FormGroup>
-                        </Grid>
-                        <Grid size={{ xs: 6 }}>
-                          <Alert severity="info">
-                            If you used CHARMM-GUI to parameterize your inputs
-                            then please select the CRD/PSF option
-                          </Alert>
-                        </Grid>
-                      </Grid>
                       <Divider
                         textAlign="left"
                         sx={{ my: 1 }}
@@ -461,31 +352,17 @@ const ResubmitJobForm = () => {
                         <MdEngineField
                           value={values.md_engine as 'charmm' | 'openmm'}
                           onChange={(val) => {
+                            const newMode =
+                              val === 'charmm' ? 'crd_psf' : 'pdb'
                             void setFieldValue('md_engine', val)
+                            void setFieldValue('bilbomd_mode', newMode)
                             setMdEngine(val)
-                            if (val === 'charmm') {
-                              setPdbWarning('')
-                              setPdbInfo('')
-                            } else if (
-                              val === 'openmm' &&
-                              values.pdb_file instanceof File
-                            ) {
-                              void Promise.all([
-                                detectGaffCofactors(values.pdb_file),
-                                detectMetalCofactors(values.pdb_file)
-                              ]).then(([gaffFound, metalFound]) => {
-                                setPdbInfo(
-                                  gaffFound.length > 0
-                                    ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM MD: ${gaffFound.join(', ')}`
-                                    : ''
-                                )
-                                setPdbWarning(
-                                  metalFound.length > 0
-                                    ? `The following metal-containing residues have no force-field parameters and will be removed before MD: ${metalFound.join(', ')}`
-                                    : ''
-                                )
-                              })
-                            }
+                            void setFieldValue('pdb_file', '')
+                            void setFieldValue('crd_file', '')
+                            void setFieldValue('psf_file', '')
+                            setPdbWarning('')
+                            setPdbInfo('')
+                            setTimeout(() => void validateForm(), 0)
                           }}
                           disabled={isSubmitting}
                           disableCharmm={!charmmEnabled}

--- a/apps/ui/src/features/jobs/__tests__/NewJobForm.mdengine.test.tsx
+++ b/apps/ui/src/features/jobs/__tests__/NewJobForm.mdengine.test.tsx
@@ -32,36 +32,93 @@ describe('NewJobForm md_engine', () => {
       isLoading: false
     })
   })
-  it('renders CHARMM and OpenMM options and defaults to CHARMM', async () => {
+
+  it('renders CHARMM and OpenMM options and defaults to OpenMM', async () => {
     render(<NewJobForm />)
     const charmm = screen.getByLabelText(/CHARMM/i)
     const openmm = screen.getByLabelText(/OpenMM/i)
     expect(charmm).toBeInTheDocument()
     expect(openmm).toBeInTheDocument()
-    expect((charmm as HTMLInputElement).checked).toBe(true)
-  })
-
-  it('allows selecting OpenMM', async () => {
-    const user = userEvent.setup()
-    render(<NewJobForm />)
-    const openmm = screen.getByLabelText(/OpenMM/i)
-    await user.click(openmm)
     expect((openmm as HTMLInputElement).checked).toBe(true)
   })
 
-  it('disables CRD/PSF checkbox when CHARMM engine is disabled', () => {
+  it('allows selecting CHARMM when enabled', async () => {
+    const user = userEvent.setup()
+    render(<NewJobForm />)
+    const charmm = screen.getByLabelText(/CHARMM/i)
+    await user.click(charmm)
+    expect((charmm as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('disables CHARMM option when CHARMM engine is disabled', () => {
     mockUseGetConfigsQuery.mockReturnValue({
       data: { useNersc: 'false', enableCharmmEngine: 'false' },
       isLoading: false
     })
     render(<NewJobForm />)
-    const crdPsfCheckbox = screen.getByRole('checkbox', { name: /CRD\/PSF files/i })
-    expect(crdPsfCheckbox).toBeDisabled()
+    const charmm = screen.getByLabelText(/CHARMM/i)
+    expect(charmm).toBeDisabled()
   })
 
-  it('CRD/PSF checkbox is enabled when CHARMM engine is enabled', () => {
+  it('does not render mode checkboxes', () => {
     render(<NewJobForm />)
-    const crdPsfCheckbox = screen.getByRole('checkbox', { name: /CRD\/PSF files/i })
-    expect(crdPsfCheckbox).toBeEnabled()
+    expect(
+      screen.queryByRole('checkbox', { name: /PDB or CIF file/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('checkbox', { name: /CRD\/PSF files/i })
+    ).not.toBeInTheDocument()
+  })
+
+  describe('engine-mode coupling: file inputs shown per engine', () => {
+    it('shows PDB file upload by default (OpenMM)', () => {
+      render(<NewJobForm />)
+      expect(screen.getByText(/\*\.pdb or \*\.cif/i)).toBeInTheDocument()
+    })
+
+    it('does not show CRD or PSF file uploads by default (OpenMM)', () => {
+      render(<NewJobForm />)
+      expect(
+        screen.queryByText(/CHARMM-GUI \*\.crd/i)
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText(/CHARMM-GUI \*\.psf/i)
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows CRD file upload after selecting CHARMM engine', async () => {
+      const user = userEvent.setup()
+      render(<NewJobForm />)
+      await user.click(screen.getByLabelText(/CHARMM/i))
+      expect(screen.getByText(/CHARMM-GUI \*\.crd/i)).toBeInTheDocument()
+    })
+
+    it('shows PSF file upload after selecting CHARMM engine', async () => {
+      const user = userEvent.setup()
+      render(<NewJobForm />)
+      await user.click(screen.getByLabelText(/CHARMM/i))
+      expect(screen.getByText(/CHARMM-GUI \*\.psf/i)).toBeInTheDocument()
+    })
+
+    it('does not show PDB file upload after selecting CHARMM engine', async () => {
+      const user = userEvent.setup()
+      render(<NewJobForm />)
+      await user.click(screen.getByLabelText(/CHARMM/i))
+      expect(screen.queryByText(/\*\.pdb or \*\.cif/i)).not.toBeInTheDocument()
+    })
+
+    it('restores PDB file upload when switching back to OpenMM', async () => {
+      const user = userEvent.setup()
+      render(<NewJobForm />)
+      await user.click(screen.getByLabelText(/CHARMM/i))
+      await user.click(screen.getByLabelText(/OpenMM/i))
+      expect(screen.getByText(/\*\.pdb or \*\.cif/i)).toBeInTheDocument()
+      expect(
+        screen.queryByText(/CHARMM-GUI \*\.crd/i)
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText(/CHARMM-GUI \*\.psf/i)
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
+++ b/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
@@ -33,7 +33,6 @@ import ChainDeuterationSlider from './ChainDeuterationSlider'
 import { useTheme } from '@mui/material/styles'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
-import MdEngineField from 'components/MdEngineField'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -115,7 +114,7 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
     return <Alert severity="error">Configuration not available</Alert>
 
   const useNersc = config.useNersc?.toLowerCase() === 'true'
-  const charmmEnabled = config.enableCharmmEngine?.toLowerCase() !== 'false'
+
 
   const handleStatusCheck = (isUnavailable: boolean) => {
     setIsPerlmutterUnavailable(isUnavailable)
@@ -130,7 +129,7 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
     rg_max: 0,
     inp_file: '',
     d2o_fraction: 100,
-    md_engine: charmmEnabled ? 'charmm' : 'openmm'
+    md_engine: 'openmm'
   }
 
   const onSubmit = async (values: NewSANSJobFormValues) => {
@@ -278,16 +277,6 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
                           errors.title && touched.title ? errors.title : ''
                         }
                         value={values.title || ''}
-                      />
-                    </Grid>
-
-                    {/* MD Engine selection */}
-                    {/* Disabled until we write teh necessary worker code*/}
-                    <Grid sx={{ width: '520px' }}>
-                      <MdEngineField
-                        value={values.md_engine as 'charmm' | 'openmm'}
-                        onChange={(val) => void setFieldValue('md_engine', val)}
-                        disabled={true}
                       />
                     </Grid>
 

--- a/apps/ui/src/features/sansjob/__tests__/NewSANSJobForm.mdengine.test.tsx
+++ b/apps/ui/src/features/sansjob/__tests__/NewSANSJobForm.mdengine.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-// import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import NewSANSJob from '../NewSANSJobForm'
 
@@ -25,20 +24,9 @@ vi.mock('../../../slices/configsApiSlice', () => ({
 }))
 
 describe('NewSANSJobForm md_engine', () => {
-  it('renders CHARMM and OpenMM options and defaults to CHARMM', async () => {
+  it('does not render engine selection radio buttons', () => {
     render(<NewSANSJob />)
-    const charmm = screen.getByLabelText(/CHARMM/i)
-    const openmm = screen.getByLabelText(/OpenMM/i)
-    expect(charmm).toBeInTheDocument()
-    expect(openmm).toBeInTheDocument()
-    expect((charmm as HTMLInputElement).checked).toBe(true)
+    expect(screen.queryByLabelText(/CHARMM/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/OpenMM/i)).not.toBeInTheDocument()
   })
-
-  // it('allows selecting OpenMM', async () => {
-  //   const user = userEvent.setup()
-  //   render(<NewSANSJob />)
-  //   const openmm = screen.getByLabelText(/OpenMM/i)
-  //   await user.click(openmm)
-  //   expect((openmm as HTMLInputElement).checked).toBe(true)
-  // })
 })


### PR DESCRIPTION
## Summary

- Replace the Pelikan et al. 2009 (*Gen Physiol Biophys*) citation with the newly published Classen et al. 2026 (*Nucleic Acids Research*) paper across all four pages that reference the BilboMD manuscript: Home, About, Acknowledgments, and Help
- Citation links now point to the DOI (`https://doi.org/10.1093/nar/gkag377`) instead of a PubMed ID (no PMID assigned yet for this advance article)
- Updated `Acknowledgments.test.tsx` to assert the new DOI link is present

## Test plan

- [x] All 1039 UI tests pass (`pnpm -F @bilbomd/ui test`)
- [x] Lint passes (`pnpm -F @bilbomd/ui lint`)
- [ ] Verify citation text and link render correctly on Home, About, Acknowledgments, and Help pages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)