### PR TITLE
docs: update BilboMD citation to published NAR 2026 paper

### DIFF
--- a/.changeset/update-bilbomd-citation.md
+++ b/.changeset/update-bilbomd-citation.md
@@ -1,0 +1,6 @@
+---
+'@bilbomd/worker': patch
+'@bilbomd/ui': patch
+---
+
+Update BilboMD citation to the published NAR 2026 paper. Worker README files now include the new citation and a BibTeX entry. UI pages (Home, About, Help, Acknowledgments) now show a copyable BibTeX block alongside the citation.

--- a/apps/ui/src/components/Common/BilboMDBibTeX.tsx
+++ b/apps/ui/src/components/Common/BilboMDBibTeX.tsx
@@ -1,0 +1,46 @@
+import { Box, Typography } from '@mui/material'
+import CopyToClipboardButton from 'components/Common/CopyToClipboardButton'
+
+const BIBTEX = `@article{10.1093/nar/gkag377,
+    author = {Classen, Scott and Del Mundo, Joshua and Kulkarni, Dhruva and Prabhakar, Shreyas and Hicks, Alan and Hammel, Michal},
+    title = {BilboMD: a web-accessible SAXS and AlphaFold-guided modeling pipeline},
+    journal = {Nucleic Acids Research},
+    pages = {gkag377},
+    year = {2026},
+    month = {04},
+    issn = {1362-4962},
+    doi = {10.1093/nar/gkag377},
+    url = {https://doi.org/10.1093/nar/gkag377},
+    eprint = {https://academic.oup.com/nar/advance-article-pdf/doi/10.1093/nar/gkag377/68163429/gkag377.pdf},
+}`
+
+const BilboMDBibTeX = () => (
+  <Box sx={{ my: 1 }}>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        borderRadius: '4px',
+        p: 2,
+        backgroundColor: 'grey.100',
+        border: '1px solid',
+        borderColor: 'grey.300'
+      }}
+    >
+      <Typography
+        component='pre'
+        variant='body2'
+        sx={{ fontFamily: 'monospace', whiteSpace: 'pre-wrap', m: 0 }}
+      >
+        {BIBTEX}
+      </Typography>
+      <Box sx={{ ml: 2, flexShrink: 0 }}>
+        <CopyToClipboardButton text={BIBTEX} />
+      </Box>
+    </Box>
+  </Box>
+)
+
+export default BilboMDBibTeX

--- a/apps/ui/src/components/Home.tsx
+++ b/apps/ui/src/components/Home.tsx
@@ -18,6 +18,7 @@ import Introduction from '../features/shared/Introduction'
 import FeaturesList from '../features/shared/FeaturesList'
 import PipelineOptions from '../features/shared/PipelineOptions'
 import AdditionalInfo from '../features/shared/AdditionalInfo'
+import BilboMDBibTeX from 'components/Common/BilboMDBibTeX'
 
 const Home = ({ title = 'BilboMD' }) => {
   useTitle(title)
@@ -234,6 +235,7 @@ const Home = ({ title = 'BilboMD' }) => {
             </Link>
             .
           </Typography>
+          <BilboMDBibTeX />
         </Introduction>
 
         {/* Config Alert */}

--- a/apps/ui/src/features/about/About.tsx
+++ b/apps/ui/src/features/about/About.tsx
@@ -13,6 +13,7 @@ import Introduction from '../shared/Introduction'
 import FeaturesList from '../shared/FeaturesList'
 import PipelineOptions from '../shared/PipelineOptions'
 import AdditionalInfo from '../shared/AdditionalInfo'
+import BilboMDBibTeX from 'components/Common/BilboMDBibTeX'
 
 const About = ({ title = 'BilboMD: About' }) => {
   useTitle(title)
@@ -204,6 +205,7 @@ const About = ({ title = 'BilboMD: About' }) => {
             </Link>
             .
           </Typography>
+          <BilboMDBibTeX />
         </Introduction>
 
         {/* Config Alert */}

--- a/apps/ui/src/features/about/Acknowledgments.tsx
+++ b/apps/ui/src/features/about/Acknowledgments.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Typography, Link } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import BilboMDBibTeX from 'components/Common/BilboMDBibTeX'
 
 const Acknowledgments: React.FC = () => {
   return (
@@ -35,6 +36,7 @@ const Acknowledgments: React.FC = () => {
           </Link>
           .
         </Typography>
+        <BilboMDBibTeX />
       </Grid>
       <Grid size={8}>
         <Typography>

--- a/apps/ui/src/features/help/Help.tsx
+++ b/apps/ui/src/features/help/Help.tsx
@@ -15,6 +15,7 @@ import AdditionalInfo from '../shared/AdditionalInfo'
 import { Grid } from '@mui/system'
 import { blue } from '@mui/material/colors'
 import { useTheme } from '@mui/material/styles'
+import BilboMDBibTeX from 'components/Common/BilboMDBibTeX'
 
 const Help = ({ title = 'BilboMD: Help' }) => {
   useTitle(title)
@@ -92,6 +93,7 @@ const Help = ({ title = 'BilboMD: Help' }) => {
             </Link>
             .
           </Typography>
+          <BilboMDBibTeX />
         </Introduction>
 
         <Box sx={{ m: 1, p: 0 }}>

--- a/apps/worker/src/services/functions/create-readme-file.ts
+++ b/apps/worker/src/services/functions/create-readme-file.ts
@@ -20,7 +20,19 @@ type AnyBilboMDJob =
   | IBilboMDSANSJob
   | IMultiJob
 
-const CITATION = `Pelikan M, Hura GL, Hammel M. Structure and flexibility within proteins as identified through small angle X-ray scattering. Gen Physiol Biophys. 2009 Jun;28(2):174-89. doi: 10.4149/gpb_2009_02_174. PMID: 19592714; PMCID: PMC3773563.`
+const CITATION = `Scott Classen, Joshua Del Mundo, Dhruva Kulkarni, Shreyas Prabhakar, Alan Hicks, Michal Hammel, BilboMD: a web-accessible SAXS and AlphaFold-guided modeling pipeline, Nucleic Acids Research, 2026;, gkag377, https://doi.org/10.1093/nar/gkag377`
+
+const CITATION_BIBTEX = `@article{10.1093/nar/gkag377,
+    author = {Classen, Scott and Del Mundo, Joshua and Kulkarni, Dhruva and Prabhakar, Shreyas and Hicks, Alan and Hammel, Michal},
+    title = {BilboMD: a web-accessible SAXS and AlphaFold-guided modeling pipeline},
+    journal = {Nucleic Acids Research},
+    pages = {gkag377},
+    year = {2026},
+    month = {04},
+    issn = {1362-4962},
+    doi = {10.1093/nar/gkag377},
+    url = {https://doi.org/10.1093/nar/gkag377},
+}`
 
 const MULTIFOXS_ENSEMBLE_EXPLANATION = `
 ## The ensemble_size_N.txt files
@@ -195,6 +207,10 @@ If you use BilboMD in your research, please cite:
 
 ${CITATION}
 
+BibTeX:
+
+${CITATION_BIBTEX}
+
 If you use Pepsi-SANS, please cite:
 
 Grudinin S, Garkavenko M, Kazennov A. Pepsi-SANS: an adaptive method for rapid and accurate
@@ -235,6 +251,10 @@ ${MULTIFOXS_ENSEMBLE_EXPLANATION}
 If you use BilboMD in your research, please cite:
 
 ${CITATION}
+
+BibTeX:
+
+${CITATION_BIBTEX}
 
 Thank you for using BilboMD
 `
@@ -284,6 +304,10 @@ ${MULTIFOXS_ENSEMBLE_EXPLANATION}
 If you use BilboMD in your research, please cite:
 
 ${CITATION}
+
+BibTeX:
+
+${CITATION_BIBTEX}
 
 Thank you for using BilboMD
 `


### PR DESCRIPTION
## Summary

- Replaces the old MultiFoXS reference with the BilboMD NAR 2026 citation in all generated `results.tar.gz` README files (worker)
- Adds a BibTeX entry alongside the plain-text citation in worker-generated READMEs
- Adds a copyable BibTeX block to the Home, About, Help, and Acknowledgments UI pages via a new shared `BilboMDBibTeX` component

## Test plan

- [x] Lint, build, and tests all pass for `@bilbomd/worker` and `@bilbomd/ui`
- [x] Download a completed job's `results.tar.gz` and verify the README contains the updated citation and BibTeX block
- [x] Visit Home, About, Help, and Acknowledgments pages and confirm the BibTeX block renders with a working Copy button

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)