### PR TITLE
fix: allow admins to delete jobs stuck in Running or Submitted state

### DIFF
--- a/.changeset/admin-delete-stuck-jobs.md
+++ b/.changeset/admin-delete-stuck-jobs.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Allow admins to delete jobs stuck in Running or Submitted state. A warning is shown in the confirmation dialog explaining that the underlying simulation process may continue running.

--- a/apps/ui/src/features/jobs/JobActionsMenu.tsx
+++ b/apps/ui/src/features/jobs/JobActionsMenu.tsx
@@ -12,11 +12,12 @@ interface JobActionsMenuProps {
   jobTitle: string
   jobStatus: string
   resultsReady?: boolean
+  isAdmin?: boolean
   anchorEl: HTMLElement | null
   open: boolean
   onClose: () => void
   onResubmit: (id: string, type: string) => void
-  onDelete: (id: string, title: string) => void
+  onDelete: (id: string, title: string, status: string) => void
   onDownload: (id: string) => void
 }
 
@@ -26,6 +27,7 @@ const JobActionsMenu: React.FC<JobActionsMenuProps> = ({
   jobTitle,
   jobStatus,
   resultsReady,
+  isAdmin = false,
   anchorEl,
   open,
   onClose,
@@ -39,7 +41,7 @@ const JobActionsMenu: React.FC<JobActionsMenuProps> = ({
   }
 
   const handleDeleteClick = () => {
-    onDelete(jobId, jobTitle)
+    onDelete(jobId, jobTitle, jobStatus)
     onClose()
   }
 
@@ -72,7 +74,7 @@ const JobActionsMenu: React.FC<JobActionsMenuProps> = ({
       <MenuItem
         onClick={handleDeleteClick}
         disableRipple
-        disabled={['Running', 'Submitted'].includes(jobStatus)}
+        disabled={['Running', 'Submitted'].includes(jobStatus) && !isAdmin}
         sx={{ color: 'error.main' }}
       >
         <DeleteIcon color='error' />

--- a/apps/ui/src/features/jobs/Jobs.tsx
+++ b/apps/ui/src/features/jobs/Jobs.tsx
@@ -243,11 +243,15 @@ const Jobs = () => {
   const [deleteTargetTitle, setDeleteTargetTitle] = useState<string | null>(
     null
   )
+  const [deleteTargetStatus, setDeleteTargetStatus] = useState<string | null>(
+    null
+  )
   const [deleteJob, { isLoading: isDeleting }] = useDeleteJobMutation()
 
-  const openDeleteDialog = (id: string, title: string) => {
+  const openDeleteDialog = (id: string, title: string, status: string) => {
     setDeleteTargetJobId(id)
     setDeleteTargetTitle(title)
+    setDeleteTargetStatus(status)
     setDeleteDialogOpen(true)
   }
 
@@ -266,6 +270,7 @@ const Jobs = () => {
       setDeleteDialogOpen(false)
       setDeleteTargetJobId(null)
       setDeleteTargetTitle(null)
+      setDeleteTargetStatus(null)
     }
   }
 
@@ -674,6 +679,7 @@ const Jobs = () => {
               jobTitle={params.row.title}
               jobStatus={params.row.status}
               resultsReady={params.row.results_ready}
+              isAdmin={isAdmin}
               anchorEl={anchorEl}
               open={isOpen}
               onClose={handleMenuClose}
@@ -783,6 +789,19 @@ const Jobs = () => {
                         Are you sure you want to delete the job{' '}
                         <strong>{deleteTargetTitle}</strong>?
                       </Typography>
+                      {['Running', 'Submitted'].includes(
+                        deleteTargetStatus ?? ''
+                      ) && (
+                        <Alert
+                          severity="warning"
+                          sx={{ mt: 2 }}
+                        >
+                          This job is currently <strong>{deleteTargetStatus}</strong>.
+                          Deleting it will remove the database record and files,
+                          but the underlying simulation process may continue
+                          until it finishes naturally.
+                        </Alert>
+                      )}
                     </DialogContent>
                     <DialogActions>
                       <Button

--- a/apps/ui/src/features/jobs/__tests__/JobActionMenu.test.tsx
+++ b/apps/ui/src/features/jobs/__tests__/JobActionMenu.test.tsx
@@ -46,7 +46,7 @@ describe('JobActionsMenu', () => {
   it('calls onDelete and onClose when Delete is clicked', () => {
     render(<JobActionsMenu {...baseProps} />)
     fireEvent.click(screen.getByText('Delete'))
-    expect(baseProps.onDelete).toHaveBeenCalledWith('abc123', 'Test Job')
+    expect(baseProps.onDelete).toHaveBeenCalledWith('abc123', 'Test Job', 'Completed')
     expect(baseProps.onClose).toHaveBeenCalled()
   })
 })

--- a/apps/ui/src/features/jobs/__tests__/JobActionsMenu.test.tsx
+++ b/apps/ui/src/features/jobs/__tests__/JobActionsMenu.test.tsx
@@ -16,6 +16,7 @@ describe('JobActionsMenu', () => {
     jobTitle: 'Test Job',
     jobStatus: 'Completed',
     resultsReady: true,
+    isAdmin: false,
     anchorEl: document.createElement('div'),
     open: true,
     onClose: mockOnClose,
@@ -171,7 +172,7 @@ describe('JobActionsMenu', () => {
         const deleteButton = screen.getByText('Delete')
         await user.click(deleteButton)
 
-        expect(mockOnDelete).toHaveBeenCalledWith('job-123', 'Test Job')
+        expect(mockOnDelete).toHaveBeenCalledWith('job-123', 'Test Job', status)
         expect(mockOnDelete).toHaveBeenCalledTimes(1)
       })
 
@@ -260,6 +261,34 @@ describe('JobActionsMenu', () => {
 
       const deleteButton = screen.getByText('Delete').closest('li')
       expect(deleteButton).toHaveStyle({ color: 'rgb(211, 47, 47)' })
+    })
+  })
+
+  describe('Delete button - admin overrides', () => {
+    const stuckStatuses = ['Running', 'Submitted']
+
+    stuckStatuses.forEach((status) => {
+      it(`should enable Delete for admins when status is ${status}`, () => {
+        renderWithProviders(
+          <JobActionsMenu {...defaultProps} jobStatus={status} isAdmin={true} />
+        )
+
+        const deleteButton = screen.getByText('Delete').closest('li')
+        expect(deleteButton).not.toHaveClass('Mui-disabled')
+      })
+
+      it(`should call onDelete with status arg for admins when status is ${status}`, async () => {
+        const user = userEvent.setup()
+        renderWithProviders(
+          <JobActionsMenu {...defaultProps} jobStatus={status} isAdmin={true} />
+        )
+
+        const deleteButton = screen.getByText('Delete')
+        await user.click(deleteButton)
+
+        expect(mockOnDelete).toHaveBeenCalledWith('job-123', 'Test Job', status)
+        expect(mockOnDelete).toHaveBeenCalledTimes(1)
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

- Adds `isAdmin` prop to `JobActionsMenu` — admins can now click Delete on Running/Submitted jobs (previously disabled for all users)
- Passes the job's current status through to `openDeleteDialog` so the confirmation dialog can react to it
- Shows an MUI warning `Alert` in the confirm dialog when deleting a Running or Submitted job, explaining that the underlying simulation process may continue until it finishes naturally

Closes #706

## Test plan

- [ ] As a regular user, confirm Delete is still disabled for Running and Submitted jobs
- [ ] As an admin, confirm Delete is enabled for Running and Submitted jobs
- [ ] As an admin deleting a Running job, confirm the warning alert appears in the confirm dialog
- [ ] As an admin deleting a Completed/Failed job, confirm no warning alert appears
- [ ] All 1055 UI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)