### PR TITLE
chore: upgrade pnpm from v10 to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-inject-workspace-packages=true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bilbomd",
   "private": true,
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.0.8",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,10 +3,10 @@ packages:
   - "packages/*"
 injectWorkspacePackages: true
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - '@scarf/scarf'
-  - esbuild
-  - msgpackr-extract
-  - msw
-  - unrs-resolver
+allowBuilds:
+  '@parcel/watcher': true
+  '@scarf/scarf': true
+  esbuild: true
+  msgpackr-extract: true
+  msw: true
+  unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,11 @@ packages:
   - "apps/*"
   - "packages/*"
 injectWorkspacePackages: true
+
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@scarf/scarf'
+  - esbuild
+  - msgpackr-extract
+  - msw
+  - unrs-resolver


### PR DESCRIPTION
## Summary

- Add `allowBuilds` allowlist in `pnpm-workspace.yaml` (pnpm v11 replaced `onlyBuiltDependencies` with this map-based format) for the 6 packages that require native/binary build scripts: `@parcel/watcher`, `@scarf/scarf`, `esbuild`, `msgpackr-extract`, `msw`, `unrs-resolver`
- Bump `packageManager` to `pnpm@11.0.8` in `package.json` — CI reads this dynamically via `jq`/Corepack, so no workflow changes needed
- Remove duplicate `inject-workspace-packages=true` from `.npmrc` (already declared in `pnpm-workspace.yaml`)

## Test plan

- [x] Fresh `node_modules` delete across all apps/ and packages/
- [x] `pnpm install` — clean, no warnings
- [x] `pnpm lint` — 5/5 packages pass
- [x] `pnpm build` — 7/7 packages pass
- [x] `pnpm test` — 124 test files, 1051 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)