### PR TITLE
fix(ui): improve failed job error message with account-aware messaging

### DIFF
--- a/.changeset/improve-failed-job-error-message.md
+++ b/.changeset/improve-failed-job-error-message.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Improve error message on failed job page: logged-in users see their job UUID for support reference; anonymous users see a prompt to create an account for personalized support.

--- a/apps/ui/src/features/jobs/SingleJobPage.tsx
+++ b/apps/ui/src/features/jobs/SingleJobPage.tsx
@@ -1,5 +1,5 @@
 import { useState, lazy, Suspense } from 'react'
-import { useParams, useLocation, useNavigate } from 'react-router'
+import { useParams, useLocation, useNavigate, Link } from 'react-router'
 import useTitle from 'hooks/useTitle'
 import {
   Button,
@@ -550,15 +550,34 @@ const SingleJobPage = () => {
             </HeaderBox>
 
             <Item>
-              <Alert
-                severity="error"
-                variant="outlined"
-              >
-                Hmmmm... Well something didn&apos;t work. Please try submitting
-                again and if things still don&apos;t work contact Scott or
-                Michal.
-              </Alert>
-              {/* <JobError job={job} /> */}
+              {token ? (
+                <Alert
+                  severity="error"
+                  variant="outlined"
+                >
+                  <AlertTitle>Job Failed</AlertTitle>
+                  We&apos;ve logged the details of this job failure. Please
+                  contact Scott or Michal and reference your job ID for faster
+                  support:{' '}
+                  <Box
+                    component="code"
+                    sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+                  >
+                    {job.mongo.uuid}
+                  </Box>
+                </Alert>
+              ) : (
+                <Alert
+                  severity="error"
+                  variant="outlined"
+                >
+                  <AlertTitle>Job Failed</AlertTitle>
+                  Something didn&apos;t work.{' '}
+                  <Link to="/register">Creating a free BilboMD account</Link>{' '}
+                  allows us to investigate job failures and provide personalized
+                  support. You can also try resubmitting.
+                </Alert>
+              )}
             </Item>
           </Grid>
         )}


### PR DESCRIPTION
## Summary

- Replaces the generic "Hmmmm... Well something didn't work" error on the failed job page with context-aware messaging
- Logged-in users see their job UUID so support staff can look up the job directly
- Anonymous users see a prompt to create a free account, with a link to `/register`, explaining it enables personalized support for failed jobs

Closes #685

## Test plan

- [ ] View a failed job while logged in → Alert shows "Job Failed" with the job UUID in monospace
- [ ] View a failed job while logged out → Alert shows "Job Failed" with a "Creating a free BilboMD account" link to `/register`
- [ ] `pnpm -F @bilbomd/ui lint` passes
- [ ] `pnpm -F @bilbomd/ui build` passes
- [ ] `pnpm -F @bilbomd/ui test` passes (1039 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)