### PR TITLE
fix(worker): add prep_pdb step to SANS OpenMM pipeline; rename strip_ions → prep_pdb

### DIFF
--- a/.changeset/fix-sans-prep-pdb.md
+++ b/.changeset/fix-sans-prep-pdb.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Add PDB preparation step (strip waters and ions) to SANS OpenMM pipeline. Rename strip_ions.py → prep_pdb.py and runStripIons → runPrepPdb for accuracy — the script has always removed both HOH waters and metal/polyatomic ions.

--- a/.changeset/fix-sans-prep-pdb.md
+++ b/.changeset/fix-sans-prep-pdb.md
@@ -1,5 +1,8 @@
 ---
 '@bilbomd/worker': patch
+'@bilbomd/ui': patch
 ---
 
 Add PDB preparation step (strip waters and ions) to SANS OpenMM pipeline. Rename strip_ions.py → prep_pdb.py and runStripIons → runPrepPdb for accuracy — the script has always removed both HOH waters and metal/polyatomic ions.
+
+Add GAFF2/metal cofactor alerts to the SANS new job form, matching the behaviour already present on the Classic PDB and Auto forms.

--- a/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
+++ b/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import type { ReactNode } from 'react'
 import {
   Box,
   Button,
@@ -9,6 +10,7 @@ import {
   Slider,
   Chip
 } from '@mui/material'
+import LaunchIcon from '@mui/icons-material/Launch'
 import Grid from '@mui/material/Grid'
 import { Form, Formik, Field } from 'formik'
 import FileSelect from 'features/jobs/FileSelect'
@@ -30,6 +32,10 @@ import NewSANSJobFormInstructions from './NewSANSJobFormInstructions'
 import NerscStatusChecker from 'features/nersc/NerscStatusChecker'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import ChainDeuterationSlider from './ChainDeuterationSlider'
+import {
+  detectGaffCofactors,
+  detectMetalCofactors
+} from 'schemas/ValidationFunctions'
 import { useTheme } from '@mui/material/styles'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
@@ -99,6 +105,8 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
   const [isPerlmutterUnavailable, setIsPerlmutterUnavailable] = useState(false)
   const [chainIds, setChainIds] = useState<string[]>([])
   const [autoRgError, setAutoRgError] = useState<string | null>(null)
+  const [pdbInfo, setPdbInfo] = useState<string>('')
+  const [pdbWarning, setPdbWarning] = useState<ReactNode>('')
 
   const {
     data: config,
@@ -292,6 +300,8 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
                         setFieldTouched={setFieldTouched}
                         error={errors.pdb_file && touched.pdb_file}
                         errorMessage={errors.pdb_file ? errors.pdb_file : ''}
+                        infoMessage={pdbInfo}
+                        warningMessage={pdbWarning}
                         fileType="Starting PDB file *.pdb"
                         fileExt=".pdb"
                         onFileChange={async (selectedFile: File) => {
@@ -305,8 +315,55 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
                               setChainIds(parsedChainIds)
                             }
                             reader.readAsText(selectedFile)
+
+                            const [gaffFound, metalFound] = await Promise.all([
+                              detectGaffCofactors(selectedFile),
+                              detectMetalCofactors(selectedFile)
+                            ])
+                            setPdbInfo(
+                              gaffFound.length > 0
+                                ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM: ${gaffFound.join(', ')}`
+                                : ''
+                            )
+                            setPdbWarning(
+                              metalFound.length > 0 ? (
+                                <>
+                                  The following metal-containing residues
+                                  have no force-field parameters and will
+                                  be removed before MD:{' '}
+                                  {metalFound.join(', ')}. If these
+                                  residues are important for your system,
+                                  consider using{' '}
+                                  <Button
+                                    href="https://charmm-gui.org/"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    size="small"
+                                    variant="outlined"
+                                    color="info"
+                                    endIcon={<LaunchIcon />}
+                                    sx={{
+                                      textTransform: 'none',
+                                      py: 0,
+                                      px: 0.75,
+                                      minHeight: 0,
+                                      fontSize: 'inherit',
+                                      lineHeight: 'inherit',
+                                      verticalAlign: 'baseline'
+                                    }}
+                                  >
+                                    CHARMM-GUI
+                                  </Button>{' '}
+                                  to properly parameterize your structure.
+                                </>
+                              ) : (
+                                ''
+                              )
+                            )
                           } else {
                             setChainIds([])
+                            setPdbInfo('')
+                            setPdbWarning('')
                           }
                         }}
                       />

--- a/apps/worker/scripts/prep_pdb.py
+++ b/apps/worker/scripts/prep_pdb.py
@@ -1,16 +1,17 @@
-"""Strip residues that OpenMM cannot process from a PDB file.
+"""Prepare a PDB file for OpenMM by removing incompatible residues.
 
 Removes:
   - Water molecules (HOH) — crystal waters from CIF conversion typically
     lack hydrogen atoms and cannot be matched to any force-field template.
-  - Metal ions and common polyatomic ions — CHARMM36 has no parameters
-    for these.
+    Also unnecessary when using implicit solvent.
+  - Metal ions and common polyatomic ions — no parameters exist for these
+    in the Amber implicit-solvent force-field combination used by BilboMD.
 
 Modifies the file in place.  Prints a summary so the caller (Node.js
 worker) can surface the information in logs.
 
 Usage:
-    python strip_ions.py <pdb_file>
+    python prep_pdb.py <pdb_file>
 
 The ion list mirrors KNOWN_IONS in tools/python/pdb2crd.py and
 SUPPORTED_PDB_RESIDUES in packages/bilbomd-types/src/pdbResidues.ts.
@@ -59,7 +60,7 @@ def strip_ions(lines):
 
 
 if len(sys.argv) != 2:
-    print("Usage: strip_ions.py <pdb_file>", file=sys.stderr)
+    print("Usage: prep_pdb.py <pdb_file>", file=sys.stderr)
     sys.exit(1)
 
 pdb_path = sys.argv[1]
@@ -74,6 +75,6 @@ with open(pdb_path, "w", encoding="utf-8") as f:
     f.writelines(lines)
 
 print(
-    f"strip_ions: removed {n_water} water record(s) and "
+    f"prep_pdb: removed {n_water} water record(s) and "
     f"{n_ions} ion record(s) from {pdb_path}"
 )

--- a/apps/worker/src/services/functions/__tests__/pdb-to-crd.test.ts
+++ b/apps/worker/src/services/functions/__tests__/pdb-to-crd.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { runStripIons, runStripCofactors, runCifToPdb } from '../pdb-to-crd.js'
+import { runPrepPdb, runStripCofactors, runCifToPdb } from '../pdb-to-crd.js'
 import { logger } from '../../../helpers/loggers.js'
 import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
@@ -47,35 +47,35 @@ describe('pdb-to-crd', () => {
   })
 
   // -------------------------------------------------------------------------
-  // runStripIons
+  // runPrepPdb
   // -------------------------------------------------------------------------
-  describe('runStripIons', () => {
-    it('resolves when strip_ions.py exits 0', async () => {
+  describe('runPrepPdb', () => {
+    it('resolves when prep_pdb.py exits 0', async () => {
       await expect(
-        runStripIons({ uuid: 'test-uuid', pdb_file: 'input.pdb' })
+        runPrepPdb({ uuid: 'test-uuid', pdb_file: 'input.pdb' })
       ).resolves.toBeUndefined()
     })
 
     it('spawns the correct script path', async () => {
-      await runStripIons({ uuid: 'test-uuid', pdb_file: 'input.pdb' })
+      await runPrepPdb({ uuid: 'test-uuid', pdb_file: 'input.pdb' })
       expect(vi.mocked(spawn)).toHaveBeenCalledWith(
         '/opt/envs/base/bin/python',
-        expect.arrayContaining(['/app/scripts/strip_ions.py']),
+        expect.arrayContaining(['/app/scripts/prep_pdb.py']),
         expect.any(Object)
       )
     })
 
-    it('rejects when strip_ions.py exits non-zero', async () => {
+    it('rejects when prep_pdb.py exits non-zero', async () => {
       vi.mocked(spawn).mockReturnValueOnce(makeProc(1) as ReturnType<typeof spawn>)
       await expect(
-        runStripIons({ uuid: 'test-uuid', pdb_file: 'input.pdb' })
-      ).rejects.toThrow('strip_ions.py exited with code 1')
+        runPrepPdb({ uuid: 'test-uuid', pdb_file: 'input.pdb' })
+      ).rejects.toThrow('prep_pdb.py exited with code 1')
     })
 
     it('logs info on success', async () => {
-      await runStripIons({ uuid: 'abc', pdb_file: 'x.pdb' })
+      await runPrepPdb({ uuid: 'abc', pdb_file: 'x.pdb' })
       expect(vi.mocked(logger).info).toHaveBeenCalledWith(
-        expect.stringContaining('runStripIons')
+        expect.stringContaining('runPrepPdb')
       )
     })
   })

--- a/apps/worker/src/services/functions/pdb-to-crd.ts
+++ b/apps/worker/src/services/functions/pdb-to-crd.ts
@@ -171,25 +171,21 @@ const spawnPdb2CrdCharmm = (
   return Promise.all(promises)
 }
 
-interface StripIonsData {
+interface PrepPdbData {
   uuid: string
   pdb_file: string
 }
 
-/**
- * Strip metal ions from a PDB file in place, so that OpenMM's ForceField
- * does not encounter residues it has no parameters for.
- */
-const runStripIons = (data: StripIonsData): Promise<void> => {
+const runPrepPdb = (data: PrepPdbData): Promise<void> => {
   const workingDir = path.join(uploadFolder, data.uuid)
   const pdbPath = path.join(workingDir, data.pdb_file)
-  const logFile = path.join(workingDir, 'strip_ions.log')
-  const errorFile = path.join(workingDir, 'strip_ions_error.log')
+  const logFile = path.join(workingDir, 'prep_pdb.log')
+  const errorFile = path.join(workingDir, 'prep_pdb_error.log')
   const logStream = fs.createWriteStream(logFile)
   const errorStream = fs.createWriteStream(errorFile)
-  const script = '/app/scripts/strip_ions.py'
+  const script = '/app/scripts/prep_pdb.py'
 
-  logger.info(`runStripIons: stripping ions from ${data.pdb_file}`)
+  logger.info(`runPrepPdb: preparing ${data.pdb_file} for OpenMM`)
 
   return new Promise<void>((resolve, reject) => {
     const proc = spawn('/opt/envs/base/bin/python', [script, pdbPath], {
@@ -202,12 +198,12 @@ const runStripIons = (data: StripIonsData): Promise<void> => {
 
     proc.stderr.on('data', (chunk: Buffer) => {
       const msg = chunk.toString().trim()
-      logger.error(`runStripIons stderr: ${msg}`)
+      logger.error(`runPrepPdb stderr: ${msg}`)
       errorStream.write(msg + '\n')
     })
 
     proc.on('error', (error) => {
-      logger.error(`runStripIons spawn error: ${error}`)
+      logger.error(`runPrepPdb spawn error: ${error}`)
       reject(error)
     })
 
@@ -217,10 +213,10 @@ const runStripIons = (data: StripIonsData): Promise<void> => {
         new Promise((r) => errorStream.end(r))
       ]).then(() => {
         if (code === 0) {
-          logger.info(`runStripIons succeeded for ${data.pdb_file}`)
+          logger.info(`runPrepPdb succeeded for ${data.pdb_file}`)
           resolve()
         } else {
-          reject(new Error(`strip_ions.py exited with code ${code}`))
+          reject(new Error(`prep_pdb.py exited with code ${code}`))
         }
       }).catch(reject)
     })
@@ -340,4 +336,4 @@ const runStripCofactors = (data: StripCofactorsData): Promise<void> => {
   })
 }
 
-export { createPdb2CrdCharmmInpFiles, spawnPdb2CrdCharmm, runStripIons, runStripCofactors, runCifToPdb }
+export { createPdb2CrdCharmmInpFiles, spawnPdb2CrdCharmm, runPrepPdb, runStripCofactors, runCifToPdb }

--- a/apps/worker/src/services/pipelines/__tests__/bilbomd-alphafold.test.ts
+++ b/apps/worker/src/services/pipelines/__tests__/bilbomd-alphafold.test.ts
@@ -49,8 +49,8 @@ vi.mock('../../functions/openmm-functions.js', () => ({
 }))
 
 vi.mock('../../functions/pdb-to-crd.js', () => ({
-  runStripIons: vi.fn(async () => {
-    callOrder.push('strip-ions')
+  runPrepPdb: vi.fn(async () => {
+    callOrder.push('prep-pdb')
   })
 }))
 
@@ -108,7 +108,7 @@ describe('processBilboMDAlphaFoldJob', () => {
     expect(callOrder).toEqual([
       'initializeJob',
       'alphafold',
-      'strip-ions',
+      'prep-pdb',
       'openmm-config',
       'pae',
       'openmm-config',

--- a/apps/worker/src/services/pipelines/bilbomd-alphafold.ts
+++ b/apps/worker/src/services/pipelines/bilbomd-alphafold.ts
@@ -11,7 +11,7 @@ import {
   runOmmHeat,
   runOmmMD
 } from '../functions/openmm-functions.js'
-import { runStripIons } from '../functions/pdb-to-crd.js'
+import { runPrepPdb } from '../functions/pdb-to-crd.js'
 import { runFoXS } from '../functions/foxs-functions.js'
 import { prepareBilboMDResults } from '../functions/bilbomd-step-functions-nersc.js'
 import { initializeJob, cleanupJob } from '../functions/job-utils.js'
@@ -69,13 +69,13 @@ const processBilboMDAlphaFoldJob = async (MQjob: BullMQJob) => {
   await MQjob.log('end alphafold')
   await progress.update(25)
 
-  // Strip metal ions before OpenMM ForceField sees the structure.
-  await MQjob.log('start strip-ions')
-  await runStripIons({
+  // Remove waters and ions — incompatible with the implicit-solvent force field
+  await MQjob.log('start prep-pdb')
+  await runPrepPdb({
     uuid: foundJob.uuid,
     pdb_file: foundJob.pdb_file as string
   })
-  await MQjob.log('end strip-ions')
+  await MQjob.log('end prep-pdb')
 
   // First openmm_config.yaml — bare config, no constraints yet.
   await MQjob.log('start openmm-config')

--- a/apps/worker/src/services/pipelines/bilbomd-auto.ts
+++ b/apps/worker/src/services/pipelines/bilbomd-auto.ts
@@ -15,7 +15,7 @@ import {
   runOmmMD,
   prepareOpenMMConfig
 } from '../functions/openmm-functions.js'
-import { runCifToPdb, runStripIons } from '../functions/pdb-to-crd.js'
+import { runCifToPdb, runPrepPdb } from '../functions/pdb-to-crd.js'
 import {
   extractPDBFilesFromDCD,
   remediatePDBFiles
@@ -131,10 +131,10 @@ const processBilboMDAutoJob = async (MQjob: BullMQJob) => {
     await MQjob.log('end remediate')
     await progress.update(70)
   } else {
-    // Strip ions before OpenMM — ForceField has no parameters for metal ions
-    await MQjob.log('start strip-ions')
-    await runStripIons({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
-    await MQjob.log('end strip-ions')
+    // Remove waters and ions — incompatible with the implicit-solvent force field
+    await MQjob.log('start prep-pdb')
+    await runPrepPdb({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
+    await MQjob.log('end prep-pdb')
 
     // Prepare OpenMM config YAML
     await MQjob.log('start openmm-config')

--- a/apps/worker/src/services/pipelines/bilbomd-pdb.ts
+++ b/apps/worker/src/services/pipelines/bilbomd-pdb.ts
@@ -12,7 +12,7 @@ import {
   runOmmHeat,
   runOmmMD
 } from '../functions/openmm-functions.js'
-import { runCifToPdb, runStripIons } from '../functions/pdb-to-crd.js'
+import { runCifToPdb, runPrepPdb } from '../functions/pdb-to-crd.js'
 import {
   extractPDBFilesFromDCD,
   remediatePDBFiles
@@ -99,10 +99,10 @@ const processBilboMDPDBJob = async (MQjob: BullMQJob) => {
     await runPdb2Crd(MQjob, foundJob)
     await MQjob.log('end pdb2crd')
   } else {
-    // Strip ions before OpenMM — ForceField has no parameters for metal ions
-    await MQjob.log('start strip-ions')
-    await runStripIons({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
-    await MQjob.log('end strip-ions')
+    // Remove waters and ions — incompatible with the implicit-solvent force field
+    await MQjob.log('start prep-pdb')
+    await runPrepPdb({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
+    await MQjob.log('end prep-pdb')
 
     // Strip unsupported cofactors (FAD, HEM, PCA, etc.) — no bundled Amber parameters.
     // They are removed for MD only; the original uploaded PDB is used for FoXS.

--- a/apps/worker/src/services/pipelines/bilbomd-sans.ts
+++ b/apps/worker/src/services/pipelines/bilbomd-sans.ts
@@ -24,6 +24,7 @@ import {
   prepareBilboMDSANSResults
 } from '../functions/bilbomd-sans-functions.js'
 // import { prepareBilboMDResults } from '../functions/bilbomd-step-functions-nersc'
+import { runPrepPdb } from '../functions/pdb-to-crd.js'
 import { initializeJob, cleanupJob } from '../functions/job-utils.js'
 import { enqueueMakeMovie } from '../functions/movie-enqueuer.js'
 import {
@@ -105,6 +106,11 @@ const processBilboMDSANSJob = async (MQjob: BullMQJob) => {
     await MQjob.log('end remediate')
     await progress.update(70)
   } else {
+    // Remove waters and ions — incompatible with the implicit-solvent force field
+    await MQjob.log('start prep-pdb')
+    await runPrepPdb({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
+    await MQjob.log('end prep-pdb')
+
     // Prepare OpenMM config YAML
     await MQjob.log('start openmm-config')
     await prepareOpenMMConfig(foundJob)


### PR DESCRIPTION
## Summary

- The SANS pipeline was the only local OpenMM pipeline missing a PDB preparation step before minimization. Without it, jobs with crystallographic waters (HOH) or metal ions (MG, ZN, NA, CL, etc.) crash at system creation — the implicit-solvent force field (`amber19-all.xml` + `implicit/gbn2.xml`) has no parameters for those residues.
- Renames `strip_ions.py` → `prep_pdb.py` and `runStripIons` → `runPrepPdb` to accurately reflect that the script removes both waters **and** ions, and to give a generic name that can absorb future preprocessing steps.
- All four local OpenMM pipelines (pdb, auto, alphafold, sans) now call `runPrepPdb` before `prepareOpenMMConfig`.

Closes #716

## Test plan

- [x] `pnpm -F @bilbomd/worker lint` passes
- [x] `pnpm -F @bilbomd/worker build` passes
- [x] `pnpm -F @bilbomd/worker test` — 118/118 tests pass
- [x] Submit a SANS job with a PDB that contains crystallographic waters/ions and confirm it no longer crashes at the minimize step

🤖 Generated with [Claude Code](https://claude.com/claude-code)