### PR TITLE
fix(worker): add Dmax to OpenMM reporter, fix null Rgyr/Dmax for OpenMM jobs

### DIFF
--- a/.changeset/openmm-rgyr-dmax-reporter.md
+++ b/.changeset/openmm-rgyr-dmax-reporter.md
@@ -1,0 +1,9 @@
+---
+'@bilbomd/worker': minor
+---
+
+Add Dmax computation to OpenMM reporter and fix null Rgyr/Dmax in consolidated_rgyr_dmax_data.json for OpenMM jobs.
+
+Renames `RadiusOfGyrationReporter` to `RgyrDmaxReporter` (backward-compatible alias kept) and extends it to also compute and write Dmax alongside Rgyr, using CA atoms only — consistent with the CHARMM dcd2pdb pipeline. The combined CSV is now named `rgyr_dmax.csv` (previously `rgyr.csv` locally, `rgyr_report.csv` on NERSC).
+
+Updates `rgyr_v_dmax_analysis.py` to read `rgyr_dmax.csv` files from `openmm/md/rg_*/` directories when building `consolidated_rgyr_dmax_data.json`, so OpenMM jobs now have non-null `rgyr` and `dmax` values instead of `null`.

--- a/apps/worker/scripts/nersc/gen-openmm-slurm-file.py
+++ b/apps/worker/scripts/nersc/gen-openmm-slurm-file.py
@@ -160,7 +160,7 @@ def prepare_openmm_config(config, params):
                     "rg_sets": [],
                     "k_rg": 1,
                     "report_interval": 500,
-                    "filename": "rgyr_report.csv",
+                    "filename": "rgyr_dmax.csv",
                 },
                 "output_pdb": "md.pdb",
                 "pdb_report_interval": 500,

--- a/apps/worker/scripts/openmm/md.py
+++ b/apps/worker/scripts/openmm/md.py
@@ -18,7 +18,7 @@ from openmm.unit import angstroms
 from utils.fixed_bodies import apply_fixed_body_constraints
 from utils.model_prep import register_ligand_templates_for_topology
 from utils.pdb_writer import PDBFrameWriter
-from utils.rgyr import RadiusOfGyrationCVForce, RadiusOfGyrationReporter
+from utils.rgyr import RadiusOfGyrationCVForce, RgyrDmaxReporter
 from utils.rigid_body import create_rigid_bodies, get_rigid_bodies
 
 
@@ -151,10 +151,10 @@ def run_md_for_rg(rg, config_path, gpu_id=None):
     rgyr_file_path = os.path.join(rg_md_dir, rgyr_report)
     simulation.reporters.append(DCDReporter(dcd_file_path, report_interval))
 
-    # Radius of Gyration Reporter
+    # Rgyr + Dmax Reporter
     simulation.reporters.append(
-        RadiusOfGyrationReporter(
-            atom_indices, system, rgyr_file_path, reportInterval=report_interval
+        RgyrDmaxReporter(
+            atom_indices, rgyr_file_path, reportInterval=report_interval
         )
     )
 

--- a/apps/worker/scripts/openmm/utils/rgyr.py
+++ b/apps/worker/scripts/openmm/utils/rgyr.py
@@ -27,60 +27,56 @@ class TestReporter:
         print(f"TestReporter triggered at step {simulation.currentStep}")
 
 
-class RadiusOfGyrationReporter:
+class RgyrDmaxReporter:
+    """
+    Reports radius of gyration (Rgyr) and maximum pairwise distance (Dmax) for a
+    set of atom indices at each report interval, writing both to a CSV file.
+
+    Both quantities are computed over the supplied atom_indices (typically CA atoms)
+    and reported in Ångströms.
+    """
+
     def __init__(
         self,
         atom_indices,
-        system,
         filename,
         reportInterval=500,
     ):
         self.atom_indices = atom_indices
-        self.system = system
         self.reportInterval = reportInterval
         self.filename = filename
-        # Open CSV file and write header
         self.csvfile = open(self.filename, "w", newline="")
         self.writer = csv.writer(self.csvfile)
-        self.writer.writerow(["Step", "Radius_of_Gyration_nm"])
+        self.writer.writerow(["Step", "Rgyr_A", "Dmax_A"])
 
     def describeNextReport(self, simulation):
-        # print(f"describeNextReport called at step {simulation.currentStep}, interval={self.reportInterval}")
-        # return (self.reportInterval, True, True, True, True)
         return (self.reportInterval, True, False, False, False)
 
     def report(self, simulation, state):
         try:
-            # I'm worried that this is ignoring virtual particles
-            # or virtual particles cause the real particles to be ignored?
             positions = state.getPositions()
-            # print(f"report called at step {simulation.currentStep}, positions={len(positions)}")
-            # for i in self.atom_indices:
-            #     mass_i = self.system.getParticleMass(i)
-            #     print(f"Atom {i} mass: {mass_i}")
-            # masses = np.array([self.system.getParticleMass(i).value_in_unit(dalton) for i in self.atom_indices])
-            masses = np.array([12.011] * len(self.atom_indices))
-            # print("Atom masses:")
-            # for i, m in zip(self.atom_indices, masses):
-            #     print(f"  Atom {i}: mass = {m} Da")
             coords = np.array(
                 [positions[i].value_in_unit(angstroms) for i in self.atom_indices]
             )
-            total_mass = np.sum(masses)
-            com = np.average(coords, axis=0, weights=masses)
-            sq_dists = np.sum((coords - com) ** 2, axis=1)
-            rg2 = np.sum(masses * sq_dists) / total_mass
-            rg = np.sqrt(rg2)
-            # Write step and Rg to CSV
-            self.writer.writerow([simulation.currentStep, rg])
-            self.csvfile.flush()  # ensure data is written promptly
-            print(f"Step {simulation.currentStep}: Radius of Gyration = {rg:.4f} nm")
+            com = coords.mean(axis=0)
+            rg = np.sqrt(np.mean(np.sum((coords - com) ** 2, axis=1)))
+            diff = coords[:, None, :] - coords[None, :, :]
+            dmax = np.max(np.sqrt(np.sum(diff ** 2, axis=-1)))
+            self.writer.writerow([simulation.currentStep, rg, dmax])
+            self.csvfile.flush()
+            print(
+                f"Step {simulation.currentStep}: Rgyr = {rg:.4f} Å, Dmax = {dmax:.4f} Å"
+            )
         except Exception as e:
-            print(f"Exception in RadiusOfGyrationReporter: {e}")
+            print(f"Exception in RgyrDmaxReporter: {e}")
 
     def __del__(self):
         if hasattr(self, "csvfile") and not self.csvfile.closed:
             self.csvfile.close()
+
+
+# Backward-compatible alias
+RadiusOfGyrationReporter = RgyrDmaxReporter
 
 
 class RadiusOfGyrationCVForce(CustomCVForce):

--- a/apps/worker/scripts/pymol/test_data/openmm_config.yaml
+++ b/apps/worker/scripts/pymol/test_data/openmm_config.yaml
@@ -48,7 +48,7 @@ steps:
       timestep: 0.001
     pdb_report_interval: 500
     rgyr:
-      filename: rgyr.csv
+      filename: rgyr_dmax.csv
       k_rg: 10
       report_interval: 500
       rgs:

--- a/apps/worker/scripts/rgyr_v_dmax_analysis.py
+++ b/apps/worker/scripts/rgyr_v_dmax_analysis.py
@@ -1,4 +1,5 @@
 import argparse
+import csv
 import json
 import os
 import re
@@ -43,6 +44,41 @@ def parse_ensemble_size_file(ensemble_file):
                 
     return pdb_occurrences, pdb_counts
 
+def collect_openmm_structural_data(base_dir):
+    """
+    Read Rgyr and Dmax from rgyr_dmax.csv files written by RgyrDmaxReporter for
+    OpenMM jobs. Returns a dict keyed by uppercase PDB stem (e.g. 'MD_000000500').
+    Returns an empty dict if no OpenMM MD output is found.
+    """
+    openmm_md_dir = os.path.join(base_dir, "openmm", "md")
+    if not os.path.isdir(openmm_md_dir):
+        return {}
+
+    data = {}
+    for rg_dir in os.listdir(openmm_md_dir):
+        rg_path = os.path.join(openmm_md_dir, rg_dir)
+        if not os.path.isdir(rg_path):
+            continue
+        csv_path = os.path.join(rg_path, "rgyr_dmax.csv")
+        if not os.path.exists(csv_path):
+            continue
+        with open(csv_path, "r", encoding="utf-8", newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                try:
+                    step = int(float(row["Step"]))
+                    rgyr = float(row["Rgyr_A"])
+                    dmax = float(row["Dmax_A"])
+                except (KeyError, ValueError):
+                    continue
+                prefix = f"MD_{step:09d}"
+                data[prefix] = {"rgyr": rgyr, "dmax": dmax, "pdb": prefix}
+
+    if data:
+        print(f"Loaded Rgyr/Dmax for {len(data)} frames from OpenMM CSV files")
+    return data
+
+
 def collect_pdb_data(foxs_dir):
     """Collect Rgyr, Dmax, and initial size data from PDB files."""
     pdb_data = {}
@@ -68,8 +104,11 @@ def build_scatter_data(base_dir):
     print(f"FoXS directory: {foxs_dir}")
     print(f"MultiFoXS directory: {multifoxs_dir}")
 
-    # Collect PDB data from the foxs directory
+    # Collect PDB data: CHARMM jobs populate via REMARK DCD2PDB_RG in each PDB;
+    # OpenMM jobs have no such REMARK, so fall back to rgyr_dmax.csv files.
     pdb_data = collect_pdb_data(foxs_dir)
+    openmm_data = collect_openmm_structural_data(base_dir)
+    pdb_data.update(openmm_data)
 
     # Traverse through the multifoxs directory for ensemble size files
     for root, _, files in os.walk(multifoxs_dir):

--- a/apps/worker/src/services/functions/openmm-functions.ts
+++ b/apps/worker/src/services/functions/openmm-functions.ts
@@ -183,7 +183,7 @@ const buildOpenMMConfigForJob = async (
             : (omm_params.md?.rgyr ?? []),
           k_rg: omm_params.md?.k_rg ?? 10,
           report_interval: omm_params.md?.rg_report_interval ?? 500,
-          filename: 'rgyr.csv'
+          filename: 'rgyr_dmax.csv'
         },
         output_pdb: 'md.pdb',
         output_restart: 'md.xml',


### PR DESCRIPTION
Fixes #773

## Summary

- Renames `RadiusOfGyrationReporter` → `RgyrDmaxReporter` in `rgyr.py` (backward-compatible alias kept). Extends it to compute and write **Dmax** (max CA pairwise distance) alongside Rgyr into a combined CSV with columns `Step, Rgyr_A, Dmax_A`. Drops the unused `system` parameter.
- Updates `md.py` to use the new class name and drop the `system` argument.
- Standardizes the CSV filename to `rgyr_dmax.csv` everywhere (was `rgyr.csv` locally, `rgyr_report.csv` on NERSC).
- Extends `rgyr_v_dmax_analysis.py` with `collect_openmm_structural_data()` that reads `rgyr_dmax.csv` files from `openmm/md/rg_*/` and populates Rgyr/Dmax by matching step numbers to PDB filenames. For CHARMM jobs the function returns `{}` harmlessly; for OpenMM jobs it fills in what was previously always `null`.

## Test plan

- [x] Verify `openmm/md/rg_*/rgyr_dmax.csv` is written with `Step, Rgyr_A, Dmax_A` columns and non-null values during an OpenMM run
- [x] Run `python rgyr_v_dmax_analysis.py <jobDir>` on an OpenMM job and confirm `consolidated_rgyr_dmax_data.json` has non-null `rgyr` and `dmax`
- [x] Confirm an existing CHARMM job is unaffected (REMARK-based path unchanged)
- [x] `pnpm -F @bilbomd/worker lint && build && test` — 127 tests passing ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)