### PR TITLE
fix: epyc colabfold startup ordering, read-only fs, and env cleanup

### DIFF
--- a/.changeset/worker-log-error-cause.md
+++ b/.changeset/worker-log-error-cause.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Log the underlying cause of fetch errors in handleError so failures like TimeoutError or ECONNREFUSED are visible in logs instead of just "fetch failed".

--- a/apps/worker/src/services/functions/job-utils.ts
+++ b/apps/worker/src/services/functions/job-utils.ts
@@ -254,8 +254,12 @@ const handleError = async (
   if (error instanceof Error) {
     errorMsg = error.message
     stackTrace = error.stack
+    const cause =
+      (error as Error & { cause?: unknown }).cause instanceof Error
+        ? (error as Error & { cause?: Error }).cause
+        : undefined
     logger.error(
-      `handleError - Error object details: name=${error.name}, message=${error.message}, stack=${error.stack}, step=${step || 'unknown'}`
+      `handleError - Error object details: name=${error.name}, message=${error.message}, stack=${error.stack}, step=${step || 'unknown'}${cause ? `, cause=${cause.name}: ${cause.message}` : ''}`
     )
   } else {
     errorMsg = String(error)

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,12 +1,12 @@
 # id -u   # paste result as UID
 # id -g   # paste result as GID
-# getent group docker | cut -d: -f3   # paste result as DOCKER_GID
 UID=501
 GID=1231
-DOCKER_GID=973
 
 # development or production
 BILBOMD_ENV=development
+# Winston log level: error, warn, info, http, verbose, debug, silly (default: info)
+# LOG_LEVEL=debug
 # bl1231, nersc, or local
 BILBOMD_DEPLOY_SITE=local
 BILBOMD_DEV_BIND_ADDR=127.0.0.1
@@ -45,7 +45,6 @@ MONGO_EXTERNAL_PORT=28017
 # Redis
 REDIS_HOST=redis
 REDIS_PORT=6379
-REDIS_PASSWORD=xxxxxxxxxxx
 
 # Redis - needed for external access
 REDIS_DEV_BIND_ADDR=127.0.0.1
@@ -105,7 +104,6 @@ OF3_TIMEOUT_MS=3600000                      # 1h default per OF3 run
 USE_NERSC=false
 NERSC_PROJECT=xxxxxxxxxxx
 SFAPI_CLIENT_ID=xxxxxxxxxxx
-SFAPI_CLIENT_SECRET=xxxxxxxxxxx
 SFAPI_URL="https://example.gov/api/v1"
 SCRIPT_DIR=/app/scripts
 UPLOAD_DIR=/app/uploads

--- a/infra/docker-compose-epyc.dev.yml
+++ b/infra/docker-compose-epyc.dev.yml
@@ -146,9 +146,15 @@ services:
       - OF3_SERVICE_URL=http://of3-service:8000
       - COLABFOLD_TIMEOUT_MS=${COLABFOLD_TIMEOUT_MS:-3600000}
       - COLABFOLD_SERVICE_URL=http://colabfold-service:8000
+      - MPLCONFIGDIR=/tmp/matplotlib
+      - XDG_CACHE_HOME=/tmp/cache
     depends_on:
-      - mongodb
-      - redis
+      mongodb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      colabfold-service:
+        condition: service_healthy
     healthcheck:
       test: [ "CMD", "curl", "--fail", "http://localhost:3000/config" ]
       interval: 30s
@@ -191,8 +197,9 @@ services:
 
   # ------------------------------------------------------------------------------------
   colabfold-service:
-    image: ghcr.io/bl1231/bilbomd-colabfold-service:latest
+    image: ghcr.io/bl1231/bilbomd-colabfold-service:0.1.0
     pull_policy: always
+    shm_size: "16gb"
     security_opt:
       - no-new-privileges:true
       - seccomp:./seccomp/bilbomd-seccomp.json

--- a/infra/list-latest-tags.sh
+++ b/infra/list-latest-tags.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #   IMAGES="bilbomd-backend bilbomd-ui bilbomd-worker bilbomd-scoper"
 
 OWNER="${GH_OWNER:-bl1231}"
-IMAGES="${IMAGES:-bilbomd-backend bilbomd-ui bilbomd-worker bilbomd-scoper}"
+IMAGES="${IMAGES:-bilbomd-backend bilbomd-ui bilbomd-worker-base bilbomd-worker bilbomd-scoper-base bilbomd-scoper bilbomd-of3-service bilbomd-colabfold bilbomd-colabfold-service}"
 
 if [[ -z "$OWNER" ]]; then
   echo "GH_OWNER not set. Export GH_OWNER=your-org-or-username" >&2


### PR DESCRIPTION
## Summary

- Worker now depends on `colabfold-service` healthcheck before starting, preventing fetch failures when models are still loading on boot
- Add `MPLCONFIGDIR=/tmp/matplotlib` and `XDG_CACHE_HOME=/tmp/cache` to worker environment to fix matplotlib/fontconfig write errors under `read_only: true`
- Log `error.cause` in `handleError` so fetch failures (e.g. `TimeoutError`, `ECONNREFUSED`) surface the root cause instead of just "fetch failed"
- Remove stale entries from `.env.example`: `DOCKER_GID`, `REDIS_PASSWORD`, `SFAPI_CLIENT_SECRET` (NERSC now uses PEM-key JWT auth)
- Add commented `LOG_LEVEL` to `.env.example` (read at runtime but previously undocumented)
- Expand `list-latest-tags.sh` to include new sidecar images

## Test plan

- [x] Restart epyc stack and confirm worker waits for colabfold-service to be healthy before accepting jobs
- [ ] Submit an alphafold job and confirm no matplotlib/fontconfig errors in worker logs
- [ ] Confirm a failed fetch logs the underlying cause (e.g. `TimeoutError` or `ECONNREFUSED`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)