### PR TITLE
fix(ui): poll MD movies query so SANS+OpenMM movies appear without refresh

### DIFF
--- a/.changeset/fix-ui-movie-polling.md
+++ b/.changeset/fix-ui-movie-polling.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Fix MD movies not appearing without manual page refresh for SANS and OpenMM jobs by using RTK Query's built-in pollingInterval instead of a broken manual setInterval.

--- a/apps/ui/src/features/jobs/SingleJobPage.tsx
+++ b/apps/ui/src/features/jobs/SingleJobPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, lazy, Suspense } from 'react'
+import { useState, lazy, Suspense } from 'react'
 import { useParams, useLocation, useNavigate } from 'react-router'
 import useTitle from 'hooks/useTitle'
 import {
@@ -111,26 +111,10 @@ const SingleJobPage = () => {
     data: moviesData,
     error: moviesError,
     isLoading: moviesLoading
-  } = useGetMDMoviesQuery(id ?? skipToken)
-
-  const allMoviesReady =
-    moviesData &&
-    moviesData.movies.length > 0 &&
-    moviesData.movies.every((m) => m.status === 'ready')
-
-  // Optionally, use a refetch or polling effect:
-  useEffect(() => {
-    let interval: ReturnType<typeof setInterval> | undefined
-    if (!allMoviesReady && id) {
-      interval = setInterval(() => {
-        // You may need to use refetch from RTK Query if available
-        // refetchMovies()
-      }, 15000)
-    }
-    return () => {
-      if (interval) clearInterval(interval)
-    }
-  }, [allMoviesReady, id])
+  } = useGetMDMoviesQuery(id ?? skipToken, {
+    pollingInterval: 15000,
+    skipPollingIfUnfocused: true
+  })
 
   // Debug logging
   // console.log('moviesData:', moviesData)


### PR DESCRIPTION
## Summary

- Replaces the dead `useEffect`+`setInterval` pattern (which set up a timer but called nothing) with RTK Query's built-in `pollingInterval: 15000, skipPollingIfUnfocused: true` on `useGetMDMoviesQuery`
- Removes the now-unused `allMoviesReady` variable and `useEffect` import

## Root cause

For SANS+OpenMM jobs, `enqueueMakeMovie` is called fire-and-forget at ~50% job progress. The movie-worker renders MP4s **in parallel** with PepsiSANS, GA-SANS, and results steps. If the user opens the job page before the movie-worker finishes, the initial query sees `status: 'queued'` and the UI never re-fetched — MP4 files exist on disk but the MD Movies tab stays empty.

The `auto`+OpenMM pipeline is less affected because FoXS+MultiFoXS add enough wall time after the fire-and-forget that movies are usually ready before the user opens the page.

## Test plan

- [x] Submit a SANS+OpenMM job and open the job detail page while it is still running
- [x] Switch to the **MD Movies** tab — confirm movies appear within 15 seconds of the movie-worker finishing (no page refresh needed)
- [x] Verify that `auto`+OpenMM movie display is unaffected
- [x] Verify tab is not making unnecessary requests when the browser tab is hidden (`skipPollingIfUnfocused`)

Closes #690

🤖 Generated with [Claude Code](https://claude.ai/claude-code)