### PR TITLE
feat(sans): add Molstar viewer for SANS jobs

### DIFF
--- a/.changeset/sans-molstar-viewer.md
+++ b/.changeset/sans-molstar-viewer.md
@@ -1,0 +1,10 @@
+---
+'@bilbomd/worker': patch
+'@bilbomd/ui': patch
+---
+
+Add Molstar viewer support for SANS jobs.
+
+Worker: fix SANS ensemble PDB files to use proper MODEL N / ENDMDL formatting so Molstar can load each conformation as a separate assembly. Populate results.sans.ensembles in MongoDB after each SANS job completes.
+
+UI: enable the Molstar viewer for completed SANS jobs in SingleJobPage. Viewer.tsx now routes SANS jobs through the same ensemble loading path as classic/auto/alphafold jobs.

--- a/apps/backend/src/controllers/public/getPublicMovies.ts
+++ b/apps/backend/src/controllers/public/getPublicMovies.ts
@@ -1,0 +1,108 @@
+import type { Request, Response } from 'express'
+import { Job as JobModel } from '@bilbomd/mongodb-schema'
+import type { IJob } from '@bilbomd/mongodb-schema'
+import { logger } from '../../middleware/loggers.js'
+import path from 'path'
+
+interface MovieAsset {
+  label: string
+  status: 'queued' | 'running' | 'ready' | 'failed'
+  mp4?: string
+  poster?: string
+  thumb?: string
+  source?: { pdb?: string; dcd?: string; constYaml?: string }
+  meta?: {
+    width?: number
+    height?: number
+    stride?: number
+    fps?: number
+    ray?: boolean
+  }
+  error?: string
+  createdAt?: Date
+  updatedAt?: Date
+}
+
+interface Assets {
+  movies: MovieAsset[]
+}
+
+interface JobWithAssets extends IJob {
+  assets?: Assets
+}
+
+interface NormalizedMovieAsset extends Omit<MovieAsset, 'source'> {
+  source?: { pdb?: string; dcd?: string; constYaml?: string }
+}
+
+interface MoviesResponse {
+  movies: NormalizedMovieAsset[]
+}
+
+function toPublicUrl(
+  absPath?: string | null,
+  publicId?: string,
+  label?: string
+): string | undefined {
+  if (!absPath || !publicId || !label) return undefined
+  const filename = path.basename(absPath)
+  return `/api/v1/public/jobs/${publicId}/movies/${label}/${filename}`
+}
+
+const getPublicMovies = async (
+  req: Request,
+  res: Response
+): Promise<Response<MoviesResponse>> => {
+  const rawPublicId = req.params.publicId
+  const publicId = Array.isArray(rawPublicId) ? rawPublicId[0] : rawPublicId
+
+  if (!publicId) {
+    return res.status(400).json({ error: 'Missing publicId' })
+  }
+
+  try {
+    const job = (await JobModel.findOne(
+      { public_id: publicId, access_mode: 'anonymous' },
+      { 'assets.movies': 1 }
+    ).lean()) as JobWithAssets | null
+
+    if (!job) {
+      return res.status(404).json({ error: 'Job not found' })
+    }
+
+    const movies: MovieAsset[] = job.assets?.movies ?? []
+
+    const normalizedMovies: NormalizedMovieAsset[] = movies.map((movie) => ({
+      label: movie.label,
+      status: movie.status,
+      mp4: toPublicUrl(movie.mp4, publicId, movie.label),
+      poster: toPublicUrl(movie.poster, publicId, movie.label),
+      thumb: toPublicUrl(movie.thumb, publicId, movie.label),
+      source: movie.source
+        ? {
+            pdb: toPublicUrl(movie.source.pdb, publicId, movie.label),
+            dcd: toPublicUrl(movie.source.dcd, publicId, movie.label),
+            constYaml: toPublicUrl(
+              movie.source.constYaml,
+              publicId,
+              movie.label
+            )
+          }
+        : undefined,
+      meta: movie.meta,
+      error: movie.error,
+      createdAt: movie.createdAt,
+      updatedAt: movie.updatedAt
+    }))
+
+    logger.info(
+      `getPublicMovies: publicId=${publicId}, ${normalizedMovies.length} movies`
+    )
+    return res.json({ movies: normalizedMovies })
+  } catch (err) {
+    logger.error(`Error fetching public movies: ${err}`)
+    return res.status(500).json({ error: 'Failed to fetch movies' })
+  }
+}
+
+export default getPublicMovies

--- a/apps/backend/src/controllers/public/streamPublicVideo.ts
+++ b/apps/backend/src/controllers/public/streamPublicVideo.ts
@@ -1,0 +1,126 @@
+import { Request, Response } from 'express'
+import fs from 'fs'
+import path from 'path'
+import { Job as JobModel, IAssets, IMovieAsset } from '@bilbomd/mongodb-schema'
+import { logger } from '../../middleware/loggers.js'
+
+const getContentType = (filename: string): string => {
+  const ext = path.extname(filename).toLowerCase()
+  switch (ext) {
+    case '.mp4':
+      return 'video/mp4'
+    case '.webm':
+      return 'video/webm'
+    case '.mov':
+      return 'video/quicktime'
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg'
+    case '.png':
+      return 'image/png'
+    case '.gif':
+      return 'image/gif'
+    case '.webp':
+      return 'image/webp'
+    default:
+      return 'application/octet-stream'
+  }
+}
+
+const streamPublicVideo = async (req: Request, res: Response) => {
+  try {
+    const { publicId, label, filename } = req.params
+
+    const job = await JobModel.findOne({
+      public_id: publicId,
+      access_mode: 'anonymous'
+    })
+    if (!job) {
+      return res.status(404).json({ message: 'Job not found' })
+    }
+
+    const assets = job.assets as IAssets | undefined
+    const movies = assets?.movies ?? []
+    const movieAsset = movies.find(
+      (movie: IMovieAsset) =>
+        movie.label === label &&
+        ((movie.mp4 && path.basename(movie.mp4) === filename) ||
+          (movie.poster && path.basename(movie.poster) === filename) ||
+          (movie.thumb && path.basename(movie.thumb) === filename))
+    )
+    if (!movieAsset) {
+      return res.status(404).json({ message: 'Movie asset not found' })
+    }
+
+    let mediaPath = ''
+    if (movieAsset.mp4 && path.basename(movieAsset.mp4) === filename) {
+      mediaPath = movieAsset.mp4
+    } else if (
+      movieAsset.poster &&
+      path.basename(movieAsset.poster) === filename
+    ) {
+      mediaPath = movieAsset.poster
+    } else if (
+      movieAsset.thumb &&
+      path.basename(movieAsset.thumb) === filename
+    ) {
+      mediaPath = movieAsset.thumb
+    } else {
+      return res.status(404).json({ message: 'File not found in movie asset' })
+    }
+
+    const resolvedPath = path.resolve(mediaPath)
+    const uploadsPath = path.resolve('/bilbomd/uploads')
+    if (!resolvedPath.startsWith(uploadsPath)) {
+      logger.warn(`Path traversal attempt on public stream: ${mediaPath}`)
+      return res.status(403).json({ message: 'Invalid file path' })
+    }
+
+    let stat: fs.Stats
+    try {
+      stat = await fs.promises.stat(resolvedPath)
+    } catch {
+      return res.status(404).json({ message: 'Media file not found' })
+    }
+
+    const fileSize = stat.size
+    const range = req.headers.range
+    const contentType = getContentType(filename)
+
+    if (contentType.startsWith('video/') && range) {
+      const parts = range.replace(/bytes=/, '').split('-')
+      const start = parseInt(parts[0], 10)
+      const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1
+      const chunkSize = end - start + 1
+
+      res.writeHead(206, {
+        'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+        'Accept-Ranges': 'bytes',
+        'Content-Length': chunkSize,
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=3600'
+      })
+      fs.createReadStream(resolvedPath, { start, end }).pipe(res)
+    } else {
+      const headers: Record<string, string | number> = {
+        'Content-Length': fileSize,
+        'Content-Type': contentType
+      }
+      if (contentType.startsWith('video/')) {
+        headers['Accept-Ranges'] = 'bytes'
+        headers['Cache-Control'] = 'public, max-age=3600'
+      } else {
+        headers['Cache-Control'] = 'public, max-age=86400'
+      }
+      res.writeHead(200, headers)
+      fs.createReadStream(resolvedPath).pipe(res)
+    }
+
+    logger.info(`Public media served: ${filename} for publicId=${publicId}`)
+  } catch (error) {
+    logger.error('Error streaming public media:', error)
+    res.status(500).json({ message: 'Internal server error' })
+  }
+}
+
+export default streamPublicVideo

--- a/apps/backend/src/routes/public.ts
+++ b/apps/backend/src/routes/public.ts
@@ -6,12 +6,16 @@ import getPublicFoxsData from '../controllers/public/getPublicFoxsData.js'
 import { getPublicFeedbackData } from '../controllers/public/getPublicFeedbackData.js'
 import { downloadPublicJobResultFile } from '../controllers/public/downloadPublicJobResultFile.js'
 import { createPublicSANSJob } from '../controllers/jobs/sansJobController.js'
+import getPublicMovies from '../controllers/public/getPublicMovies.js'
+import streamPublicVideo from '../controllers/public/streamPublicVideo.js'
 
 const router = express.Router()
 
 router.route('/').post(publicJobLimiter, createPublicJob)
 router.route('/sans').post(publicJobLimiter, createPublicSANSJob)
 router.route('/:publicId').get(getPublicJobById)
+router.route('/:publicId/movies').get(getPublicMovies)
+router.route('/:publicId/movies/:label/:filename').get(streamPublicVideo)
 router.route('/:publicId/results').get(downloadPublicJobResults)
 router.route('/:publicId/results/foxs').get(getPublicFoxsData)
 router.route('/:publicId/results/feedback').get(getPublicFeedbackData)

--- a/apps/ui/src/features/jobs/SingleJobPage.tsx
+++ b/apps/ui/src/features/jobs/SingleJobPage.tsx
@@ -438,7 +438,8 @@ const SingleJobPage = () => {
             job.mongo.jobType === 'crd' ||
             job.mongo.jobType === 'auto' ||
             job.mongo.jobType === 'alphafold' ||
-            job.mongo.jobType === 'scoper') && (
+            job.mongo.jobType === 'scoper' ||
+            job.mongo.jobType === 'sans') && (
             <Grid size={{ xs: 12 }}>
               <HeaderBox sx={{ py: '6px' }}>
                 <Typography>

--- a/apps/ui/src/features/molstar/Viewer.tsx
+++ b/apps/ui/src/features/molstar/Viewer.tsx
@@ -191,7 +191,7 @@ const MolstarViewer = ({
     }
 
     // Adding LoadParams based on job type and results structure
-    const ensembleJobTypes: JobType[] = ['pdb', 'crd', 'auto', 'alphafold']
+    const ensembleJobTypes: JobType[] = ['pdb', 'crd', 'auto', 'alphafold', 'sans']
 
     if (ensembleJobTypes.includes(jobType)) {
       // Use the appropriate results structure based on job type
@@ -210,9 +210,6 @@ const MolstarViewer = ({
         const pdbFilename = `scoper_combined_${results.scoper.foxs_top_file}`
         addFilesToLoadParams(pdbFilename, 1)
       }
-    } else if (jobType === 'sans') {
-      // SANS jobs might have different file structures - handle if needed
-      console.log('SANS job detected - no ensemble loading implemented yet')
     }
 
     // Convert the Map values to an array of arrays

--- a/apps/ui/src/features/public/PublicJobAnalysisSection.tsx
+++ b/apps/ui/src/features/public/PublicJobAnalysisSection.tsx
@@ -12,14 +12,21 @@ import HeaderBox from 'components/HeaderBox'
 import FoXSAnalysis from 'features/jobs/FoXSAnalysis'
 import type { PublicJobStatus } from '@bilbomd/bilbomd-types'
 import BilboMdFeedback from 'features/analysis/BilboMdFeedback'
+import MovieGallery from 'features/analysis/MovieGallery'
+import { useGetPublicMDMoviesQuery } from 'slices/publicJobsApiSlice'
 
 interface JobAnalysisSectionProps {
   job: PublicJobStatus
 }
 
 const JobAnalysisSection = ({ job }: JobAnalysisSectionProps) => {
-  // console.log('JobAnalysisSection job:', job)
   const [tabValue, setTabValue] = useState(0)
+
+  const {
+    data: moviesData,
+    error: moviesError,
+    isLoading: moviesLoading
+  } = useGetPublicMDMoviesQuery(job.publicId)
 
   const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue)
@@ -68,11 +75,15 @@ const JobAnalysisSection = ({ job }: JobAnalysisSectionProps) => {
       {tabValue === 1 && (
         <Box sx={{ p: 0 }}>
           <Grid size={{ xs: 12 }}>
-            <Suspense fallback={<CircularProgress />}>
-              <Alert severity="info">
-                No MD Movies available for this job.
-              </Alert>
-            </Suspense>
+            {moviesLoading ? (
+              <CircularProgress />
+            ) : moviesError ? (
+              <Alert severity="error">Error loading movies.</Alert>
+            ) : moviesData ? (
+              <MovieGallery data={moviesData} />
+            ) : (
+              <Alert severity="warning">No movie data available.</Alert>
+            )}
           </Grid>
         </Box>
       )}

--- a/apps/ui/src/slices/publicJobsApiSlice.ts
+++ b/apps/ui/src/slices/publicJobsApiSlice.ts
@@ -1,5 +1,9 @@
 import { apiSlice } from 'app/api/apiSlice'
-import type { PublicJobStatus, AnonJobResponse } from '@bilbomd/bilbomd-types'
+import type {
+  PublicJobStatus,
+  AnonJobResponse,
+  JobAssetsDTO
+} from '@bilbomd/bilbomd-types'
 import type { IFeedbackData } from '@bilbomd/mongodb-schema/frontend'
 import type { FoxsData } from 'types/foxs'
 
@@ -51,6 +55,9 @@ export const publicJobsApiSlice = apiSlice.injectEndpoints({
         url: `/public/jobs/${publicId}/results/${filename}`,
         responseHandler: (response) => response.text()
       })
+    }),
+    getPublicMDMovies: builder.query<JobAssetsDTO, string>({
+      query: (publicId) => `/public/jobs/${publicId}/movies`
     })
   })
 })
@@ -63,5 +70,6 @@ export const {
   useGetPublicFeedbackDataQuery,
   useGetPublicResultFileQuery,
   useGetPublicResultFileJsonQuery,
-  useGetPublicResultFileTextQuery
+  useGetPublicResultFileTextQuery,
+  useGetPublicMDMoviesQuery
 } = publicJobsApiSlice

--- a/apps/worker/src/services/functions/bilbomd-sans-functions.ts
+++ b/apps/worker/src/services/functions/bilbomd-sans-functions.ts
@@ -5,7 +5,7 @@ import csv from 'csv-parser'
 import { logger } from '../../helpers/loggers.js'
 import { glob } from 'glob'
 import { promisify } from 'util'
-import { IStepStatus } from '@bilbomd/mongodb-schema'
+import { IStepStatus, IEnsemble } from '@bilbomd/mongodb-schema'
 import { IJob, IBilboMDSANSJob } from '@bilbomd/mongodb-schema'
 import { updateStepStatus } from './mongo-utils.js'
 import { generateDCD2PDBInpFile } from './bilbomd-step-functions.js'
@@ -743,28 +743,50 @@ const prepareResults = async (DBjob: IBilboMDSANSJob): Promise<void> => {
           `REMARK`
         ].join('\n')
 
-        // Read and concatenate the content of all PDB files in memory
-        const concatenatedContent = await Promise.all(
-          pdbFilesToConcatenate.map((filePath) =>
-            fs.promises.readFile(filePath, 'utf-8')
+        // Build a proper multi-model PDB with MODEL N / ENDMDL records so
+        // Molstar can load each conformation as a separate assembly.
+        const modelLines: string[] = []
+        for (let i = 0; i < pdbFilesToConcatenate.length; i++) {
+          let content = await fs.promises.readFile(
+            pdbFilesToConcatenate[i],
+            'utf-8'
           )
-        ).then((contents) => contents.join('\n')) // Join all files' contents
+          content = content
+            .split('\n')
+            .filter((line) => !line.startsWith('REMARK'))
+            .join('\n')
+            .replace(/\bEND\n?$/, 'ENDMDL')
+          modelLines.push(`MODEL       ${i + 1}`)
+          modelLines.push(content)
+        }
 
-        // Filter out lines starting with "REMARK"
-        const filteredContent = concatenatedContent
-          .split('\n')
-          .filter((line) => !line.startsWith('REMARK'))
-          .join('\n')
-
-        // Combine the custom header and the filtered content
-        const finalContent = [header, filteredContent].join('\n')
+        const finalContent = [header, ...modelLines].join('\n')
 
         // Write the final content to the output file
         await fs.promises.writeFile(concatenatedPdbFile, finalContent, 'utf-8')
 
         logger.info(
-          `Created filtered PDB file with custom header: ${concatenatedPdbFile}`
+          `Created multi-model PDB file: ${concatenatedPdbFile}`
         )
+      }
+    }
+
+    // Store ensemble metadata in MongoDB so the Molstar viewer can load them.
+    // Only the size field is required — the viewer uses it to build filenames
+    // and to know how many MODEL records to load.
+    const sansEnsembles: IEnsemble[] = gasansSummaryFiles
+      .map((f) => ({
+        size: parseInt(f.match(/\d+/)?.[0] ?? '0', 10),
+        models: []
+      }))
+      .filter((e) => e.size > 0)
+      .sort((a, b) => a.size - b.size)
+
+    if (sansEnsembles.length > 0) {
+      DBjob.results = DBjob.results || {}
+      DBjob.results.sans = {
+        total_num_ensembles: sansEnsembles.length,
+        ensembles: sansEnsembles
       }
     }
 

--- a/packages/mongodb-schema/src/interfaces/resultsInterface.ts
+++ b/packages/mongodb-schema/src/interfaces/resultsInterface.ts
@@ -42,7 +42,10 @@ interface IAlphaFoldResults {
   ensembles?: IEnsemble[]
 }
 
-interface ISANSResults {}
+interface ISANSResults {
+  total_num_ensembles?: number
+  ensembles?: IEnsemble[]
+}
 
 interface IScoperResults {
   kgs_conformations?: number


### PR DESCRIPTION
## Summary

- Fix SANS ensemble PDB files to use proper `MODEL N` / `ENDMDL` formatting so Molstar can load each conformation as a separate assembly (previously the files were flat-concatenated without any model records)
- Populate `results.sans.ensembles` in MongoDB after each SANS job completes so the UI has data to load
- Enable the Molstar viewer for completed SANS jobs in `SingleJobPage` and route SANS through the same ensemble loading path as classic/auto/alphafold in `Viewer.tsx`

Closes #703

## Test plan

- [x] Run a SANS job to completion and verify `results.sans.ensembles` is populated in MongoDB
- [x] Confirm `ensemble_size_N_model.pdb` files in the results directory contain proper `MODEL N` / `ENDMDL` records
- [x] Verify the Molstar viewer renders on the SANS job detail page with the ensemble toggle panel showing the correct ensemble sizes
- [x] Confirm `PublicJobPage` also shows the viewer for a public SANS job

🤖 Generated with [Claude Code](https://claude.com/claude-code)