### PR TITLE
fix: run coverage report on PRs only, drop direct push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1119,12 +1119,12 @@ jobs:
           echo "All required jobs succeeded"
 
   coverage-report:
-    name: Update Coverage in README
+    name: Coverage Report
     runs-on: ubuntu-24.04
     needs: [backend-unit-tests, ui-unit-tests, worker-unit-tests, scoper-unit-tests]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -1155,13 +1155,5 @@ jobs:
       - name: Run scoper tests with coverage
         run: pnpm -C apps/scoper run test
 
-      - name: Update README with coverage
+      - name: Report coverage
         run: node .github/scripts/update-coverage-readme.js
-
-      - name: Commit coverage update
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git diff --staged --quiet || git commit -m "chore: update test coverage in README [skip ci]"
-          git push


### PR DESCRIPTION
## Summary
- Coverage job was failing on main pushes because it tried to push directly to `main`, which is blocked by the branch protection ruleset (`GH013: Changes must be made through a pull request`)
- Changed the job trigger from `main` push to `pull_request` only
- Removed the commit/push step entirely; coverage numbers are now visible in CI logs during PR review
- Downgraded permissions from `contents: write` to `contents: read`

## Test plan
- [ ] Verify the `Coverage Report` job appears and passes on this PR
- [ ] Verify no coverage-related job runs or fails on future merges to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)