### PR TITLE
fix: keyword allowlist in validateInpConstraints (F-4 pen test)

### DIFF
--- a/.changeset/inp-constraint-allowlist.md
+++ b/.changeset/inp-constraint-allowlist.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/md-utils': patch
+---
+
+Add keyword allowlist to validateInpConstraints to block CHARMM directives like 'system', 'open', 'read', etc. that could execute OS commands or perform file I/O. Mirrors the existing backend isValidConstInpFile allowlist, closing the gap on the worker-side validator. Addresses F-4 pen test finding.

--- a/packages/md-utils/src/constraintUtils.test.ts
+++ b/packages/md-utils/src/constraintUtils.test.ts
@@ -171,6 +171,56 @@ describe('Constraint Utils', () => {
       )
     })
 
+    test('should reject INP files containing "system" directive', async () => {
+      expect.assertions(1)
+
+      const inpPath = path.join(tempDir, 'system.inp')
+      await fs.writeFile(
+        inpPath,
+        `define fixed1 sele ( resid 1:639 .and. segid PROA ) end
+cons fix sele fixed1 end
+system rm -rf /tmp/bilbomd
+return`
+      )
+
+      await expect(validateInpConstraints(inpPath)).rejects.toThrow(
+        'Disallowed keyword'
+      )
+    })
+
+    test('should reject INP files containing "open" directive', async () => {
+      expect.assertions(1)
+
+      const inpPath = path.join(tempDir, 'open.inp')
+      await fs.writeFile(
+        inpPath,
+        `define fixed1 sele ( resid 1:639 .and. segid PROA ) end
+cons fix sele fixed1 end
+open unit 1 read card name /etc/passwd
+return`
+      )
+
+      await expect(validateInpConstraints(inpPath)).rejects.toThrow(
+        'Disallowed keyword'
+      )
+    })
+
+    test('should allow comment lines starting with ! or *', async () => {
+      expect.assertions(1)
+
+      const inpPath = path.join(tempDir, 'comments.inp')
+      await fs.writeFile(
+        inpPath,
+        `! This is a comment
+* Another comment style
+define fixed1 sele ( resid 1:639 .and. segid PROA ) end
+cons fix sele fixed1 end
+return`
+      )
+
+      await expect(validateInpConstraints(inpPath)).resolves.toBeUndefined()
+    })
+
     test('should validate valid YAML files', async () => {
       expect.assertions(1)
 

--- a/packages/md-utils/src/constraintUtils.ts
+++ b/packages/md-utils/src/constraintUtils.ts
@@ -223,6 +223,16 @@ export async function validateYamlConstraints(
   }
 }
 
+const ALLOWED_INP_PREFIXES = [
+  'define',
+  'cons fix',
+  'cons harm',
+  'shape desc',
+  'return',
+  '!',
+  '*'
+]
+
 /**
  * Validates INP constraint file format
  */
@@ -237,15 +247,33 @@ export async function validateInpConstraints(
       throw new Error('Empty INP constraint file')
     }
 
-    // Basic validation for CHARMM syntax
-    const lines = inpContent
-      .split('\n')
-      .filter((line: string) => line.trim() && !line.startsWith('!'))
+    const lines = inpContent.split('\n').filter((line: string) => line.trim())
 
-    // Check for required CHARMM commands
-    const hasDefine = lines.some((line: string) => line.includes('define'))
-    const hasConstraint = lines.some(
-      (line: string) => line.includes('cons fix') || line.includes('shape desc')
+    // Allowlist check: reject any line that doesn't start with a permitted keyword.
+    // Mirrors the backend isValidConstInpFile check to block CHARMM directives like
+    // 'system', 'open', 'read', etc. that could execute OS commands or perform file I/O.
+    for (const line of lines) {
+      const lower = line.trim().toLowerCase()
+      if (!ALLOWED_INP_PREFIXES.some((pfx) => lower.startsWith(pfx))) {
+        throw new Error(
+          `Disallowed keyword in constraint file: "${line.trim()}"`
+        )
+      }
+    }
+
+    // Check for required CHARMM commands (skip comment lines)
+    const nonCommentLines = lines.filter((line: string) => {
+      const t = line.trim()
+      return !t.startsWith('!') && !t.startsWith('*')
+    })
+
+    const hasDefine = nonCommentLines.some((line: string) =>
+      line.toLowerCase().includes('define')
+    )
+    const hasConstraint = nonCommentLines.some(
+      (line: string) =>
+        line.toLowerCase().includes('cons fix') ||
+        line.toLowerCase().includes('shape desc')
     )
 
     if (!hasDefine) {


### PR DESCRIPTION
## Summary

- Add `ALLOWED_INP_PREFIXES` constant to `packages/md-utils/src/constraintUtils.ts`
- `validateInpConstraints` now rejects any line not starting with `define`, `cons fix`, `cons harm`, `shape desc`, `return`, `!`, or `*` — matching the existing `isValidConstInpFile` allowlist in the backend
- Blocks CHARMM directives like `system`, `open`, `read` etc. that could execute OS commands or perform file I/O if a malicious `.inp` file reached the worker
- 3 new tests: rejects `system`, rejects `open unit`, allows `!`/`*` comment lines

Addresses **F-4** (CHARMM `system` directive RCE via worker-side validator gap) from the May 2026 penetration test. The backend `isValidConstInpFile` check already gates uploads; this closes the secondary validator gap.

## Test plan

- [ ] `pnpm -F @bilbomd/md-utils test` — all 50 tests pass
- [ ] `pnpm -F @bilbomd/md-utils build` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)