### PR TITLE
fix: per-account OTP attempt limiter (F-1 pen test)

### DIFF
--- a/.changeset/otp-per-account-rate-limit.md
+++ b/.changeset/otp-per-account-rate-limit.md
@@ -1,0 +1,6 @@
+---
+'@bilbomd/backend': patch
+'@bilbomd/mongodb-schema': patch
+---
+
+Add per-account OTP attempt counter to prevent brute-force of magic link tokens. After 5 failed attempts (expired OTP submissions), the OTP is nulled and the user must request a new magic link. Addresses F-1 pen test finding (per-account rate limiting).

--- a/apps/backend/src/controllers/auth/__tests__/authController.test.ts
+++ b/apps/backend/src/controllers/auth/__tests__/authController.test.ts
@@ -32,6 +32,67 @@ const makeRes = (): Response => {
 
 beforeEach(() => vi.clearAllMocks())
 
+describe('otp handler — per-account attempt limiting', () => {
+  const makeExpiredOtpUser = (attempts: number) => ({
+    active: true,
+    username: 'scott',
+    email: 'scott@example.com',
+    otp: { code: 'abc', expiresAt: new Date(Date.now() - 1000), attempts },
+    save: vi.fn()
+  })
+
+  it('returns 401 and increments attempts on first expired OTP submission', async () => {
+    const mockUser = makeExpiredOtpUser(0)
+    vi.mocked(User.findOne).mockResolvedValue(mockUser as never)
+
+    await otp(makeReq({ otp: 'abc' }), makeRes())
+
+    expect(mockUser.save).toHaveBeenCalled()
+    expect(mockUser.otp.attempts).toBe(1)
+  })
+
+  it('returns 429 and nulls OTP when attempt limit is reached on expiry', async () => {
+    const mockUser = makeExpiredOtpUser(4)
+    vi.mocked(User.findOne).mockResolvedValue(mockUser as never)
+
+    const res = makeRes()
+    await otp(makeReq({ otp: 'abc' }), res)
+
+    expect(mockUser.otp).toBeNull()
+    expect(mockUser.save).toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(429)
+  })
+
+  it('returns 429 and nulls OTP when stored attempts already at limit', async () => {
+    const mockUser = makeExpiredOtpUser(5)
+    vi.mocked(User.findOne).mockResolvedValue(mockUser as never)
+
+    const res = makeRes()
+    await otp(makeReq({ otp: 'abc' }), res)
+
+    expect(mockUser.otp).toBeNull()
+    expect(res.status).toHaveBeenCalledWith(429)
+  })
+
+  it('clears OTP (resetting attempts) on successful login', async () => {
+    const mockUser = {
+      active: true,
+      username: 'scott',
+      email: 'scott@example.com',
+      otp: { code: 'abc', expiresAt: new Date(Date.now() + 60000), attempts: 2 },
+      save: vi.fn()
+    }
+    vi.mocked(User.findOne).mockResolvedValue(mockUser as never)
+    vi.mocked(issueTokensAndSetCookie).mockResolvedValue('access-token')
+
+    const res = makeRes()
+    await otp(makeReq({ otp: 'abc' }), res)
+
+    expect(mockUser.otp).toBeNull()
+    expect(res.json).toHaveBeenCalledWith({ accessToken: 'access-token' })
+  })
+})
+
 describe('otp handler — NoSQL injection prevention', () => {
   it('casts an object payload to string, querying with a literal string', async () => {
     const req = makeReq({ otp: { $gt: '' } })

--- a/apps/backend/src/controllers/auth/authController.ts
+++ b/apps/backend/src/controllers/auth/authController.ts
@@ -13,6 +13,8 @@ interface BilboMDJwtPayload {
   email: string
 }
 
+const MAX_OTP_ATTEMPTS = 5
+
 const otp = async (req: Request, res: Response) => {
   try {
     const code = String(req.body.otp ?? '')
@@ -24,36 +26,54 @@ const otp = async (req: Request, res: Response) => {
 
     const user: IUser | null = await User.findOne({ 'otp.code': code })
 
-    if (user) {
-      if (!user.active) {
-        logger.warn('User is not active')
-        res.status(401).json({ message: 'Unauthorized - User is not active' })
-        return
-      }
-      logger.debug(`User found: ${user.username}`)
-      logger.info(`OTP login for user: ${user.username} email: ${user.email}`)
-
-      // Check if OTP has expired
-      const currentTimestamp = Date.now()
-      if (
-        user.otp?.expiresAt &&
-        user.otp.expiresAt.getTime() < currentTimestamp
-      ) {
-        logger.warn('OTP has expired')
-        res.status(401).json({ error: 'OTP has expired' })
-        return
-      }
-
-      const accessToken = await issueTokensAndSetCookie(user, res)
-
-      user.otp = null
-      await user.save()
-
-      res.json({ accessToken })
-    } else {
+    if (!user) {
       logger.warn('Invalid OTP')
       res.status(401).json({ message: 'Invalid OTP' })
+      return
     }
+
+    if (!user.active) {
+      logger.warn('User is not active')
+      res.status(401).json({ message: 'Unauthorized - User is not active' })
+      return
+    }
+
+    logger.debug(`User found: ${user.username}`)
+
+    const currentAttempts = user.otp?.attempts ?? 0
+
+    if (currentAttempts >= MAX_OTP_ATTEMPTS) {
+      logger.warn(`OTP attempt limit reached for user: ${user.username}`)
+      user.otp = null
+      await user.save()
+      res
+        .status(429)
+        .json({ message: 'Too many OTP attempts. Please request a new magic link.' })
+      return
+    }
+
+    if (user.otp?.expiresAt && user.otp.expiresAt.getTime() < Date.now()) {
+      logger.warn('OTP has expired')
+      const newAttempts = currentAttempts + 1
+      if (newAttempts >= MAX_OTP_ATTEMPTS) {
+        user.otp = null
+        await user.save()
+        res
+          .status(429)
+          .json({ message: 'Too many OTP attempts. Please request a new magic link.' })
+      } else {
+        user.otp.attempts = newAttempts
+        await user.save()
+        res.status(401).json({ error: 'OTP has expired' })
+      }
+      return
+    }
+
+    logger.info(`OTP login for user: ${user.username} email: ${user.email}`)
+    const accessToken = await issueTokensAndSetCookie(user, res)
+    user.otp = null
+    await user.save()
+    res.json({ accessToken })
   } catch (error) {
     logger.error(`Error occurred while querying user: ${error}`)
     res.status(500).json({ message: 'Internal server error' })

--- a/packages/mongodb-schema/src/interfaces/userInterface.ts
+++ b/packages/mongodb-schema/src/interfaces/userInterface.ts
@@ -4,6 +4,7 @@ import { IJob } from './jobInterface'
 interface IOtp {
   code: string
   expiresAt: Date
+  attempts?: number
 }
 
 interface IConfirmationCode {

--- a/packages/mongodb-schema/src/models/User.ts
+++ b/packages/mongodb-schema/src/models/User.ts
@@ -79,6 +79,10 @@ const userSchema = new Schema(
       },
       expiresAt: {
         type: Date
+      },
+      attempts: {
+        type: Number,
+        default: 0
       }
     },
     UUID: {


### PR DESCRIPTION
## Summary

- Add `attempts?: number` to `IOtp` interface in `@bilbomd/mongodb-schema`
- Add `attempts` field (default 0) to the otp subdocument in the User Mongoose schema
- Update OTP handler in `authController.ts`: after 5 failed expired-OTP submissions the token is nulled and HTTP 429 is returned, forcing the user to request a new magic link
- 4 new tests covering: increment on first expiry, 429 on 5th expiry, 429 when already at limit, successful login clears attempts

Addresses **F-1** (per-account OTP brute-force, no per-account rate limiting) from the May 2026 penetration test. Complements the existing IP-based rate limiter (`loginLimiter`).

## Test plan

- [ ] `pnpm -F @bilbomd/backend test` — all tests pass
- [ ] `pnpm -F @bilbomd/backend build` — no TypeScript errors
- [ ] Manual: submit an expired OTP 5 times, confirm 429 response and null OTP in DB

🤖 Generated with [Claude Code](https://claude.ai/claude-code)