### PR TITLE
fix: seccomp profile blocking AF_ALG sockets (F-6 pen test)

### DIFF
--- a/.changeset/seccomp-af-alg.md
+++ b/.changeset/seccomp-af-alg.md
@@ -1,0 +1,8 @@
+---
+'@bilbomd/backend': patch
+'@bilbomd/ui': patch
+'@bilbomd/worker': patch
+'@bilbomd/scoper': patch
+---
+
+Add custom seccomp profile blocking AF_ALG sockets (CVE-2026-31431) and other dangerous syscalls not needed by BilboMD containers. Profile applied to all services in all Docker Compose environments. Addresses F-6 pen test finding.

--- a/infra/docker-compose-epyc.dev.yml
+++ b/infra/docker-compose-epyc.dev.yml
@@ -79,6 +79,8 @@ services:
   backend:
     image: ghcr.io/bl1231/bilbomd-backend:2.7.6
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     deploy:
       resources:
         limits:
@@ -109,6 +111,8 @@ services:
   worker:
     image: ghcr.io/bl1231/bilbomd-worker:2.9.3
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     deploy:
       replicas: 1
       resources:
@@ -151,6 +155,8 @@ services:
   ui:
     image: ghcr.io/bl1231/bilbomd-ui:pr-676-a263b932
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     env_file:
       - .env.dev
     ports:

--- a/infra/docker-compose-epyc.prod.yml
+++ b/infra/docker-compose-epyc.prod.yml
@@ -83,6 +83,8 @@ services:
   backend:
     image: ghcr.io/bl1231/bilbomd-backend:2.7.6
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     deploy:
       resources:
         limits:
@@ -113,6 +115,8 @@ services:
   worker:
     image: ghcr.io/bl1231/bilbomd-worker:pr-652-9a1785cc
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     deploy:
       replicas: 2
       resources:
@@ -155,6 +159,8 @@ services:
   ui:
     image: ghcr.io/bl1231/bilbomd-ui:2.14.5
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     env_file:
       - .env.prod
     ports:

--- a/infra/docker-compose-hyperion.dev.yml
+++ b/infra/docker-compose-hyperion.dev.yml
@@ -13,6 +13,8 @@ services:
   scoper:
     image: ghcr.io/bl1231/bilbomd-scoper:1.7.7
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     deploy:
       replicas: 1
       resources:

--- a/infra/docker-compose-hyperion.yml
+++ b/infra/docker-compose-hyperion.yml
@@ -13,6 +13,8 @@ services:
   scoper:
     image: ghcr.io/bl1231/bilbomd-scoper:1.7.7
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     deploy:
       replicas: 1
       resources:

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -83,6 +83,8 @@ services:
   backend:
     image: ghcr.io/bl1231/bilbomd-backend:2.7.6
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     env_file:
       - path: .env.local
     ports:
@@ -107,6 +109,8 @@ services:
   worker:
     image: ghcr.io/bl1231/bilbomd-worker:2.9.3
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     deploy:
       replicas: 1
       resources:
@@ -140,6 +144,8 @@ services:
   ui:
     image: ghcr.io/bl1231/bilbomd-ui:2.14.5
     pull_policy: always
+    security_opt:
+      - seccomp:./seccomp/bilbomd-seccomp.json
     env_file:
       - .env.local
     ports:

--- a/infra/seccomp/bilbomd-seccomp.json
+++ b/infra/seccomp/bilbomd-seccomp.json
@@ -1,0 +1,73 @@
+{
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "architectures": [
+    "SCMP_ARCH_X86_64",
+    "SCMP_ARCH_X86",
+    "SCMP_ARCH_X32",
+    "SCMP_ARCH_AARCH64"
+  ],
+  "syscalls": [
+    {
+      "comment": "Block AF_ALG sockets (CVE-2026-31431 — kernel page-cache write primitive via algif_aead). AF_ALG = 38.",
+      "names": ["socket"],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [
+        {
+          "index": 0,
+          "value": 38,
+          "op": "SCMP_CMP_EQ"
+        }
+      ]
+    },
+    {
+      "comment": "Block kernel loading and container filesystem escape vectors.",
+      "names": [
+        "kexec_load",
+        "kexec_file_load",
+        "open_by_handle_at",
+        "pivot_root",
+        "init_module",
+        "finit_module",
+        "delete_module",
+        "create_module",
+        "query_module",
+        "get_kernel_syms"
+      ],
+      "action": "SCMP_ACT_ERRNO"
+    },
+    {
+      "comment": "Block cross-process memory access (not needed, undermines process isolation).",
+      "names": [
+        "ptrace",
+        "process_vm_readv",
+        "process_vm_writev"
+      ],
+      "action": "SCMP_ACT_ERRNO"
+    },
+    {
+      "comment": "Block kernel keyring syscalls (frequently abused for credential theft and privilege escalation).",
+      "names": [
+        "add_key",
+        "request_key",
+        "keyctl"
+      ],
+      "action": "SCMP_ACT_ERRNO"
+    },
+    {
+      "comment": "Block userfaultfd (race-condition primitive used in many kernel exploit chains).",
+      "names": ["userfaultfd"],
+      "action": "SCMP_ACT_ERRNO"
+    },
+    {
+      "comment": "Block system-level operations that BilboMD containers have no need for.",
+      "names": [
+        "acct",
+        "reboot",
+        "swapon",
+        "swapoff",
+        "syslog"
+      ],
+      "action": "SCMP_ACT_ERRNO"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `infra/seccomp/bilbomd-seccomp.json` — a custom seccomp profile with `defaultAction: SCMP_ACT_ALLOW` and an explicit deny list covering:
  - `socket(AF_ALG=38)` — the CVE-2026-31431 kernel page-cache write primitive via `algif_aead`
  - Kernel load/escape vectors: `kexec_load`, `kexec_file_load`, `open_by_handle_at`, `pivot_root`, kernel module syscalls
  - Cross-process memory access: `ptrace`, `process_vm_readv`, `process_vm_writev`
  - Kernel keyring: `add_key`, `request_key`, `keyctl`
  - Exploit primitives: `userfaultfd`
  - Unneeded system ops: `reboot`, `swapon`, `swapoff`, `syslog`, `acct`
- Apply via `security_opt: - seccomp:./seccomp/bilbomd-seccomp.json` to all services in all five Compose files

The profile file lives in `infra/seccomp/` and is read by the Docker daemon from the host at container start — it does not need to be inside the image.

Addresses **F-6** (CVE-2026-31431 kernel exploit via AF_ALG) from the May 2026 penetration test.

## Merge order note

Rebase this branch on main **after** `fix/docker-security-no-new-privileges` (#733) merges — both add entries to `security_opt:` in the same Compose files. Conflict resolution is straightforward: combine both lines under one `security_opt:` key.

## Test plan

- [ ] `docker compose up` starts cleanly with the custom seccomp profile applied
- [ ] Verify profile is active: `docker inspect <container> | grep -A5 Seccomp`
- [ ] Confirm AF_ALG is blocked inside a running container: `python3 -c "import socket; socket.socket(38, 2)"` should raise `OSError: [Errno 1] Operation not permitted`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)