### PR TITLE
fix(worker): replace fetch with axios in OF3 service call to avoid 5-min timeout

### DIFF
--- a/.changeset/fix-of3-headers-timeout.md
+++ b/.changeset/fix-of3-headers-timeout.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Fix OF3 pipeline timing out after 5 minutes due to undici's default headersTimeout. Switch callOf3Service from native fetch to axios, which does not impose a headers-level timeout separate from the overall request timeout.

--- a/.changeset/fix-of3-headers-timeout.md
+++ b/.changeset/fix-of3-headers-timeout.md
@@ -2,4 +2,4 @@
 '@bilbomd/worker': patch
 ---
 
-Fix OF3 pipeline timing out after 5 minutes due to undici's default headersTimeout. Switch callOf3Service from native fetch to axios, which does not impose a headers-level timeout separate from the overall request timeout.
+Fix OF3 and AlphaFold pipelines timing out after 5 minutes due to undici's default headersTimeout. Switch callOf3Service and callColabFoldService from native fetch to axios, which does not impose a headers-level timeout separate from the overall request timeout. Also adds BullMQ heartbeat to callColabFoldService to match the OF3 implementation.

--- a/apps/worker/src/services/functions/__tests__/alphafold-functions.test.ts
+++ b/apps/worker/src/services/functions/__tests__/alphafold-functions.test.ts
@@ -54,8 +54,15 @@ vi.mock('../../../config/config.js', () => ({
   }
 }))
 
-const mockFetch = vi.fn()
-vi.stubGlobal('fetch', mockFetch)
+const { mockAxiosPost } = vi.hoisted(() => ({ mockAxiosPost: vi.fn() }))
+
+vi.mock('axios', () => ({
+  default: {
+    post: mockAxiosPost,
+    isAxiosError: (e: unknown) =>
+      typeof e === 'object' && e !== null && 'isAxiosError' in e
+  }
+}))
 
 describe('rank_001 patterns', () => {
   it('matches relaxed rank_001 PDB names', () => {
@@ -88,7 +95,7 @@ describe('rank_001 patterns', () => {
 describe('runAlphaFold integration shape', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockFetch.mockResolvedValue({ ok: true, text: async () => '' })
+    mockAxiosPost.mockResolvedValue({ status: 200, data: {} })
   })
 
   it('throws when the FASTA file is missing', async () => {
@@ -107,7 +114,7 @@ describe('runAlphaFold integration shape', () => {
       save: vi.fn(async () => undefined)
     } as never
 
-    const fakeMQ = { log: vi.fn() } as never
+    const fakeMQ = { log: vi.fn(), updateProgress: vi.fn() } as never
 
     await expect(runAlphaFold(fakeMQ, fakeJob)).rejects.toThrow(
       /AlphaFold input FASTA missing/
@@ -138,7 +145,7 @@ describe('runAlphaFold integration shape', () => {
       pae_file: undefined,
       save
     } as never
-    const fakeMQ = { log: vi.fn() } as never
+    const fakeMQ = { log: vi.fn(), updateProgress: vi.fn() } as never
 
     await runAlphaFold(fakeMQ, fakeJob)
 
@@ -147,12 +154,10 @@ describe('runAlphaFold integration shape', () => {
       pae_file: 'af-pae.json'
     })
     expect(save).toHaveBeenCalled()
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(mockAxiosPost).toHaveBeenCalledWith(
       'http://colabfold-service:8000/infer',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({ uuid: 'abc' })
-      })
+      { uuid: 'abc' },
+      expect.objectContaining({ timeout: 60_000 })
     )
   })
 
@@ -163,11 +168,11 @@ describe('runAlphaFold integration shape', () => {
     }
     fs.__setFiles({ '/in/uploads/abc/af-entities.fasta': '>a\nACDE' })
     fs.__setDirs({})
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 500,
-      text: async () => 'GPU OOM'
+    const axiosErr = Object.assign(new Error('Request failed'), {
+      isAxiosError: true,
+      response: { status: 500, data: 'GPU OOM' }
     })
+    mockAxiosPost.mockRejectedValue(axiosErr)
 
     const { runAlphaFold } = await import('../alphafold-functions.js')
     const fakeJob = {
@@ -176,7 +181,7 @@ describe('runAlphaFold integration shape', () => {
       pae_file: undefined,
       save: vi.fn()
     } as never
-    const fakeMQ = { log: vi.fn() } as never
+    const fakeMQ = { log: vi.fn(), updateProgress: vi.fn() } as never
 
     await expect(runAlphaFold(fakeMQ, fakeJob)).rejects.toThrow(
       /ColabFold service returned HTTP 500/

--- a/apps/worker/src/services/functions/alphafold-functions.ts
+++ b/apps/worker/src/services/functions/alphafold-functions.ts
@@ -1,6 +1,7 @@
 import { Job as BullMQJob } from 'bullmq'
 import path from 'node:path'
 import fs from 'fs-extra'
+import axios from 'axios'
 import { IBilboMDAlphaFoldJob, IStepStatus } from '@bilbomd/mongodb-schema'
 import { config } from '../../config/config.js'
 import { logger } from '../../helpers/loggers.js'
@@ -43,18 +44,25 @@ const callColabFoldService = async (
   logger.info(`Calling ColabFold service: POST ${url} uuid=${uuid}`)
   await MQjob.log(`alphafold http: POST ${url}`)
 
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ uuid }),
-    signal: AbortSignal.timeout(config.colabfoldTimeoutMs)
-  })
+  const heartbeat = setInterval(() => {
+    MQjob.updateProgress({ status: 'running', timestamp: Date.now() })
+  }, 20_000)
 
-  if (!res.ok) {
-    const body = await res.text().catch(() => '')
-    throw new Error(
-      `ColabFold service returned HTTP ${res.status}: ${body}`
-    )
+  try {
+    await axios.post(url, { uuid }, {
+      headers: { 'content-type': 'application/json' },
+      // Use axios instead of native fetch to avoid undici's default 300s headersTimeout
+      timeout: config.colabfoldTimeoutMs
+    })
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(
+        `ColabFold service returned HTTP ${error.response.status}: ${JSON.stringify(error.response.data)}`
+      )
+    }
+    throw error
+  } finally {
+    clearInterval(heartbeat)
   }
 }
 

--- a/apps/worker/src/services/functions/openfold-functions.ts
+++ b/apps/worker/src/services/functions/openfold-functions.ts
@@ -1,6 +1,7 @@
 import { Job as BullMQJob } from 'bullmq'
 import path from 'node:path'
 import fs from 'fs-extra'
+import axios from 'axios'
 import { IBilboMDOpenFoldJob, IStepStatus } from '@bilbomd/mongodb-schema'
 import { config } from '../../config/config.js'
 import { logger } from '../../helpers/loggers.js'
@@ -31,23 +32,21 @@ const callOf3Service = async (
     MQjob.updateProgress({ status: 'running', timestamp: Date.now() })
   }, 20_000)
 
-  let res: Response
   try {
-    res = await fetch(url, {
-      method: 'POST',
+    await axios.post(url, { uuid }, {
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ uuid }),
-      signal: AbortSignal.timeout(config.of3TimeoutMs)
+      // Use axios instead of native fetch to avoid undici's default 300s headersTimeout
+      timeout: config.of3TimeoutMs
     })
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(
+        `OF3 service returned HTTP ${error.response.status}: ${JSON.stringify(error.response.data)}`
+      )
+    }
+    throw error
   } finally {
     clearInterval(heartbeat)
-  }
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => '')
-    throw new Error(
-      `OF3 service returned HTTP ${res.status}: ${body}`
-    )
   }
 }
 


### PR DESCRIPTION
## Summary

- Native `fetch` in Node.js uses undici internally, which enforces a default `headersTimeout` of 300 seconds regardless of any `AbortSignal` timeout set on the request
- The OF3 inference service takes longer than 5 minutes to begin sending response headers, so jobs were consistently failing with `HeadersTimeoutError: Headers Timeout Error`
- Replaced `fetch` with `axios.post()` in `callOf3Service` — axios uses Node's `http` module and does not impose a separate headers-level timeout; the configured `OF3_TIMEOUT_MS` (1 hour default) is now the only limit

## Test plan

- [x] Submit an OF3 example job and confirm it runs past the 5-minute mark without failing
- [ ] Confirm HTTP 4xx/5xx errors from the OF3 service are still surfaced with a useful message
- [ ] Lint, build, and tests all pass (`pnpm -F @bilbomd/worker lint && build && test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)