### PR TITLE
fix: enable colabfold-service in epyc compose and publish base image

### DIFF
--- a/apps/colabfold-service/Dockerfile
+++ b/apps/colabfold-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bl1231/bilbomd-colabfold:0.0.10
+FROM ghcr.io/bl1231/bilbomd-colabfold:0.1.0
 
 WORKDIR /app
 

--- a/infra/docker-compose-epyc.dev.yml
+++ b/infra/docker-compose-epyc.dev.yml
@@ -77,7 +77,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   backend:
-    image: ghcr.io/bl1231/bilbomd-backend:2.7.8
+    image: ghcr.io/bl1231/bilbomd-backend:2.8.0
     pull_policy: always
     security_opt:
       - no-new-privileges:true
@@ -110,7 +110,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   worker:
-    image: ghcr.io/bl1231/bilbomd-worker:2.9.4
+    image: ghcr.io/bl1231/bilbomd-worker:2.10.0
     pull_policy: always
     security_opt:
       - no-new-privileges:true
@@ -158,8 +158,8 @@ services:
 
   # ------------------------------------------------------------------------------------
   of3-service:
-    image: ghcr.io/bl1231/bilbomd-of3-service:latest
-    pull_policy: never
+    image: ghcr.io/bl1231/bilbomd-of3-service:0.1.0
+    pull_policy: always
     shm_size: "16gb"
     security_opt:
       - no-new-privileges:true
@@ -190,40 +190,40 @@ services:
       start_period: 30s
 
   # ------------------------------------------------------------------------------------
-  # colabfold-service:
-  #   image: ghcr.io/bl1231/bilbomd-colabfold-service:latest
-  #   pull_policy: always
-  #   security_opt:
-  #     - no-new-privileges:true
-  #     - seccomp:./seccomp/bilbomd-seccomp.json
-  #   deploy:
-  #     resources:
-  #       reservations:
-  #         devices:
-  #           - driver: nvidia
-  #             count: 1
-  #             capabilities: [ gpu ]
-  #   restart: no
-  #   env_file:
-  #     - path: .env.dev
-  #   environment:
-  #     - UPLOAD_DIR=/bilbomd/uploads
-  #     - COLABFOLD_DATA_DIR=/cache
-  #   volumes:
-  #     - /bilbomd/dev/uploads:/bilbomd/uploads
-  #     - /bilbomd/colabfold-cache:/cache:ro
-  #   networks:
-  #     - app-network-dev
-  #   healthcheck:
-  #     test: [ "CMD", "curl", "--fail", "http://localhost:8000/health" ]
-  #     interval: 30s
-  #     timeout: 10s
-  #     retries: 3
-  #     start_period: 30s
+  colabfold-service:
+    image: ghcr.io/bl1231/bilbomd-colabfold-service:latest
+    pull_policy: always
+    security_opt:
+      - no-new-privileges:true
+      - seccomp:./seccomp/bilbomd-seccomp.json
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [ gpu ]
+    restart: no
+    env_file:
+      - path: .env.dev
+    environment:
+      - UPLOAD_DIR=/bilbomd/uploads
+      - COLABFOLD_DATA_DIR=/cache
+    volumes:
+      - /bilbomd/dev/uploads:/bilbomd/uploads
+      - /bilbomd/colabfold-cache:/cache:ro
+    networks:
+      - app-network-dev
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://localhost:8000/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   # ------------------------------------------------------------------------------------
   ui:
-    image: ghcr.io/bl1231/bilbomd-ui:pr-724-877720d4
+    image: ghcr.io/bl1231/bilbomd-ui:pr-750-fe1f1c56
     pull_policy: always
     security_opt:
       - seccomp:./seccomp/bilbomd-seccomp.json

--- a/infra/docker-compose-epyc.prod.yml
+++ b/infra/docker-compose-epyc.prod.yml
@@ -192,35 +192,35 @@ services:
   #     start_period: 30s
 
   # ------------------------------------------------------------------------------------
-  # colabfold-service:
-  #   image: ghcr.io/bl1231/bilbomd-colabfold-service:latest
-  #   pull_policy: always
-  #   security_opt:
-  #     - no-new-privileges:true
-  #   deploy:
-  #     resources:
-  #       reservations:
-  #         devices:
-  #           - driver: nvidia
-  #             count: 1
-  #             capabilities: [ gpu ]
-  #   restart: no
-  #   env_file:
-  #     - .env.prod
-  #   environment:
-  #     - UPLOAD_DIR=/bilbomd/uploads
-  #     - COLABFOLD_DATA_DIR=/cache
-  #   volumes:
-  #     - /bilbomd/prod/uploads:/bilbomd/uploads
-  #     - /bilbomd/colabfold-cache:/cache:ro
-  #   networks:
-  #     - app-network
-  #   healthcheck:
-  #     test: [ "CMD", "curl", "--fail", "http://localhost:8000/health" ]
-  #     interval: 30s
-  #     timeout: 10s
-  #     retries: 3
-  #     start_period: 30s
+  colabfold-service:
+    image: ghcr.io/bl1231/bilbomd-colabfold-service:latest
+    pull_policy: always
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [ gpu ]
+    restart: no
+    env_file:
+      - .env.prod
+    environment:
+      - UPLOAD_DIR=/bilbomd/uploads
+      - COLABFOLD_DATA_DIR=/cache
+    volumes:
+      - /bilbomd/prod/uploads:/bilbomd/uploads
+      - /bilbomd/colabfold-cache:/cache:ro
+    networks:
+      - app-network
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://localhost:8000/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   # ------------------------------------------------------------------------------------
   ui:


### PR DESCRIPTION
## Summary

- Update `apps/colabfold-service/Dockerfile` FROM pin: `0.0.10` → `0.1.0` (base image `ghcr.io/bl1231/bilbomd-colabfold:0.1.0` is now published to GHCR, built manually on epyc)
- Uncomment `colabfold-service` in `infra/docker-compose-epyc.dev.yml` and `infra/docker-compose-epyc.prod.yml`
- Bump image tags in `docker-compose-epyc.dev.yml`: backend `2.7.8→2.8.0`, worker `2.9.4→2.10.0`, of3-service pinned to `0.1.0` with `pull_policy: always`, ui tag updated

## Background

The `bilbomd-colabfold` base image (~22 GB CUDA + LocalColabFold) is too large to build on GitHub-hosted runners. It is built on epyc (which has GPU + disk) and pushed manually to GHCR. The `colabfold-service-image.yml` CI workflow then builds the thin FastAPI wrapper on top of the pre-built base.

## Test plan

- [ ] Confirm `ghcr.io/bl1231/bilbomd-colabfold:0.1.0` is visible in GHCR
- [ ] Verify `colabfold-service-image` CI workflow builds successfully after merge
- [ ] On epyc: `docker compose -f infra/docker-compose-epyc.dev.yml up colabfold-service` and `curl http://localhost:8000/health` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)