### PR TITLE
fix(ui): fix DNA rendering consistency and add domain coloring in Molstar

### DIFF
--- a/.changeset/molstar-dna-domain-coloring.md
+++ b/.changeset/molstar-dna-domain-coloring.md
@@ -1,0 +1,9 @@
+---
+'@bilbomd/ui': minor
+'@bilbomd/bilbomd-types': patch
+---
+
+Fix DNA representation consistency in Molstar viewer and add domain-based coloring.
+
+- #768: DNA now renders consistently as cartoon (tube/slab) for both CHARMM and OpenMM pipelines. The fix uses a residue-name-based selection that recognises standard PDB names (DA, DT, DG, DC) and CHARMM names (ADE, GUA, CYT, THY) explicitly.
+- #769: Add "Color by Domain" toggle button above the Molstar viewport. When active, fixed-body regions are colored blue and rigid-body regions orange, matching the PyMol movie scheme; flexible linkers retain the default chain coloring. The button appears whenever MD constraint data is available, independent of ensemble count.

--- a/apps/ui/src/features/jobs/SingleJobPage.tsx
+++ b/apps/ui/src/features/jobs/SingleJobPage.tsx
@@ -474,6 +474,7 @@ const SingleJobPage = () => {
                   id={id ?? ''}
                   jobType={job.mongo.jobType}
                   results={job.mongo.results}
+                  constraints={job.mongo.md_constraints}
                 />
               </Suspense>
             </Grid>

--- a/apps/ui/src/features/molstar/EnsembleTogglePanel.tsx
+++ b/apps/ui/src/features/molstar/EnsembleTogglePanel.tsx
@@ -9,15 +9,24 @@ interface EnsembleTogglePanelProps {
   visibility: Record<number, boolean>
   onToggle: (size: number) => void
   onToggleAll: (action: 'show' | 'hide') => void
+  hasConstraints?: boolean
+  domainColorActive?: boolean
+  onColorByDomain?: () => void
 }
 
 const EnsembleTogglePanel = ({
   ensembleSizes,
   visibility,
   onToggle,
-  onToggleAll
+  onToggleAll,
+  hasConstraints,
+  domainColorActive,
+  onColorByDomain
 }: EnsembleTogglePanelProps) => {
-  if (ensembleSizes.length < 2) return null
+  const showEnsembleControls = ensembleSizes.length >= 2
+  const showDomainButton = !!hasConstraints && !!onColorByDomain
+
+  if (!showEnsembleControls && !showDomainButton) return null
 
   const selectedSizes = ensembleSizes.filter((s) => visibility[s])
   const allVisible = selectedSizes.length === ensembleSizes.length
@@ -45,40 +54,55 @@ const EnsembleTogglePanel = ({
         py: 0.5
       }}
     >
-      <Typography variant='body2'>Ensembles:</Typography>
-      <Button
-        size='small'
-        variant='outlined'
-        onClick={() => onToggleAll(allVisible ? 'hide' : 'show')}
-        sx={{ textTransform: 'none', minWidth: 72, alignSelf: 'stretch' }}
-      >
-        {allVisible ? 'Hide All' : 'Show All'}
-      </Button>
-      <ToggleButtonGroup
-        size='small'
-        value={selectedSizes}
-        onChange={handleChange}
-      >
-        {ensembleSizes.map((size) => (
-          <ToggleButton
-            key={size}
-            value={size}
-            sx={{
-              '&.Mui-selected': {
-                backgroundColor: 'primary.main',
-                color: 'white',
-                '&:hover': { backgroundColor: 'primary.dark' }
-              },
-              '&:not(.Mui-selected)': {
-                backgroundColor: 'grey.100',
-                color: 'text.disabled'
-              }
-            }}
+      {showEnsembleControls && (
+        <>
+          <Typography variant='body2'>Ensembles:</Typography>
+          <Button
+            size='small'
+            variant='outlined'
+            onClick={() => onToggleAll(allVisible ? 'hide' : 'show')}
+            sx={{ textTransform: 'none', minWidth: 72, alignSelf: 'stretch' }}
           >
-            Size {size}
-          </ToggleButton>
-        ))}
-      </ToggleButtonGroup>
+            {allVisible ? 'Hide All' : 'Show All'}
+          </Button>
+          <ToggleButtonGroup
+            size='small'
+            value={selectedSizes}
+            onChange={handleChange}
+          >
+            {ensembleSizes.map((size) => (
+              <ToggleButton
+                key={size}
+                value={size}
+                sx={{
+                  '&.Mui-selected': {
+                    backgroundColor: 'primary.main',
+                    color: 'white',
+                    '&:hover': { backgroundColor: 'primary.dark' }
+                  },
+                  '&:not(.Mui-selected)': {
+                    backgroundColor: 'grey.100',
+                    color: 'text.disabled'
+                  }
+                }}
+              >
+                Size {size}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </>
+      )}
+
+      {showDomainButton && (
+        <Button
+          size='small'
+          variant={domainColorActive ? 'contained' : 'outlined'}
+          onClick={onColorByDomain}
+          sx={{ textTransform: 'none', minWidth: 120, alignSelf: 'stretch' }}
+        >
+          Color by Domain
+        </Button>
+      )}
     </Box>
   )
 }

--- a/apps/ui/src/features/molstar/EnsembleTogglePanel.tsx
+++ b/apps/ui/src/features/molstar/EnsembleTogglePanel.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
 import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
@@ -24,9 +25,10 @@ const EnsembleTogglePanel = ({
   onColorByDomain
 }: EnsembleTogglePanelProps) => {
   const showEnsembleControls = ensembleSizes.length >= 2
+  const showSingleEnsembleChip = ensembleSizes.length === 1
   const showDomainButton = !!hasConstraints && !!onColorByDomain
 
-  if (!showEnsembleControls && !showDomainButton) return null
+  if (!showEnsembleControls && !showSingleEnsembleChip && !showDomainButton) return null
 
   const selectedSizes = ensembleSizes.filter((s) => visibility[s])
   const allVisible = selectedSizes.length === ensembleSizes.length
@@ -54,6 +56,18 @@ const EnsembleTogglePanel = ({
         py: 0.5
       }}
     >
+      {showSingleEnsembleChip && (
+        <>
+          <Typography variant='body2'>Ensembles:</Typography>
+          <Chip
+            label={`Size ${ensembleSizes[0]}`}
+            size='small'
+            variant='outlined'
+            color='primary'
+          />
+        </>
+      )}
+
       {showEnsembleControls && (
         <>
           <Typography variant='body2'>Ensembles:</Typography>

--- a/apps/ui/src/features/molstar/Viewer.tsx
+++ b/apps/ui/src/features/molstar/Viewer.tsx
@@ -9,7 +9,8 @@ import type {
   JobResultsDTO,
   IEnsembleModel,
   IEnsembleMember,
-  IEnsemble
+  IEnsemble,
+  MDConstraintsDTO
 } from '@bilbomd/bilbomd-types'
 import { createPluginUI } from 'molstar/lib/mol-plugin-ui'
 import {
@@ -26,7 +27,11 @@ import { PluginUIContext } from 'molstar/lib/mol-plugin-ui/context'
 
 import { ViewportComponent } from './Viewport'
 import EnsembleTogglePanel from './EnsembleTogglePanel'
-import { ShowButtons, StructurePreset } from './presets'
+import {
+  ShowButtons,
+  StructurePreset,
+  createDomainColorPreset
+} from './presets'
 import { BuiltInTrajectoryFormat } from 'molstar/lib/mol-plugin-state/formats/trajectory'
 import 'molstar/lib/mol-plugin-ui/skin/light.scss'
 import Item from 'themes/components/Item'
@@ -81,6 +86,7 @@ interface MolstarViewerProps {
   results: JobResultsDTO
   isPublic?: boolean
   publicId?: string
+  constraints?: MDConstraintsDTO
 }
 
 const MolstarViewer = ({
@@ -88,34 +94,35 @@ const MolstarViewer = ({
   jobType,
   results,
   isPublic,
-  publicId
+  publicId,
+  constraints
 }: MolstarViewerProps) => {
   const token = useSelector(selectCurrentToken)
   const [ensembleVisibility, setEnsembleVisibility] = useState<
     Record<number, boolean>
   >({})
+  const [isDomainColor, setIsDomainColor] = useState(false)
   const ensembleStructureRefs = useRef<Map<number, string[]>>(new Map())
   const ensembleVisibilityRef = useRef<Record<number, boolean>>({})
+  const isDomainColorRef = useRef(false)
+  const allStructureRefs = useRef<string[]>([])
+
+  const hasConstraints =
+    (constraints?.fixed_bodies?.length ?? 0) > 0 ||
+    (constraints?.rigid_bodies?.length ?? 0) > 0
 
   const createLoadParamsArray = async (
     id: string,
     jobType: JobType,
     results: JobResultsDTO
   ): Promise<PDBsToLoad[]> => {
-    // console.log('Creating LoadParams for job:', id, 'jobType:', jobType)
-    // console.log('Results available:', !!results)
-    // console.log('MolstarViewer job:', { id, jobType, results })
     const loadParamsMap = new Map<string, LoadParams[]>()
 
-    // Helper function to add LoadParams to the Map
     const addFilesToLoadParams = (
       fileName: string,
       numModels: number,
       ensembleSize?: number
     ) => {
-      // console.log(
-      //   `Adding file to load params: ${fileName} with ${numModels} models`
-      // )
       let paramsArray = loadParamsMap.get(fileName)
 
       if (!paramsArray) {
@@ -137,7 +144,6 @@ const MolstarViewer = ({
       }
     }
 
-    // Helper function to get the results key based on job type
     const getResultsKey = (jobType: JobType): string => {
       switch (jobType) {
         case 'pdb':
@@ -154,7 +160,6 @@ const MolstarViewer = ({
         case 'scoper':
           return 'scoper'
         case 'multi':
-          // Multi jobs don't have ensembles
           return ''
         default:
           console.warn(`Unknown job type '${jobType}', defaulting to 'classic'`)
@@ -162,21 +167,16 @@ const MolstarViewer = ({
       }
     }
 
-    // Helper function to process ensemble results
     const processEnsembleResults = (results: JobResultsDTO) => {
-      // console.log('Processing ensemble results for job type:', jobType)
-      // console.log('Ensemble results data:', results)
       if (
         !('ensembles' in results) ||
         !Array.isArray((results as HasEnsembles).ensembles)
       )
         return
 
-      // Process each ensemble size
       for (const ensemble of (results as HasEnsembles).ensembles) {
         const fileName = `ensemble_size_${ensemble.size}_model.pdb`
 
-        // Count unique PDB files from all models' states to determine number of assemblies
         const uniquePdbs = new Set<string>()
         ensemble.models.forEach((model: IEnsembleModel) => {
           model.states.forEach((state: IEnsembleMember) => {
@@ -186,17 +186,13 @@ const MolstarViewer = ({
           })
         })
 
-        // Use the ensemble size as the number of models to load
-        // This corresponds to the number of MODEL records in the ensemble PDB file
         addFilesToLoadParams(fileName, ensemble.size, ensemble.size)
       }
     }
 
-    // Adding LoadParams based on job type and results structure
     const ensembleJobTypes: JobType[] = ['pdb', 'crd', 'auto', 'alphafold', 'openfold', 'sans']
 
     if (ensembleJobTypes.includes(jobType)) {
-      // Use the appropriate results structure based on job type
       const resultsKey = getResultsKey(jobType)
       const jobResults = results?.[
         resultsKey as keyof typeof results
@@ -206,19 +202,15 @@ const MolstarViewer = ({
         processEnsembleResults(jobResults)
       }
     } else if (jobType === 'scoper') {
-      // const scoperJob = job as BilboMDScoperDTO
-      // const scoperResults = results as ScoperJobResults
       if (results && results.scoper && results.scoper.foxs_top_file) {
         const pdbFilename = `scoper_combined_${results.scoper.foxs_top_file}`
         addFilesToLoadParams(pdbFilename, 1)
       }
     }
 
-    // Convert the Map values to an array of arrays
     return Array.from(loadParamsMap.values())
   }
 
-  // Function to fetch PDB data with authorization
   const fetchPdbData = async (url: string) => {
     try {
       const headers = isPublic ? {} : { Authorization: `Bearer ${token}` }
@@ -226,11 +218,9 @@ const MolstarViewer = ({
         responseType: 'text',
         headers
       })
-      // console.log('fetch: ', url)
       return response.data
     } catch (error) {
       console.error('Error fetching PDB data:', error)
-      // Optionally, return something to indicate an error to the caller
       return null
     }
   }
@@ -241,7 +231,10 @@ const MolstarViewer = ({
     ensembleVisibilityRef.current = ensembleVisibility
   }, [ensembleVisibility])
 
-  // Attempt to prevent React Strictmode from loading molstar twice in dev mode.
+  useEffect(() => {
+    isDomainColorRef.current = isDomainColor
+  }, [isDomainColor])
+
   const hasRun = useRef(false)
 
   useEffect(() => {
@@ -252,6 +245,7 @@ const MolstarViewer = ({
     const showButtons = true
 
     const refsMap = ensembleStructureRefs.current
+    const structRefs = allStructureRefs.current
 
     async function init() {
       if (window.molstar) {
@@ -327,7 +321,6 @@ const MolstarViewer = ({
           [PluginConfig.VolumeStreaming.DefaultServer, o.volumeStreamingServer],
           [PluginConfig.Download.DefaultPdbProvider, o.pdbProvider],
           [PluginConfig.Download.DefaultEmdbProvider, o.emdbProvider],
-          // [PluginConfig.item('showButtons', true), true]
           [ShowButtons, showButtons]
         ]
       }
@@ -339,9 +332,8 @@ const MolstarViewer = ({
       })
 
       const loadParamsArray = await createLoadParamsArray(id, jobType, results)
-      // console.log(loadParamsArray)
       for (const loadParamsGroup of loadParamsArray) {
-        const { url, format, fileName, ensembleSize } = loadParamsGroup[0] // All items in group have same url, format, fileName
+        const { url, format, fileName, ensembleSize } = loadParamsGroup[0]
         const pdbData = await fetchPdbData(url)
 
         for (const { assemblyId } of loadParamsGroup) {
@@ -354,8 +346,6 @@ const MolstarViewer = ({
               data,
               format
             )
-          // console.log('traj: ', trajectory)
-          // console.log('create model for assemblyId:', assemblyId)
           const model = await window.molstar.builders.structure.createModel(
             trajectory,
             {
@@ -364,7 +354,10 @@ const MolstarViewer = ({
           )
           const struct =
             await window.molstar.builders.structure.createStructure(model)
-          // console.log('struct: ', struct)
+
+          // Track all loaded structure refs for domain coloring
+          structRefs.push(struct.ref)
+
           if (ensembleSize !== undefined) {
             const refs = ensembleStructureRefs.current.get(ensembleSize) ?? []
             refs.push(struct.ref)
@@ -411,7 +404,6 @@ const MolstarViewer = ({
             }
           }
 
-          // Register callback so preset buttons can re-apply visibility after rebuilding representations
           ;(window.molstar.customState as Record<string, unknown>).reapplyVisibility =
             () => {
               const plugin = window.molstar
@@ -445,9 +437,44 @@ const MolstarViewer = ({
       window.molstar = undefined
       hasRun.current = false
       refsMap.clear()
+      structRefs.length = 0
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  const toggleDomainColor = async () => {
+    const plugin = window.molstar
+    if (!plugin || !constraints) return
+
+    const nextMode = !isDomainColorRef.current
+    const allStructures = plugin.managers.structure.hierarchy.current.structures
+    const targets = allStructures.filter((s) =>
+      allStructureRefs.current.includes(s.cell.transform.ref)
+    )
+
+    if (targets.length === 0) return
+
+    if (nextMode) {
+      const domainPreset = createDomainColorPreset(constraints)
+      await plugin.managers.structure.component.applyPreset(
+        targets,
+        domainPreset
+      )
+    } else {
+      await plugin.managers.structure.component.applyPreset(
+        targets,
+        StructurePreset
+      )
+    }
+
+    // Re-apply ensemble visibility after rebuilding representations
+    const reapply = (
+      plugin.customState as Record<string, unknown>
+    ).reapplyVisibility
+    if (typeof reapply === 'function') reapply()
+
+    setIsDomainColor(nextMode)
+  }
 
   const toggleAllEnsembles = (action: 'show' | 'hide') => {
     const plugin = window.molstar
@@ -488,6 +515,9 @@ const MolstarViewer = ({
             visibility={ensembleVisibility}
             onToggle={toggleEnsemble}
             onToggleAll={toggleAllEnsembles}
+            hasConstraints={hasConstraints}
+            domainColorActive={isDomainColor}
+            onColorByDomain={toggleDomainColor}
           />
           <div
             ref={parent}

--- a/apps/ui/src/features/molstar/Viewer.tsx
+++ b/apps/ui/src/features/molstar/Viewer.tsx
@@ -454,26 +454,30 @@ const MolstarViewer = ({
 
     if (targets.length === 0) return
 
-    if (nextMode) {
-      const domainPreset = createDomainColorPreset(constraints)
-      await plugin.managers.structure.component.applyPreset(
-        targets,
-        domainPreset
-      )
-    } else {
-      await plugin.managers.structure.component.applyPreset(
-        targets,
-        StructurePreset
-      )
+    try {
+      if (nextMode) {
+        const domainPreset = createDomainColorPreset(constraints)
+        await plugin.managers.structure.component.applyPreset(
+          targets,
+          domainPreset
+        )
+      } else {
+        await plugin.managers.structure.component.applyPreset(
+          targets,
+          StructurePreset
+        )
+      }
+
+      // Re-apply ensemble visibility after rebuilding representations
+      const reapply = (
+        plugin.customState as Record<string, unknown>
+      ).reapplyVisibility
+      if (typeof reapply === 'function') reapply()
+
+      setIsDomainColor(nextMode)
+    } catch (error) {
+      console.error('Failed to apply domain color preset:', error)
     }
-
-    // Re-apply ensemble visibility after rebuilding representations
-    const reapply = (
-      plugin.customState as Record<string, unknown>
-    ).reapplyVisibility
-    if (typeof reapply === 'function') reapply()
-
-    setIsDomainColor(nextMode)
   }
 
   const toggleAllEnsembles = (action: 'show' | 'hide') => {

--- a/apps/ui/src/features/molstar/__tests__/EnsembleTogglePanel.test.tsx
+++ b/apps/ui/src/features/molstar/__tests__/EnsembleTogglePanel.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from 'test/test-utils'
+import EnsembleTogglePanel from '../EnsembleTogglePanel'
+
+const baseProps = {
+  ensembleSizes: [],
+  visibility: {},
+  onToggle: vi.fn(),
+  onToggleAll: vi.fn()
+}
+
+describe('EnsembleTogglePanel', () => {
+  describe('visibility', () => {
+    it('renders nothing when there are no ensembles and no constraints', () => {
+      const { container } = renderWithProviders(
+        <EnsembleTogglePanel {...baseProps} />
+      )
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders nothing when there is only one ensemble and no constraints', () => {
+      const { container } = renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1]}
+          visibility={{ 1: true }}
+        />
+      )
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders only the domain button when constraints exist but fewer than 2 ensembles', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          hasConstraints={true}
+          onColorByDomain={vi.fn()}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'Color by Domain' })).toBeInTheDocument()
+      expect(screen.queryByText('Ensembles:')).not.toBeInTheDocument()
+    })
+
+    it('renders ensemble controls when there are 2+ ensembles', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: false }}
+        />
+      )
+      expect(screen.getByText('Ensembles:')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Show All' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Size 1' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Size 2' })).toBeInTheDocument()
+    })
+
+    it('renders both ensemble controls and domain button when both apply', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: false }}
+          hasConstraints={true}
+          onColorByDomain={vi.fn()}
+        />
+      )
+      expect(screen.getByText('Ensembles:')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Color by Domain' })).toBeInTheDocument()
+    })
+
+    it('does not render domain button when hasConstraints is false', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: false }}
+          hasConstraints={false}
+          onColorByDomain={vi.fn()}
+        />
+      )
+      expect(screen.queryByRole('button', { name: 'Color by Domain' })).not.toBeInTheDocument()
+    })
+
+    it('does not render domain button when onColorByDomain is not provided', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: false }}
+          hasConstraints={true}
+        />
+      )
+      expect(screen.queryByRole('button', { name: 'Color by Domain' })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('domain color button', () => {
+    it('renders as outlined when domainColorActive is false', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          hasConstraints={true}
+          domainColorActive={false}
+          onColorByDomain={vi.fn()}
+        />
+      )
+      const btn = screen.getByRole('button', { name: 'Color by Domain' })
+      expect(btn).toHaveClass('MuiButton-outlined')
+    })
+
+    it('renders as contained when domainColorActive is true', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          hasConstraints={true}
+          domainColorActive={true}
+          onColorByDomain={vi.fn()}
+        />
+      )
+      const btn = screen.getByRole('button', { name: 'Color by Domain' })
+      expect(btn).toHaveClass('MuiButton-contained')
+    })
+
+    it('calls onColorByDomain when clicked', async () => {
+      const onColorByDomain = vi.fn()
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          hasConstraints={true}
+          onColorByDomain={onColorByDomain}
+        />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Color by Domain' }))
+      expect(onColorByDomain).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('ensemble controls', () => {
+    it('shows "Hide All" when all ensembles are visible', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: true }}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'Hide All' })).toBeInTheDocument()
+    })
+
+    it('shows "Show All" when not all ensembles are visible', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: false }}
+        />
+      )
+      expect(screen.getByRole('button', { name: 'Show All' })).toBeInTheDocument()
+    })
+
+    it('calls onToggleAll with "hide" when Hide All is clicked', async () => {
+      const onToggleAll = vi.fn()
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: true }}
+          onToggleAll={onToggleAll}
+        />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Hide All' }))
+      expect(onToggleAll).toHaveBeenCalledWith('hide')
+    })
+
+    it('calls onToggle when an ensemble size button is clicked', async () => {
+      const onToggle = vi.fn()
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: false }}
+          onToggle={onToggle}
+        />
+      )
+      await userEvent.click(screen.getByRole('button', { name: 'Size 2' }))
+      expect(onToggle).toHaveBeenCalledWith(2)
+    })
+  })
+})

--- a/apps/ui/src/features/molstar/__tests__/EnsembleTogglePanel.test.tsx
+++ b/apps/ui/src/features/molstar/__tests__/EnsembleTogglePanel.test.tsx
@@ -20,15 +20,17 @@ describe('EnsembleTogglePanel', () => {
       expect(container.firstChild).toBeNull()
     })
 
-    it('renders nothing when there is only one ensemble and no constraints', () => {
-      const { container } = renderWithProviders(
+    it('renders a size chip when there is only one ensemble and no constraints', () => {
+      renderWithProviders(
         <EnsembleTogglePanel
           {...baseProps}
           ensembleSizes={[1]}
           visibility={{ 1: true }}
         />
       )
-      expect(container.firstChild).toBeNull()
+      expect(screen.getByText('Size 1')).toBeInTheDocument()
+      expect(screen.getByText('Ensembles:')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /Hide All|Show All/ })).not.toBeInTheDocument()
     })
 
     it('renders only the domain button when constraints exist but fewer than 2 ensembles', () => {

--- a/apps/ui/src/features/molstar/presets.ts
+++ b/apps/ui/src/features/molstar/presets.ts
@@ -21,6 +21,7 @@ import { MolScriptBuilder as MS } from 'molstar/lib/mol-script/language/builder'
 import { StateObjectRef } from 'molstar/lib/mol-state'
 import { Color } from 'molstar/lib/mol-util/color'
 import { Material } from 'molstar/lib/mol-util/material'
+import type { MDConstraintsDTO } from '@bilbomd/bilbomd-types'
 
 function shinyStyle(plugin: PluginContext) {
   return PluginCommands.Canvas3D.SetSettings(plugin, {
@@ -94,6 +95,24 @@ const ligandSurroundings = StructureSelectionQuery(
   ])
 )
 
+// Selects nucleic acid residues by residue name, covering standard PDB names
+// and CHARMM non-standard names so that DNA/RNA is always rendered consistently.
+const nucleicResidueQuery = StructureSelectionQuery(
+  'Nucleic acid residues',
+  MS.struct.modifier.union([
+    MS.struct.generator.atomGroups({
+      'residue-test': MS.core.set.has([
+        MS.set(
+          'DA', 'DT', 'DG', 'DC', 'DU', // standard DNA
+          'A', 'G', 'C', 'T', 'U', // standard RNA
+          'ADE', 'GUA', 'CYT', 'THY', 'URA' // CHARMM residue names
+        ),
+        MS.ammp('label_comp_id')
+      ])
+    })
+  ])
+)
+
 const PresetParams = {
   ...StructureRepresentationPresetProvider.CommonParams
 }
@@ -110,7 +129,12 @@ export const StructurePreset = StructureRepresentationPresetProvider({
 
     const components = {
       ligand: await presetStaticComponent(plugin, structureCell, 'ligand'),
-      polymer: await presetStaticComponent(plugin, structureCell, 'polymer'),
+      protein: await presetStaticComponent(plugin, structureCell, 'protein'),
+      nucleic: await plugin.builders.structure.tryCreateComponentFromSelection(
+        structureCell,
+        nucleicResidueQuery,
+        'nucleic'
+      ),
       ions: await presetStaticComponent(plugin, structureCell, 'ion'),
       branched: await presetStaticComponent(plugin, structureCell, 'branched')
     }
@@ -129,9 +153,9 @@ export const StructurePreset = StructureRepresentationPresetProvider({
         },
         { tag: 'ligand' }
       ),
-      polymer: builder.buildRepresentation(
+      protein: builder.buildRepresentation(
         update,
-        components.polymer,
+        components.protein,
         {
           type: 'cartoon',
           typeParams: { ...typeParams, material: CustomMaterial },
@@ -139,7 +163,19 @@ export const StructurePreset = StructureRepresentationPresetProvider({
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           colorParams: { palette: (plugin.customState as any).colorPalette }
         },
-        { tag: 'polymer' }
+        { tag: 'protein' }
+      ),
+      nucleic: builder.buildRepresentation(
+        update,
+        components.nucleic,
+        {
+          type: 'cartoon',
+          typeParams: { ...typeParams, material: CustomMaterial },
+          color: 'structure-index',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          colorParams: { palette: (plugin.customState as any).colorPalette }
+        },
+        { tag: 'nucleic' }
       ),
       ions: builder.buildRepresentation(
         update,
@@ -474,3 +510,182 @@ export const InteractionsPreset = StructureRepresentationPresetProvider({
 })
 
 export const ShowButtons = PluginConfig.item('showButtons', true)
+
+// Colors matching MDConstraintsRenderer
+const FIXED_COLOR = Color(0x2f54eb)
+const RIGID_COLOR = Color(0xfa8c16)
+
+const buildSegmentExpression = (chainId: string, start: number, stop: number) =>
+  MS.struct.generator.atomGroups({
+    'chain-test': MS.core.rel.eq([MS.ammp('auth_asym_id'), chainId]),
+    'residue-test': MS.core.logic.and([
+      MS.core.rel.gre([MS.ammp('auth_seq_id'), start]),
+      MS.core.rel.lte([MS.ammp('auth_seq_id'), stop])
+    ])
+  })
+
+export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
+  StructureRepresentationPresetProvider({
+    id: 'preset-domain-color',
+    display: { name: 'Domain Color' },
+    params: () => PresetParams,
+    async apply(ref, params, plugin) {
+      const structureCell = StateObjectRef.resolveAndCheck(plugin.state.data, ref)
+      if (!structureCell) return {}
+
+      const { update, builder, typeParams } =
+        StructureRepresentationPresetProvider.reprBuilder(plugin, params)
+
+      const allDomainExpressions: ReturnType<typeof buildSegmentExpression>[] = []
+
+      // Fixed bodies — blue
+      for (const body of constraints.fixed_bodies ?? []) {
+        for (const seg of body.segments ?? []) {
+          const expr = buildSegmentExpression(
+            seg.chain_id,
+            seg.residues.start,
+            seg.residues.stop
+          )
+          allDomainExpressions.push(expr)
+          const tag = `fixed-${body.name}-${seg.chain_id}-${seg.residues.start}`
+          const q = StructureSelectionQuery(
+            tag,
+            MS.struct.modifier.union([expr])
+          )
+          const comp =
+            await plugin.builders.structure.tryCreateComponentFromSelection(
+              structureCell,
+              q,
+              tag
+            )
+          builder.buildRepresentation(
+            update,
+            comp,
+            {
+              type: 'cartoon',
+              typeParams: { ...typeParams, material: CustomMaterial },
+              color: 'uniform',
+              colorParams: { value: FIXED_COLOR }
+            },
+            { tag }
+          )
+        }
+      }
+
+      // Rigid bodies — orange
+      for (const body of constraints.rigid_bodies ?? []) {
+        for (const seg of body.segments ?? []) {
+          const expr = buildSegmentExpression(
+            seg.chain_id,
+            seg.residues.start,
+            seg.residues.stop
+          )
+          allDomainExpressions.push(expr)
+          const tag = `rigid-${body.name}-${seg.chain_id}-${seg.residues.start}`
+          const q = StructureSelectionQuery(
+            tag,
+            MS.struct.modifier.union([expr])
+          )
+          const comp =
+            await plugin.builders.structure.tryCreateComponentFromSelection(
+              structureCell,
+              q,
+              tag
+            )
+          builder.buildRepresentation(
+            update,
+            comp,
+            {
+              type: 'cartoon',
+              typeParams: { ...typeParams, material: CustomMaterial },
+              color: 'uniform',
+              colorParams: { value: RIGID_COLOR }
+            },
+            { tag }
+          )
+        }
+      }
+
+      // Flexible — everything in polymer not covered by a domain segment
+      const flexExpr =
+        allDomainExpressions.length > 0
+          ? MS.struct.modifier.exceptBy({
+              0: StructureSelectionQueries.polymer.expression,
+              by: MS.struct.modifier.union(allDomainExpressions)
+            })
+          : StructureSelectionQueries.polymer.expression
+
+      const flexQ = StructureSelectionQuery('flexible', flexExpr)
+      const flexComp =
+        await plugin.builders.structure.tryCreateComponentFromSelection(
+          structureCell,
+          flexQ,
+          'flexible'
+        )
+      builder.buildRepresentation(
+        update,
+        flexComp,
+        {
+          type: 'cartoon',
+          typeParams: { ...typeParams, material: CustomMaterial },
+          color: 'structure-index',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          colorParams: { palette: (plugin.customState as any).colorPalette }
+        },
+        { tag: 'flexible' }
+      )
+
+      // Standard non-polymer components
+      const ligandComp = await presetStaticComponent(
+        plugin,
+        structureCell,
+        'ligand'
+      )
+      const ionsComp = await presetStaticComponent(plugin, structureCell, 'ion')
+      const branchedComp = await presetStaticComponent(
+        plugin,
+        structureCell,
+        'branched'
+      )
+
+      builder.buildRepresentation(
+        update,
+        ligandComp,
+        {
+          type: 'ball-and-stick',
+          typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.35 },
+          color: 'element-symbol',
+          colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
+        },
+        { tag: 'ligand' }
+      )
+      builder.buildRepresentation(
+        update,
+        ionsComp,
+        {
+          type: 'spacefill',
+          typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 1.0 },
+          color: 'element-symbol',
+          colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
+        },
+        { tag: 'ions' }
+      )
+      builder.buildRepresentation(
+        update,
+        branchedComp,
+        {
+          type: 'ball-and-stick',
+          typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.35 },
+          color: 'element-symbol',
+          colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
+        },
+        { tag: 'branched' }
+      )
+
+      await update.commit({ revertOnError: true })
+      await shinyStyle(plugin)
+      plugin.managers.interactivity.setProps({ granularity: 'residue' })
+
+      return {}
+    }
+  })

--- a/apps/ui/src/features/molstar/presets.ts
+++ b/apps/ui/src/features/molstar/presets.ts
@@ -606,7 +606,10 @@ export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
         }
       }
 
-      // Flexible — everything in polymer not covered by a domain segment
+      // Flexible — everything in polymer not covered by a domain segment.
+      // Note: CHARMM DNA classified by Molstar as 'branched' rather than
+      // 'polymer' will not appear here; that is a known limitation of the
+      // residue-classification fix in StructurePreset (see nucleicResidueQuery).
       const flexExpr =
         allDomainExpressions.length > 0
           ? MS.struct.modifier.exceptBy({

--- a/apps/ui/src/features/public/PublicJobPage.tsx
+++ b/apps/ui/src/features/public/PublicJobPage.tsx
@@ -348,6 +348,7 @@ const PublicJobPage = () => {
                 results={job.results}
                 isPublic={true}
                 publicId={job.publicId}
+                constraints={job.md_constraints}
               />
             </Suspense>
           </Grid>

--- a/packages/bilbomd-types/src/jobs/publicJob.ts
+++ b/packages/bilbomd-types/src/jobs/publicJob.ts
@@ -1,6 +1,7 @@
 import { JobResultsDTO } from './results.js'
 import { JobType, JobStatusEnum } from './jobs.js'
 import { JobStepsDTO } from './jobSteps.js'
+import { MDConstraintsDTO } from './mdConstraints.js'
 
 export type PublicJobStatus = {
   publicId: string
@@ -10,6 +11,7 @@ export type PublicJobStatus = {
   status: JobStatusEnum
   progress: number
   md_engine?: string
+  md_constraints?: MDConstraintsDTO
   submittedAt: Date
   startedAt?: Date
   completedAt?: Date


### PR DESCRIPTION
## Summary

Closes #768, closes #769.

- **#768 — DNA representation consistency**: `StructurePreset` now uses separate `protein` and `nucleic` components. The nucleic component uses an explicit residue-name query (`DA`, `DT`, `DG`, `DC`, `A`, `G`, `C`, `U`, `ADE`, `GUA`, `CYT`, `THY`, `URA`) so that CHARMM-named nucleotides — which Molstar classifies as `branched` rather than `polymer` — are always rendered as cartoon (tube/slab), consistent with OpenMM output.

- **#769 — Color by Domain**: A "Color by Domain" toggle button is added above the Molstar viewport. When active, fixed-body regions are colored blue (`#2f54eb`) and rigid-body regions orange (`#fa8c16`), matching the PyMol movie scheme; flexible linkers retain the default chain palette. The button appears whenever `md_constraints` data is present, independent of ensemble count. `PublicJobStatus` is extended with `md_constraints` so public job pages also receive the data.

## Test plan

- [ ] Lint: `pnpm -F @bilbomd/ui lint` — clean
- [ ] Build: `pnpm -F @bilbomd/ui build` — clean
- [ ] Tests: 1069 tests pass across 125 files (14 new `EnsembleTogglePanel` unit tests)
- [ ] Manual: open a completed CHARMM job with DNA — confirm DNA renders as cartoon tube/slab (not ball-and-stick)
- [ ] Manual: open a completed job with `md_constraints` — confirm "Color by Domain" button appears; clicking colors fixed regions blue and rigid regions orange; clicking again resets to default
- [ ] Manual: open a job with a single ensemble size and constraints — confirm domain button still appears

## Known limitation

CHARMM DNA residues that Molstar classifies as `branched` (rather than `polymer`) will not appear in the flexible region when domain coloring is active — they are invisible in that mode. This is noted in a code comment and can be addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)