### PR TITLE
fix(ui): fix Color by Domain preset in Molstar viewer

### DIFF
--- a/.changeset/fix-molstar-color-by-domain.md
+++ b/.changeset/fix-molstar-color-by-domain.md
@@ -1,0 +1,8 @@
+---
+'@bilbomd/ui': patch
+'@bilbomd/backend': patch
+---
+
+Fix Color by Domain preset in Molstar viewer for Classic CRD jobs.
+
+Two-phase component creation prevents "Could not find node" errors when coloring ensemble structures. Also stores `md_constraints` in MongoDB for Classic CRD jobs so the domain-coloring preset has the constraint data it needs.

--- a/apps/backend/src/controllers/jobs/handleBilboMDClassicCRD.ts
+++ b/apps/backend/src/controllers/jobs/handleBilboMDClassicCRD.ts
@@ -21,6 +21,11 @@ import { maybeAutoCalculateRg } from './utils/maybeAutoCalculateRg.js'
 import { crdJobSchema } from '../../validation/index.js'
 import { buildCHARMMParameters } from './utils/charmmParams.js'
 import { config } from '../../config/config.js'
+import {
+  validateInpConstraints,
+  convertInpToYaml,
+  extractConstraintsFromYaml
+} from '@bilbomd/md-utils'
 
 const uploadFolder = config.uploadDir
 
@@ -278,6 +283,27 @@ const handleBilboMDClassicCRD = async (
     logger.info(
       `BilboMD-${bilbomdMode} Job saved to MongoDB: ${newJob._id.toString()}`
     )
+
+    // Store MD constraints in MongoDB (CRD only supports CHARMM/const.inp)
+    if (!isResubmission && inpFile) {
+      try {
+        const constraintFilePath = path.join(jobDir, inpFileName)
+        await validateInpConstraints(constraintFilePath)
+        const yamlContent = await convertInpToYaml(constraintFilePath, logger)
+        const mdConstraints = extractConstraintsFromYaml(yamlContent)
+        newJob.md_constraints = mdConstraints
+        await newJob.save()
+        logger.info(
+          `MD constraints stored in MongoDB for job ${newJob._id.toString()}`
+        )
+      } catch (constraintError) {
+        logger.warn(
+          `Failed to store MD constraints for job ${newJob._id.toString()}:`,
+          constraintError
+        )
+        // Don't fail job creation if constraint storage fails
+      }
+    }
 
     // Write Job params for use by NERSC job script.
     await writeJobParams(newJob._id.toString())

--- a/apps/ui/src/features/molstar/presets.ts
+++ b/apps/ui/src/features/molstar/presets.ts
@@ -533,9 +533,15 @@ export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
       const structureCell = StateObjectRef.resolveAndCheck(plugin.state.data, ref)
       if (!structureCell) return {}
 
-      const { update, builder, typeParams } =
+      // Get typeParams/builder before component creation; update must be created
+      // AFTER all components are committed — reprBuilder captures the state tree
+      // as an immutable snapshot, so any component created after that point
+      // won't be findable via update.to(comp).
+      const { builder, typeParams } =
         StructureRepresentationPresetProvider.reprBuilder(plugin, params)
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const components: Record<string, any> = {}
       const allDomainExpressions: ReturnType<typeof buildSegmentExpression>[] = []
 
       // Fixed bodies — blue
@@ -552,22 +558,10 @@ export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
             tag,
             MS.struct.modifier.union([expr])
           )
-          const comp =
-            await plugin.builders.structure.tryCreateComponentFromSelection(
-              structureCell,
-              q,
-              tag
-            )
-          builder.buildRepresentation(
-            update,
-            comp,
-            {
-              type: 'cartoon',
-              typeParams: { ...typeParams, material: CustomMaterial },
-              color: 'uniform',
-              colorParams: { value: FIXED_COLOR }
-            },
-            { tag }
+          components[tag] = await plugin.builders.structure.tryCreateComponentFromSelection(
+            structureCell,
+            q,
+            tag
           )
         }
       }
@@ -586,22 +580,10 @@ export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
             tag,
             MS.struct.modifier.union([expr])
           )
-          const comp =
-            await plugin.builders.structure.tryCreateComponentFromSelection(
-              structureCell,
-              q,
-              tag
-            )
-          builder.buildRepresentation(
-            update,
-            comp,
-            {
-              type: 'cartoon',
-              typeParams: { ...typeParams, material: CustomMaterial },
-              color: 'uniform',
-              colorParams: { value: RIGID_COLOR }
-            },
-            { tag }
+          components[tag] = await plugin.builders.structure.tryCreateComponentFromSelection(
+            structureCell,
+            q,
+            tag
           )
         }
       }
@@ -619,15 +601,63 @@ export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
           : StructureSelectionQueries.polymer.expression
 
       const flexQ = StructureSelectionQuery('flexible', flexExpr)
-      const flexComp =
+      components['flexible'] =
         await plugin.builders.structure.tryCreateComponentFromSelection(
           structureCell,
           flexQ,
           'flexible'
         )
-      builder.buildRepresentation(
+
+      // Standard non-polymer components
+      components['ligand'] = await presetStaticComponent(plugin, structureCell, 'ligand')
+      components['ions'] = await presetStaticComponent(plugin, structureCell, 'ion')
+      components['branched'] = await presetStaticComponent(plugin, structureCell, 'branched')
+
+      // All components are now committed to the live state tree.
+      // Create the update builder NOW so its snapshot includes them all.
+      const update = plugin.state.data.build()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const representations: Record<string, any> = {}
+
+      // Fixed body representations — blue
+      for (const body of constraints.fixed_bodies ?? []) {
+        for (const seg of body.segments ?? []) {
+          const tag = `fixed-${body.name}-${seg.chain_id}-${seg.residues.start}`
+          representations[tag] = builder.buildRepresentation(
+            update,
+            components[tag],
+            {
+              type: 'cartoon',
+              typeParams: { ...typeParams, material: CustomMaterial },
+              color: 'uniform',
+              colorParams: { value: FIXED_COLOR }
+            },
+            { tag }
+          )
+        }
+      }
+
+      // Rigid body representations — orange
+      for (const body of constraints.rigid_bodies ?? []) {
+        for (const seg of body.segments ?? []) {
+          const tag = `rigid-${body.name}-${seg.chain_id}-${seg.residues.start}`
+          representations[tag] = builder.buildRepresentation(
+            update,
+            components[tag],
+            {
+              type: 'cartoon',
+              typeParams: { ...typeParams, material: CustomMaterial },
+              color: 'uniform',
+              colorParams: { value: RIGID_COLOR }
+            },
+            { tag }
+          )
+        }
+      }
+
+      representations['flexible'] = builder.buildRepresentation(
         update,
-        flexComp,
+        components['flexible'],
         {
           type: 'cartoon',
           typeParams: { ...typeParams, material: CustomMaterial },
@@ -637,23 +667,9 @@ export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
         },
         { tag: 'flexible' }
       )
-
-      // Standard non-polymer components
-      const ligandComp = await presetStaticComponent(
-        plugin,
-        structureCell,
-        'ligand'
-      )
-      const ionsComp = await presetStaticComponent(plugin, structureCell, 'ion')
-      const branchedComp = await presetStaticComponent(
-        plugin,
-        structureCell,
-        'branched'
-      )
-
-      builder.buildRepresentation(
+      representations['ligand'] = builder.buildRepresentation(
         update,
-        ligandComp,
+        components['ligand'],
         {
           type: 'ball-and-stick',
           typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.35 },
@@ -662,9 +678,9 @@ export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
         },
         { tag: 'ligand' }
       )
-      builder.buildRepresentation(
+      representations['ions'] = builder.buildRepresentation(
         update,
-        ionsComp,
+        components['ions'],
         {
           type: 'spacefill',
           typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 1.0 },
@@ -673,9 +689,9 @@ export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
         },
         { tag: 'ions' }
       )
-      builder.buildRepresentation(
+      representations['branched'] = builder.buildRepresentation(
         update,
-        branchedComp,
+        components['branched'],
         {
           type: 'ball-and-stick',
           typeParams: { ...typeParams, material: CustomMaterial, sizeFactor: 0.35 },
@@ -689,6 +705,6 @@ export const createDomainColorPreset = (constraints: MDConstraintsDTO) =>
       await shinyStyle(plugin)
       plugin.managers.interactivity.setProps({ granularity: 'residue' })
 
-      return {}
+      return { components, representations }
     }
   })


### PR DESCRIPTION
## Summary

- **Root cause:** `reprBuilder()` captures the Molstar state tree as an immutable snapshot. Components created via `tryCreateComponentFromSelection()` are committed to the live state *after* that snapshot, so calling `update.to(comp)` immediately after threw `"Could not find node '<ref>'"` on every structure in the ensemble.
- **Fix:** Two-phase approach — create all components first (all async commits complete), *then* call `plugin.state.data.build()` to get a fresh snapshot that includes them, then build and commit all representations.
- **Also:** Store `md_constraints` in MongoDB for Classic CRD jobs (was already done for PDB jobs), so the constraint data is available to the domain-coloring preset.

## Test plan

- [ ] Load a Classic CRD job result in the Molstar viewer
- [ ] Click "Color by Domain" — fixed bodies should render blue, rigid body orange, flexible regions gray
- [ ] Toggle back to default coloring — should revert cleanly
- [ ] Repeat for ensemble results (multiple models loaded) — all ensemble structures should receive the coloring

🤖 Generated with [Claude Code](https://claude.com/claude-code)