### PR TITLE
feat(ui): warn non-NERSC users of limited GPU compute on AF job form

### DIFF
--- a/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
+++ b/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
@@ -600,7 +600,25 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
               />
             ) : null
           ) : (
-            <Formik<NewAlphaFoldJobFormValues>
+            <>
+              {!useNersc && (
+                <Alert
+                  severity="warning"
+                  sx={{ mb: 2 }}
+                >
+                  This deployment has limited GPU compute available. If you plan
+                  to submit many AlphaFold jobs, please use{' '}
+                  <Link
+                    href="https://bilbomd-nersc.bl1231.als.lbl.gov/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    bilbomd-nersc.bl1231.als.lbl.gov
+                  </Link>
+                  .
+                </Alert>
+              )}
+              <Formik<NewAlphaFoldJobFormValues>
               initialValues={initialValues}
               validationSchema={
                 useExampleData ? undefined : BilboMDAlphaFoldJobSchema
@@ -828,7 +846,8 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
                   {import.meta.env.MODE === 'development' ? <Debug /> : ''}
                 </Form>
               )}
-            </Formik>
+              </Formik>
+            </>
           )}
         </Paper>
       </Grid>

--- a/apps/ui/src/features/alphafoldjob/__tests__/NewAlphaFoldJobForm.test.tsx
+++ b/apps/ui/src/features/alphafoldjob/__tests__/NewAlphaFoldJobForm.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { describe, it, beforeEach, vi, Mock } from 'vitest'
+import { describe, it, beforeEach, vi, Mock, expect } from 'vitest'
 import '@testing-library/jest-dom'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import NewAlphaFoldJob from '../NewAlphaFoldJobForm'
 import { useAddNewAlphaFoldJobMutation } from 'slices/jobsApiSlice'
 import { useAddNewPublicJobMutation } from 'slices/publicJobsApiSlice'
@@ -26,7 +26,14 @@ vi.mock('react-router', () => ({
 }))
 
 vi.mock('@mui/material/styles', () => ({
-  useTheme: vi.fn(() => ({ palette: { mode: 'light' } }))
+  useTheme: vi.fn(() => ({
+    palette: {
+      mode: 'light',
+      success: { main: '#2e7d32' },
+      warning: { main: '#ed6c02' },
+      error: { main: '#d32f2f' }
+    }
+  }))
 }))
 
 vi.mock('features/jobs/FileSelect', () => ({
@@ -161,5 +168,31 @@ describe('NewAlphaFoldJob Component', () => {
   it('should handle config loaded', () => {
     render(<NewAlphaFoldJob />)
     // Component should render form when config is loaded
+  })
+
+  it('shows GPU warning on non-NERSC deployments with AF enabled', () => {
+    ;(useGetConfigsQuery as Mock).mockReturnValue({
+      data: { enableBilboMdAlphaFold: 'true', useNersc: 'false' },
+      error: null,
+      isLoading: false
+    })
+
+    render(<NewAlphaFoldJob />)
+    expect(
+      screen.getByText(/limited GPU compute available/i)
+    ).toBeInTheDocument()
+  })
+
+  it('does not show GPU warning on NERSC deployments', () => {
+    ;(useGetConfigsQuery as Mock).mockReturnValue({
+      data: { enableBilboMdAlphaFold: 'true', useNersc: 'true' },
+      error: null,
+      isLoading: false
+    })
+
+    render(<NewAlphaFoldJob />)
+    expect(
+      screen.queryByText(/limited GPU compute available/i)
+    ).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- Adds a `warning` Alert at the top of the BilboMD AF new job form when the deployment has AlphaFold enabled (`enableBilboMdAlphaFold=true`) but is **not** a NERSC deployment (`useNersc=false`)
- The alert advises users with many AF jobs to use [bilbomd-nersc.bl1231.als.lbl.gov](https://bilbomd-nersc.bl1231.als.lbl.gov/) instead
- Does not block form submission — advisory only
- Adds two test cases covering the warning's presence (non-NERSC) and absence (NERSC)

## Test plan

- [ ] Non-NERSC deployment with AF enabled: warning Alert is visible above the form
- [ ] NERSC deployment with AF enabled: no warning shown
- [ ] AF disabled: existing hard-block alert unchanged
- [ ] `pnpm -F @bilbomd/ui lint && pnpm -F @bilbomd/ui build && pnpm -F @bilbomd/ui test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)