### PR TITLE
ci: trigger builds and tests on Renovate dependency bump PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
               - 'packages/eslint-config/**'
               - 'pnpm-workspace.yaml'
               - 'package.json'
+              - 'pnpm-lock.yaml'
               - 'apps/backend/bilbomd-backend.dockerfile'
             ui:
               - 'apps/ui/**'
@@ -61,6 +62,7 @@ jobs:
               - 'packages/eslint-config/**'
               - 'pnpm-workspace.yaml'
               - 'package.json'
+              - 'pnpm-lock.yaml'
               - 'apps/ui/bilbomd-ui.dockerfile'
             worker:
               - 'apps/worker/**'
@@ -70,6 +72,7 @@ jobs:
               - 'packages/eslint-config/**'
               - 'pnpm-workspace.yaml'
               - 'package.json'
+              - 'pnpm-lock.yaml'
               - 'apps/worker/bilbomd-worker.dockerfile'
             scoper:
               - 'apps/scoper/**'
@@ -77,12 +80,14 @@ jobs:
               - 'packages/eslint-config/**'
               - 'pnpm-workspace.yaml'
               - 'package.json'
+              - 'pnpm-lock.yaml'
               - 'apps/scoper/bilbomd-scoper.dockerfile'
             schema:
               - 'packages/mongodb-schema/**'
               - 'packages/eslint-config/**'
               - 'pnpm-workspace.yaml'
               - 'package.json'
+              - 'pnpm-lock.yaml'
             md-utils:
               - 'packages/md-utils/**'
               - 'packages/bilbomd-types/**'
@@ -90,6 +95,7 @@ jobs:
               - 'packages/eslint-config/**'
               - 'pnpm-workspace.yaml'
               - 'package.json'
+              - 'pnpm-lock.yaml'
 
   lint:
     name: Lint


### PR DESCRIPTION
## Summary

- Adds `pnpm-lock.yaml` to all six `dorny/paths-filter` groups (`backend`, `ui`, `worker`, `scoper`, `schema`, `md-utils`) in the `changes` job
- Renovate always regenerates the lockfile when bumping npm deps, so this guarantees the full build and test suite runs on any Renovate npm PR
- No change to normal feature PR behavior — the lockfile typically changes there too, but app-specific globs already catch those

## Test plan

- [ ] Merge this PR, then confirm the next Renovate npm deps PR shows all six `changes` outputs set to `true` in the Actions UI
- [ ] Verify build and unit test jobs all appear (not just `lint`) on that Renovate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)