### PR TITLE
fix: strip SUID/SGID binaries from all runtime Docker images (F-6 pen test)

### DIFF
--- a/.changeset/strip-suid-binaries.md
+++ b/.changeset/strip-suid-binaries.md
@@ -1,0 +1,8 @@
+---
+'@bilbomd/backend': patch
+'@bilbomd/ui': patch
+'@bilbomd/worker': patch
+'@bilbomd/scoper': patch
+---
+
+Strip all SUID/SGID bits from container filesystems before dropping to non-root user. Added to backend, ui, worker-base, worker, scoper-base, and scoper Dockerfiles. Addresses F-6 pen test finding (SUID binary privilege escalation).

--- a/apps/backend/bilbomd-backend.dockerfile
+++ b/apps/backend/bilbomd-backend.dockerfile
@@ -118,6 +118,8 @@ ENV BILBOMD_BACKEND_GIT_HASH=${BILBOMD_BACKEND_GIT_HASH}
 ENV BILBOMD_BACKEND_VERSION=${BILBOMD_BACKEND_VERSION}
 ENV NODE_DEBUG=openid-client
 
+RUN find / -xdev \( -perm /4000 -o -perm /2000 \) -exec chmod ug-s {} + 2>/dev/null || true
+
 USER bilbo:bilbomd
 EXPOSE 3500
 CMD [ "node", "dist/server.js" ]

--- a/apps/scoper/bilbomd-scoper-base.dockerfile
+++ b/apps/scoper/bilbomd-scoper-base.dockerfile
@@ -107,6 +107,8 @@ RUN pip install wandb && conda clean --all --yes
 # Environment config
 ENV RNAVIEW=/usr/local/RNAView
 
+RUN find / -xdev \( -perm /4000 -o -perm /2000 \) -exec chmod ug-s {} + 2>/dev/null || true
+
 # Default working directory for app (populated by dependent image)
 WORKDIR /home/scoper/app
 

--- a/apps/scoper/bilbomd-scoper.dockerfile
+++ b/apps/scoper/bilbomd-scoper.dockerfile
@@ -65,6 +65,8 @@ RUN groupadd -g $GROUP_ID scoper && \
     mkdir -p /home/scoper/app && \
     chown -R scoper:scoper /home/scoper
 
+RUN find / -xdev \( -perm /4000 -o -perm /2000 \) -exec chmod ug-s {} + 2>/dev/null || true
+
 # Switch to scoper user
 USER scoper:scoper
 

--- a/apps/ui/bilbomd-ui.dockerfile
+++ b/apps/ui/bilbomd-ui.dockerfile
@@ -51,6 +51,8 @@ COPY --from=build /repo/apps/ui/build /usr/share/nginx/html
 COPY apps/ui/nginx/nginx.default.conf /etc/nginx/conf.d/default.conf
 COPY apps/ui/nginx/nginx.conf /etc/nginx/nginx.conf
 
+RUN find / -xdev \( -perm /4000 -o -perm /2000 \) -exec chmod ug-s {} + 2>/dev/null || true
+
 EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/worker/bilbomd-worker-base.dockerfile
+++ b/apps/worker/bilbomd-worker-base.dockerfile
@@ -197,6 +197,8 @@ RUN find /opt/envs -type d -name "__pycache__" -prune -exec rm -rf {} + || true 
     find /opt/envs -type f -name "*.a" -delete || true && \
     find /opt/envs -type f -name "*.la" -delete || true
 
+RUN find / -xdev \( -perm /4000 -o -perm /2000 \) -exec chmod ug-s {} + 2>/dev/null || true
+
 # ---- Smoke test script installation ----
 COPY apps/worker/scripts/smoke_test.sh /usr/local/bin/smoke_test.sh
 RUN chmod +x /usr/local/bin/smoke_test.sh

--- a/apps/worker/bilbomd-worker.dockerfile
+++ b/apps/worker/bilbomd-worker.dockerfile
@@ -63,6 +63,8 @@ ARG GROUP_ID=1000
 RUN groupadd -g ${GROUP_ID} bilbomd \
     && useradd -u ${USER_ID} -g ${GROUP_ID} -m -d /home/bilbo -s /bin/bash bilbo
 
+RUN find / -xdev \( -perm /4000 -o -perm /2000 \) -exec chmod ug-s {} + 2>/dev/null || true
+
 # Copy the minimal app bundle from the build stage
 COPY --chown=bilbo:bilbomd --from=build /out/ .
 


### PR DESCRIPTION
## Summary

Add `find / -xdev \( -perm /4000 -o -perm /2000 \) -exec chmod ug-s {} +` to the final runtime stage of every non-root container image, always before the `USER` drop:

- `apps/backend/bilbomd-backend.dockerfile`
- `apps/ui/bilbomd-ui.dockerfile`
- `apps/worker/bilbomd-worker-base.dockerfile`
- `apps/worker/bilbomd-worker.dockerfile`
- `apps/scoper/bilbomd-scoper-base.dockerfile`
- `apps/scoper/bilbomd-scoper.dockerfile`

Removes setuid helpers installed by Ubuntu/Alpine by default (`su`, `newgrp`, `passwd`, `mount`, etc.) that are not needed inside these containers and could be exploited for privilege escalation within the container.

Addresses **F-6** (SUID binary privilege escalation) from the May 2026 penetration test.

## Test plan

- [ ] Build each image and verify: `docker run --rm <image> find / -xdev -perm /4000 2>/dev/null` returns no results
- [ ] Worker, backend, scoper healthchecks still pass after image rebuild

🤖 Generated with [Claude Code](https://claude.ai/claude-code)