### PR TITLE
feat(ui): replace PNG pipeline schematics with inline SVG components

### DIFF
--- a/.changeset/svg-af-openmm-pipeline-schematic.md
+++ b/.changeset/svg-af-openmm-pipeline-schematic.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': minor
+---
+
+Replace all static PNG pipeline schematics with inline SVG React components. The SVGs scale cleanly at any resolution, respond to MUI dark/light theme automatically, and eliminate the need for separate dark-mode PNG files. Pipelines covered: AF + OpenMM, AF + CHARMM, Classic PDB + OpenMM, Classic PDB + CHARMM, Classic CRD/PSF, Auto + OpenMM, Auto + CHARMM, OpenFold3, and SANS.

--- a/apps/ui/src/components/Home.tsx
+++ b/apps/ui/src/components/Home.tsx
@@ -13,7 +13,10 @@ import { useRefreshMutation } from 'slices/authApiSlice'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import usePersist from 'hooks/usePersist'
 import useTitle from 'hooks/useTitle'
-import { useTheme } from '@mui/material/styles'
+import ClassicPDBOpenMMPipelineSchematic from 'features/jobs/ClassicPDBOpenMMPipelineSchematic'
+import ClassicCRDPipelineSchematic from 'features/jobs/ClassicCRDPipelineSchematic'
+import AutoOpenMMPipelineSchematic from 'features/autojob/AutoOpenMMPipelineSchematic'
+import AFOpenMMPipelineSchematic from 'features/alphafoldjob/AFOpenMMPipelineSchematic'
 import Introduction from '../features/shared/Introduction'
 import FeaturesList from '../features/shared/FeaturesList'
 import PipelineOptions from '../features/shared/PipelineOptions'
@@ -24,8 +27,6 @@ const Home = ({ title = 'BilboMD' }) => {
   useTitle(title)
   const { data: config, isLoading: configIsLoading } =
     useGetConfigsQuery('configData')
-  const theme = useTheme()
-  const isLightMode = theme.palette.mode === 'light'
   const navigate = useNavigate()
   const [persist] = usePersist()
   const token = useSelector(selectCurrentToken)
@@ -153,34 +154,22 @@ const Home = ({ title = 'BilboMD' }) => {
       {
         title: 'BilboMD Classic w/PDB',
         description: 'Bring your own starting PDB model and constraints.',
-        imagePath: {
-          light: '/images/bilbomd-classic-pdb-schematic.png',
-          dark: '/images/bilbomd-classic-pdb-schematic-dark.png'
-        }
+        schematic: <ClassicPDBOpenMMPipelineSchematic />
       },
       {
         title: 'BilboMD Classic w/CRD/PSF',
         description: 'Bring your own parameterized model and constraints.',
-        imagePath: {
-          light: '/images/bilbomd-classic-crd-schematic.png',
-          dark: '/images/bilbomd-classic-crd-schematic-dark.png'
-        }
+        schematic: <ClassicCRDPipelineSchematic />
       },
       {
         title: 'BilboMD Auto',
         description: 'Use AlphaFold models with automatic constraints.',
-        imagePath: {
-          light: '/images/bilbomd-auto-schematic.png',
-          dark: '/images/bilbomd-auto-schematic-dark.png'
-        }
+        schematic: <AutoOpenMMPipelineSchematic />
       },
       {
         title: 'BilboMD AF - NERSC only',
         description: 'Provide an amino acid sequence for full processing.',
-        imagePath: {
-          light: '/images/bilbomd-af-schematic.png',
-          dark: '/images/bilbomd-af-schematic-dark.png'
-        }
+        schematic: <AFOpenMMPipelineSchematic />
       }
     ]
 
@@ -280,10 +269,7 @@ const Home = ({ title = 'BilboMD' }) => {
         >
           Pipeline Options
         </Typography>
-        <PipelineOptions
-          pipelines={pipelines}
-          isLightMode={isLightMode}
-        />
+        <PipelineOptions pipelines={pipelines} />
 
         {/* Additional Information */}
         <AdditionalInfo />

--- a/apps/ui/src/features/about/About.tsx
+++ b/apps/ui/src/features/about/About.tsx
@@ -17,6 +17,7 @@ import ClassicPDBOpenMMPipelineSchematic from 'features/jobs/ClassicPDBOpenMMPip
 import ClassicCRDPipelineSchematic from 'features/jobs/ClassicCRDPipelineSchematic'
 import AutoOpenMMPipelineSchematic from 'features/autojob/AutoOpenMMPipelineSchematic'
 import AFOpenMMPipelineSchematic from 'features/alphafoldjob/AFOpenMMPipelineSchematic'
+import OF3OpenMMPipelineSchematic from 'features/openfoldjob/OF3OpenMMPipelineSchematic'
 
 const About = ({ title = 'BilboMD: About' }) => {
   useTitle(title)
@@ -47,9 +48,9 @@ const About = ({ title = 'BilboMD: About' }) => {
             has already been parameterized for CHARMM as a *.crd and *.psf
             files. This is typically done with{' '}
             <Link
-              href='https://www.charmm-gui.org/'
-              target='_blank'
-              rel='noopener noreferrer'
+              href="https://www.charmm-gui.org/"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               CHARMM-GUI
             </Link>
@@ -140,55 +141,70 @@ const About = ({ title = 'BilboMD: About' }) => {
         schematic: <AutoOpenMMPipelineSchematic />
       },
       {
-        title: 'BilboMD AF - NERSC only',
+        title: 'BilboMD AF',
         description: 'Provide an amino acid sequence for full processing.',
         schematic: <AFOpenMMPipelineSchematic />
+      },
+      {
+        title: 'BilboMD OF3',
+        description: 'Provide an amino acid sequence for full processing.',
+        schematic: <OF3OpenMMPipelineSchematic />
       }
     ]
 
     content = (
       <Container>
-        <Introduction title='About BilboMD'>
+        <Introduction title="About BilboMD">
           <b>BilboMD</b> allows you to determine the three-dimensional domain
           structure of proteins based on conformational sampling using a
           Molecular Dynamics (MD) approach. Conformational sampling performed by{' '}
           <Link
-            href='https://academiccharmm.org/documentation'
-            target='_blank'
-            rel='noopener noreferrer'
+            href="https://academiccharmm.org/documentation"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             CHARMM
           </Link>{' '}
-          is followed by structure validation using{' '}
+          or{' '}
           <Link
-            href='https://modbase.compbio.ucsf.edu/foxs/about'
-            target='_blank'
-            rel='noopener noreferrer'
+            href="https://openmm.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            OpenMM
+          </Link>{' '}
+          and is followed by structure validation using{' '}
+          <Link
+            href="https://modbase.compbio.ucsf.edu/foxs/about"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             FoXS
           </Link>{' '}
-          and ensemble analysis using Minimal Ensemble Search (MES) via{' '}
+          and ensemble analysis via{' '}
           <Link
-            href='https://modbase.compbio.ucsf.edu/multifoxs/'
-            target='_blank'
-            rel='noopener noreferrer'
+            href="https://modbase.compbio.ucsf.edu/multifoxs/"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             MultiFoXS
           </Link>
           .Details of the implementation and integration of these tools into{' '}
           <b>BilboMD</b> are described in the following manuscript:
-          <Typography variant='body2' sx={{ mx: 5, my: 2 }}>
-            Classen S, Del Mundo J, Kulkarni D, Prabhakar S, Hicks A, Hammel
-            M.{' '}
+          <Typography
+            variant="body2"
+            sx={{ mx: 5, my: 2 }}
+          >
+            Classen S, Del Mundo J, Kulkarni D, Prabhakar S, Hicks A, Hammel M.{' '}
             <b>
               BilboMD: a web-accessible SAXS and AlphaFold-guided modeling
               pipeline.
             </b>{' '}
             Nucleic Acids Research. 2026; gkag377. doi:{' '}
             <Link
-              href='https://doi.org/10.1093/nar/gkag377'
-              target='_blank'
-              rel='noopener noreferrer'
+              href="https://doi.org/10.1093/nar/gkag377"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               10.1093/nar/gkag377
             </Link>
@@ -199,26 +215,32 @@ const About = ({ title = 'BilboMD: About' }) => {
 
         {/* Config Alert */}
         {config?.useNersc?.toLowerCase() === 'false' ? (
-          <Alert severity='info' variant='outlined'>
+          <Alert
+            severity="info"
+            variant="outlined"
+          >
             You are about to run <b>BilboMD</b> on SIBYLS servers. If you would
             prefer to run on NERSC head over to:{' '}
             <Link
-              href='https://bilbomd-nersc.bl1231.als.lbl.gov'
-              target='_blank'
-              rel='noopener noreferrer'
+              href="https://bilbomd-nersc.bl1231.als.lbl.gov"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <b>bilbomd-nersc.bl1231.als.lbl.gov</b>
             </Link>
             .
           </Alert>
         ) : (
-          <Alert severity='info' variant='outlined'>
+          <Alert
+            severity="info"
+            variant="outlined"
+          >
             You are about to run <b>BilboMD</b> on NERSC. If you would prefer to
             run on the SIBYLS Beamline servers head over to:{' '}
             <Link
-              href='https://bilbomd.bl1231.als.lbl.gov'
-              target='_blank'
-              rel='noopener noreferrer'
+              href="https://bilbomd.bl1231.als.lbl.gov"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <b>bilbomd.bl1231.als.lbl.gov</b>
             </Link>
@@ -227,7 +249,10 @@ const About = ({ title = 'BilboMD: About' }) => {
         )}
 
         {/* Pipeline Options */}
-        <Typography variant='h2' sx={{ my: 3 }}>
+        <Typography
+          variant="h2"
+          sx={{ my: 3 }}
+        >
           Pipeline Options
         </Typography>
         <PipelineOptions pipelines={pipelines} />

--- a/apps/ui/src/features/about/About.tsx
+++ b/apps/ui/src/features/about/About.tsx
@@ -8,19 +8,20 @@ import {
 } from '@mui/material'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import useTitle from 'hooks/useTitle'
-import { useTheme } from '@mui/material/styles'
 import Introduction from '../shared/Introduction'
 import FeaturesList from '../shared/FeaturesList'
 import PipelineOptions from '../shared/PipelineOptions'
 import AdditionalInfo from '../shared/AdditionalInfo'
 import BilboMDBibTeX from 'components/Common/BilboMDBibTeX'
+import ClassicPDBOpenMMPipelineSchematic from 'features/jobs/ClassicPDBOpenMMPipelineSchematic'
+import ClassicCRDPipelineSchematic from 'features/jobs/ClassicCRDPipelineSchematic'
+import AutoOpenMMPipelineSchematic from 'features/autojob/AutoOpenMMPipelineSchematic'
+import AFOpenMMPipelineSchematic from 'features/alphafoldjob/AFOpenMMPipelineSchematic'
 
 const About = ({ title = 'BilboMD: About' }) => {
   useTitle(title)
   const { data: config, isLoading: configIsLoading } =
     useGetConfigsQuery('configData')
-  const theme = useTheme()
-  const isLightMode = theme.palette.mode === 'light'
 
   let content
 
@@ -126,34 +127,22 @@ const About = ({ title = 'BilboMD: About' }) => {
       {
         title: 'BilboMD Classic w/PDB',
         description: 'Bring your own starting PDB model and constraints.',
-        imagePath: {
-          light: '/images/bilbomd-classic-pdb-schematic.png',
-          dark: '/images/bilbomd-classic-pdb-schematic-dark.png'
-        }
+        schematic: <ClassicPDBOpenMMPipelineSchematic />
       },
       {
         title: 'BilboMD Classic w/CRD/PSF',
         description: 'Bring your own parameterized model and constraints.',
-        imagePath: {
-          light: '/images/bilbomd-classic-crd-schematic.png',
-          dark: '/images/bilbomd-classic-crd-schematic-dark.png'
-        }
+        schematic: <ClassicCRDPipelineSchematic />
       },
       {
         title: 'BilboMD Auto',
         description: 'Use AlphaFold models with automatic constraints.',
-        imagePath: {
-          light: '/images/bilbomd-auto-schematic.png',
-          dark: '/images/bilbomd-auto-schematic-dark.png'
-        }
+        schematic: <AutoOpenMMPipelineSchematic />
       },
       {
         title: 'BilboMD AF - NERSC only',
         description: 'Provide an amino acid sequence for full processing.',
-        imagePath: {
-          light: '/images/bilbomd-af-schematic.png',
-          dark: '/images/bilbomd-af-schematic-dark.png'
-        }
+        schematic: <AFOpenMMPipelineSchematic />
       }
     ]
 
@@ -241,7 +230,7 @@ const About = ({ title = 'BilboMD: About' }) => {
         <Typography variant='h2' sx={{ my: 3 }}>
           Pipeline Options
         </Typography>
-        <PipelineOptions pipelines={pipelines} isLightMode={isLightMode} />
+        <PipelineOptions pipelines={pipelines} />
 
         {/* Additional Information */}
         <AdditionalInfo />

--- a/apps/ui/src/features/alphafoldjob/AFCharmmPipelineSchematic.tsx
+++ b/apps/ui/src/features/alphafoldjob/AFCharmmPipelineSchematic.tsx
@@ -1,0 +1,176 @@
+import { useTheme } from '@mui/material/styles'
+
+type StepColor = 'blue' | 'green' | 'purple'
+
+interface Step {
+  lines: string[]
+  color: StepColor
+}
+
+const ROW0: Step[] = [
+  { lines: ['AA Sequence', 'SAXS *.dat'], color: 'blue' },
+  { lines: ['AlphaFold2'], color: 'blue' },
+  { lines: ['Convert to', '*.crd / *.psf'], color: 'blue' },
+  { lines: ['PAE Analysis'], color: 'blue' },
+  { lines: ['CHARMM', 'Minimize'], color: 'green' },
+  { lines: ['CHARMM', 'Heat'], color: 'green' }
+]
+
+const ROW1: Step[] = [
+  { lines: ['CHARMM', 'Coarse Grained MD'], color: 'green' },
+  { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
+  { lines: ['FoXS'], color: 'purple' },
+  { lines: ['MultiFoXS'], color: 'purple' },
+  { lines: ['Gather Results'], color: 'blue' },
+  { lines: ['Notify'], color: 'blue' }
+]
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
+const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const AFCharmmPipelineSchematic = () => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const colors: Record<
+    StepColor,
+    { fill: string; stroke: string; text: string }
+  > = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    purple: {
+      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
+      stroke: theme.palette.secondary?.main ?? '#9c27b0',
+      text: isDark ? '#ede9fe' : '#3b0764'
+    }
+  }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: Step, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label="BilboMD AF CHARMM pipeline schematic"
+    >
+      {ROW0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < ROW0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {ROW1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < ROW1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default AFCharmmPipelineSchematic

--- a/apps/ui/src/features/alphafoldjob/AFCharmmPipelineSchematic.tsx
+++ b/apps/ui/src/features/alphafoldjob/AFCharmmPipelineSchematic.tsx
@@ -1,13 +1,8 @@
-import { useTheme } from '@mui/material/styles'
+import PipelineSchematicBase, {
+  PipelineStep
+} from 'features/shared/PipelineSchematicBase'
 
-type StepColor = 'blue' | 'green' | 'purple'
-
-interface Step {
-  lines: string[]
-  color: StepColor
-}
-
-const ROW0: Step[] = [
+const ROW0: PipelineStep[] = [
   { lines: ['AA Sequence', 'SAXS *.dat'], color: 'blue' },
   { lines: ['AlphaFold2'], color: 'blue' },
   { lines: ['Convert to', '*.crd / *.psf'], color: 'blue' },
@@ -16,7 +11,7 @@ const ROW0: Step[] = [
   { lines: ['CHARMM', 'Heat'], color: 'green' }
 ]
 
-const ROW1: Step[] = [
+const ROW1: PipelineStep[] = [
   { lines: ['CHARMM', 'Coarse Grained MD'], color: 'green' },
   { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
   { lines: ['FoXS'], color: 'purple' },
@@ -25,152 +20,12 @@ const ROW1: Step[] = [
   { lines: ['Notify'], color: 'blue' }
 ]
 
-const BOX_W = 110
-const BOX_H = 52
-const GAP = 28
-const LEFT_PAD = 26
-const RIGHT_PAD = 20
-const ROW_Y = [10, 90]
-
-const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
-const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
-const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
-const WRAP_LEFT_X = LEFT_PAD - 20
-const LEAD_IN = 20
-const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
-const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
-const WRAP_Y_MID =
-  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
-const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
-const SVG_H = ROW_Y[1] + BOX_H + 10
-
-const AFCharmmPipelineSchematic = () => {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
-
-  const colors: Record<
-    StepColor,
-    { fill: string; stroke: string; text: string }
-  > = {
-    blue: {
-      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
-      stroke: theme.palette.primary?.main ?? '#1976d2',
-      text: isDark ? '#e0f2fe' : '#1e3a5f'
-    },
-    green: {
-      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
-      stroke: theme.palette.success?.main ?? '#2e7d32',
-      text: isDark ? '#d1fae5' : '#14532d'
-    },
-    purple: {
-      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
-      stroke: theme.palette.secondary?.main ?? '#9c27b0',
-      text: isDark ? '#ede9fe' : '#3b0764'
-    }
-  }
-
-  const arrowColor = isDark ? '#94a3b8' : '#64748b'
-  const arrowHead = `M0,0 L6,3 L0,6 Z`
-
-  const renderBox = (step: Step, x: number, y: number, key: string) => {
-    const c = colors[step.color]
-    const lineH = 14
-    const totalTextH = step.lines.length * lineH
-    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
-    return (
-      <g key={key}>
-        <rect
-          x={x}
-          y={y}
-          width={BOX_W}
-          height={BOX_H}
-          rx={6}
-          fill={c.fill}
-          stroke={c.stroke}
-          strokeWidth={1.5}
-        />
-        {step.lines.map((line, i) => (
-          <text
-            key={i}
-            x={x + BOX_W / 2}
-            y={textStartY + i * lineH}
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
-            fill={c.text}
-            fontWeight={500}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    )
-  }
-
-  const renderArrow = (x1: number, y: number, key: string) => (
-    <g key={key}>
-      <line
-        x1={x1}
-        y1={y + BOX_H / 2}
-        x2={x1 + GAP - 6}
-        y2={y + BOX_H / 2}
-        stroke={arrowColor}
-        strokeWidth={1.5}
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  const wrapArrow = (
-    <g key="wrap">
-      <polyline
-        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
-        fill="none"
-        stroke={arrowColor}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  return (
-    <svg
-      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-      style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD AF CHARMM pipeline schematic"
-    >
-      {ROW0.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r0-${i}`}>
-            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
-            {i < ROW0.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
-          </g>
-        )
-      })}
-      {wrapArrow}
-      {ROW1.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r1-${i}`}>
-            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
-            {i < ROW1.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
-          </g>
-        )
-      })}
-    </svg>
-  )
-}
+const AFCharmmPipelineSchematic = () => (
+  <PipelineSchematicBase
+    row0={ROW0}
+    row1={ROW1}
+    ariaLabel="BilboMD AF CHARMM pipeline schematic"
+  />
+)
 
 export default AFCharmmPipelineSchematic

--- a/apps/ui/src/features/alphafoldjob/AFOpenMMPipelineSchematic.tsx
+++ b/apps/ui/src/features/alphafoldjob/AFOpenMMPipelineSchematic.tsx
@@ -1,13 +1,8 @@
-import { useTheme } from '@mui/material/styles'
+import PipelineSchematicBase, {
+  PipelineStep
+} from 'features/shared/PipelineSchematicBase'
 
-type StepColor = 'blue' | 'green' | 'purple'
-
-interface Step {
-  lines: string[]
-  color: StepColor
-}
-
-const ROW0: Step[] = [
+const ROW0: PipelineStep[] = [
   { lines: ['AA Sequence', 'SAXS *.dat'], color: 'blue' },
   { lines: ['AlphaFold2'], color: 'blue' },
   { lines: ['Select Rank 1', ' prediction'], color: 'blue' },
@@ -16,7 +11,7 @@ const ROW0: Step[] = [
   { lines: ['OpenMM', 'Heat'], color: 'green' }
 ]
 
-const ROW1: Step[] = [
+const ROW1: PipelineStep[] = [
   { lines: ['OpenMM', 'Coarse Grained MD'], color: 'green' },
   { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
   { lines: ['FoXS'], color: 'purple' },
@@ -25,153 +20,12 @@ const ROW1: Step[] = [
   { lines: ['Notify'], color: 'blue' }
 ]
 
-const BOX_W = 110
-const BOX_H = 52
-const GAP = 28
-const LEFT_PAD = 26
-const RIGHT_PAD = 20
-const ROW_Y = [10, 90]
-
-const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
-const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
-const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
-const WRAP_LEFT_X = LEFT_PAD - 20
-const LEAD_IN = 20
-const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
-const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
-const WRAP_Y_MID =
-  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
-const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
-const SVG_H = ROW_Y[1] + BOX_H + 10
-
-const AFOpenMMPipelineSchematic = () => {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
-
-  const colors: Record<
-    StepColor,
-    { fill: string; stroke: string; text: string }
-  > = {
-    blue: {
-      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
-      stroke: theme.palette.primary?.main ?? '#1976d2',
-      text: isDark ? '#e0f2fe' : '#1e3a5f'
-    },
-    green: {
-      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
-      stroke: theme.palette.success?.main ?? '#2e7d32',
-      text: isDark ? '#d1fae5' : '#14532d'
-    },
-    purple: {
-      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
-      stroke: theme.palette.secondary?.main ?? '#9c27b0',
-      text: isDark ? '#ede9fe' : '#3b0764'
-    }
-  }
-
-  const arrowColor = isDark ? '#94a3b8' : '#64748b'
-  const arrowHead = `M0,0 L6,3 L0,6 Z`
-
-  const renderBox = (step: Step, x: number, y: number, key: string) => {
-    const c = colors[step.color]
-    const lineH = 14
-    const totalTextH = step.lines.length * lineH
-    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
-    return (
-      <g key={key}>
-        <rect
-          x={x}
-          y={y}
-          width={BOX_W}
-          height={BOX_H}
-          rx={6}
-          fill={c.fill}
-          stroke={c.stroke}
-          strokeWidth={1.5}
-        />
-        {step.lines.map((line, i) => (
-          <text
-            key={i}
-            x={x + BOX_W / 2}
-            y={textStartY + i * lineH}
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
-            fill={c.text}
-            fontWeight={500}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    )
-  }
-
-  const renderArrow = (x1: number, y: number, key: string) => (
-    <g key={key}>
-      <line
-        x1={x1}
-        y1={y + BOX_H / 2}
-        x2={x1 + GAP - 6}
-        y2={y + BOX_H / 2}
-        stroke={arrowColor}
-        strokeWidth={1.5}
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
-  const wrapArrow = (
-    <g key="wrap">
-      <polyline
-        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
-        fill="none"
-        stroke={arrowColor}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  return (
-    <svg
-      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-      style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD AF pipeline schematic"
-    >
-      {ROW0.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r0-${i}`}>
-            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
-            {i < ROW0.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
-          </g>
-        )
-      })}
-      {wrapArrow}
-      {ROW1.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r1-${i}`}>
-            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
-            {i < ROW1.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
-          </g>
-        )
-      })}
-    </svg>
-  )
-}
+const AFOpenMMPipelineSchematic = () => (
+  <PipelineSchematicBase
+    row0={ROW0}
+    row1={ROW1}
+    ariaLabel="BilboMD AF pipeline schematic"
+  />
+)
 
 export default AFOpenMMPipelineSchematic

--- a/apps/ui/src/features/alphafoldjob/AFOpenMMPipelineSchematic.tsx
+++ b/apps/ui/src/features/alphafoldjob/AFOpenMMPipelineSchematic.tsx
@@ -1,0 +1,177 @@
+import { useTheme } from '@mui/material/styles'
+
+type StepColor = 'blue' | 'green' | 'purple'
+
+interface Step {
+  lines: string[]
+  color: StepColor
+}
+
+const ROW0: Step[] = [
+  { lines: ['AA Sequence', 'SAXS *.dat'], color: 'blue' },
+  { lines: ['AlphaFold2'], color: 'blue' },
+  { lines: ['Select Rank 1', ' prediction'], color: 'blue' },
+  { lines: ['PAE Analysis'], color: 'blue' },
+  { lines: ['OpenMM', 'Minimize'], color: 'green' },
+  { lines: ['OpenMM', 'Heat'], color: 'green' }
+]
+
+const ROW1: Step[] = [
+  { lines: ['OpenMM', 'Coarse Grained MD'], color: 'green' },
+  { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
+  { lines: ['FoXS'], color: 'purple' },
+  { lines: ['MultiFoXS'], color: 'purple' },
+  { lines: ['Gather Results'], color: 'blue' },
+  { lines: ['Notify'], color: 'blue' }
+]
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
+const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const AFOpenMMPipelineSchematic = () => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const colors: Record<
+    StepColor,
+    { fill: string; stroke: string; text: string }
+  > = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    purple: {
+      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
+      stroke: theme.palette.secondary?.main ?? '#9c27b0',
+      text: isDark ? '#ede9fe' : '#3b0764'
+    }
+  }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: Step, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label="BilboMD AF pipeline schematic"
+    >
+      {ROW0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < ROW0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {ROW1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < ROW1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default AFOpenMMPipelineSchematic

--- a/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
+++ b/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
@@ -39,6 +39,8 @@ import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import { useTheme } from '@mui/material/styles'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
+import AFOpenMMPipelineSchematic from './AFOpenMMPipelineSchematic'
+import AFCharmmPipelineSchematic from './AFCharmmPipelineSchematic'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -166,10 +168,8 @@ const Instructions = () => (
 )
 
 const PipelineSchematic = ({
-  isDarkMode,
   mdEngine
 }: {
-  isDarkMode: boolean
   mdEngine: 'charmm' | 'openmm'
 }) => (
   <Grid size={{ xs: 12 }}>
@@ -177,15 +177,11 @@ const PipelineSchematic = ({
       <Typography>BilboMD AF Schematic</Typography>
     </HeaderBox>
     <Paper sx={{ p: 2 }}>
-      <img
-        src={
-          isDarkMode
-            ? `/images/bilbomd-af-schematic-${mdEngine}-dark.png`
-            : `/images/bilbomd-af-schematic-${mdEngine}.png`
-        }
-        alt="Overview of BilboMD AF pipeline"
-        style={{ maxWidth: '100%', height: 'auto' }}
-      />
+      {mdEngine === 'openmm' ? (
+        <AFOpenMMPipelineSchematic />
+      ) : (
+        <AFCharmmPipelineSchematic />
+      )}
     </Paper>
   </Grid>
 )
@@ -448,10 +444,6 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
       ? 'BilboMD: New AlphaFold Job (anonymous)'
       : 'BilboMD: New AlphaFold Job'
   )
-  // theme and dark mode detection
-  const theme = useTheme()
-  const isDarkMode = theme.palette.mode === 'dark'
-
   const [
     addNewAlphaFoldJob,
     { isSuccess: isAuthSuccess, data: authJobResponse }
@@ -564,10 +556,7 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
       spacing={2}
     >
       <Instructions />
-      <PipelineSchematic
-        isDarkMode={isDarkMode}
-        mdEngine={mdEngine}
-      />
+      <PipelineSchematic mdEngine={mdEngine} />
       <Grid size={{ xs: 12 }}>
         <HeaderBox>
           <Typography>BilboMD AF Job Form</Typography>

--- a/apps/ui/src/features/autojob/AutoCharmmPipelineSchematic.tsx
+++ b/apps/ui/src/features/autojob/AutoCharmmPipelineSchematic.tsx
@@ -1,14 +1,12 @@
-import { useTheme } from '@mui/material/styles'
+import PipelineSchematicBase, {
+  PipelineStep
+} from 'features/shared/PipelineSchematicBase'
 
-type StepColor = 'blue' | 'green' | 'purple'
-
-interface Step {
-  lines: string[]
-  color: StepColor
-}
-
-const ROW0: Step[] = [
-  { lines: ['AlphaFold *.pdb', 'AlphaFold pae.json', 'SAXS *.dat'], color: 'blue' },
+const ROW0: PipelineStep[] = [
+  {
+    lines: ['AlphaFold *.pdb', 'AlphaFold pae.json', 'SAXS *.dat'],
+    color: 'blue'
+  },
   { lines: ['Convert to', '*.crd / *.psf'], color: 'blue' },
   { lines: ['PAE Analysis'], color: 'blue' },
   { lines: ['CHARMM', 'Minimize'], color: 'green' },
@@ -16,7 +14,7 @@ const ROW0: Step[] = [
   { lines: ['CHARMM', 'Coarse Grained MD'], color: 'green' }
 ]
 
-const ROW1: Step[] = [
+const ROW1: PipelineStep[] = [
   { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
   { lines: ['FoXS'], color: 'purple' },
   { lines: ['MultiFoXS'], color: 'purple' },
@@ -24,153 +22,12 @@ const ROW1: Step[] = [
   { lines: ['Notify'], color: 'blue' }
 ]
 
-const BOX_W = 110
-const BOX_H = 52
-const GAP = 28
-const LEFT_PAD = 26
-const RIGHT_PAD = 20
-const ROW_Y = [10, 90]
-
-const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
-const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
-const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
-const WRAP_LEFT_X = LEFT_PAD - 20
-const LEAD_IN = 20
-const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
-const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
-const WRAP_Y_MID =
-  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
-const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
-const SVG_H = ROW_Y[1] + BOX_H + 10
-
-const AutoCharmmPipelineSchematic = () => {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
-
-  const colors: Record<
-    StepColor,
-    { fill: string; stroke: string; text: string }
-  > = {
-    blue: {
-      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
-      stroke: theme.palette.primary?.main ?? '#1976d2',
-      text: isDark ? '#e0f2fe' : '#1e3a5f'
-    },
-    green: {
-      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
-      stroke: theme.palette.success?.main ?? '#2e7d32',
-      text: isDark ? '#d1fae5' : '#14532d'
-    },
-    purple: {
-      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
-      stroke: theme.palette.secondary?.main ?? '#9c27b0',
-      text: isDark ? '#ede9fe' : '#3b0764'
-    }
-  }
-
-  const arrowColor = isDark ? '#94a3b8' : '#64748b'
-  const arrowHead = `M0,0 L6,3 L0,6 Z`
-
-  const renderBox = (step: Step, x: number, y: number, key: string) => {
-    const c = colors[step.color]
-    const lineH = 14
-    const totalTextH = step.lines.length * lineH
-    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
-    return (
-      <g key={key}>
-        <rect
-          x={x}
-          y={y}
-          width={BOX_W}
-          height={BOX_H}
-          rx={6}
-          fill={c.fill}
-          stroke={c.stroke}
-          strokeWidth={1.5}
-        />
-        {step.lines.map((line, i) => (
-          <text
-            key={i}
-            x={x + BOX_W / 2}
-            y={textStartY + i * lineH}
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
-            fill={c.text}
-            fontWeight={500}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    )
-  }
-
-  const renderArrow = (x1: number, y: number, key: string) => (
-    <g key={key}>
-      <line
-        x1={x1}
-        y1={y + BOX_H / 2}
-        x2={x1 + GAP - 6}
-        y2={y + BOX_H / 2}
-        stroke={arrowColor}
-        strokeWidth={1.5}
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
-  const wrapArrow = (
-    <g key="wrap">
-      <polyline
-        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
-        fill="none"
-        stroke={arrowColor}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  return (
-    <svg
-      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-      style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD Auto CHARMM pipeline schematic"
-    >
-      {ROW0.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r0-${i}`}>
-            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
-            {i < ROW0.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
-          </g>
-        )
-      })}
-      {wrapArrow}
-      {ROW1.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r1-${i}`}>
-            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
-            {i < ROW1.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
-          </g>
-        )
-      })}
-    </svg>
-  )
-}
+const AutoCharmmPipelineSchematic = () => (
+  <PipelineSchematicBase
+    row0={ROW0}
+    row1={ROW1}
+    ariaLabel="BilboMD Auto CHARMM pipeline schematic"
+  />
+)
 
 export default AutoCharmmPipelineSchematic

--- a/apps/ui/src/features/autojob/AutoCharmmPipelineSchematic.tsx
+++ b/apps/ui/src/features/autojob/AutoCharmmPipelineSchematic.tsx
@@ -1,0 +1,176 @@
+import { useTheme } from '@mui/material/styles'
+
+type StepColor = 'blue' | 'green' | 'purple'
+
+interface Step {
+  lines: string[]
+  color: StepColor
+}
+
+const ROW0: Step[] = [
+  { lines: ['AlphaFold *.pdb', 'AlphaFold pae.json', 'SAXS *.dat'], color: 'blue' },
+  { lines: ['Convert to', '*.crd / *.psf'], color: 'blue' },
+  { lines: ['PAE Analysis'], color: 'blue' },
+  { lines: ['CHARMM', 'Minimize'], color: 'green' },
+  { lines: ['CHARMM', 'Heat'], color: 'green' },
+  { lines: ['CHARMM', 'Coarse Grained MD'], color: 'green' }
+]
+
+const ROW1: Step[] = [
+  { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
+  { lines: ['FoXS'], color: 'purple' },
+  { lines: ['MultiFoXS'], color: 'purple' },
+  { lines: ['Gather Results'], color: 'blue' },
+  { lines: ['Notify'], color: 'blue' }
+]
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
+const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const AutoCharmmPipelineSchematic = () => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const colors: Record<
+    StepColor,
+    { fill: string; stroke: string; text: string }
+  > = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    purple: {
+      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
+      stroke: theme.palette.secondary?.main ?? '#9c27b0',
+      text: isDark ? '#ede9fe' : '#3b0764'
+    }
+  }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: Step, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label="BilboMD Auto CHARMM pipeline schematic"
+    >
+      {ROW0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < ROW0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {ROW1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < ROW1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default AutoCharmmPipelineSchematic

--- a/apps/ui/src/features/autojob/AutoOpenMMPipelineSchematic.tsx
+++ b/apps/ui/src/features/autojob/AutoOpenMMPipelineSchematic.tsx
@@ -1,25 +1,19 @@
-import { useTheme } from '@mui/material/styles'
+import PipelineSchematicBase, {
+  PipelineStep
+} from 'features/shared/PipelineSchematicBase'
 
-type StepColor = 'blue' | 'green' | 'purple'
-
-interface Step {
-  lines: string[]
-  color: StepColor
-}
-
-const ROW0: Step[] = [
+const ROW0: PipelineStep[] = [
   {
     lines: ['AlphaFold *.pdb', 'AlphaFold pae.json', 'SAXS *.dat'],
     color: 'blue'
   },
-
   { lines: ['PAE Analysis'], color: 'blue' },
   { lines: ['OpenMM', 'Minimize'], color: 'green' },
   { lines: ['OpenMM', 'Heat'], color: 'green' },
   { lines: ['OpenMM', 'Coarse Grained MD'], color: 'green' }
 ]
 
-const ROW1: Step[] = [
+const ROW1: PipelineStep[] = [
   { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
   { lines: ['FoXS'], color: 'purple' },
   { lines: ['MultiFoXS'], color: 'purple' },
@@ -27,153 +21,12 @@ const ROW1: Step[] = [
   { lines: ['Notify'], color: 'blue' }
 ]
 
-const BOX_W = 110
-const BOX_H = 52
-const GAP = 28
-const LEFT_PAD = 26
-const RIGHT_PAD = 20
-const ROW_Y = [10, 90]
-
-const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
-const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
-const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
-const WRAP_LEFT_X = LEFT_PAD - 20
-const LEAD_IN = 20
-const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
-const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
-const WRAP_Y_MID =
-  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
-const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
-const SVG_H = ROW_Y[1] + BOX_H + 10
-
-const AutoOpenMMPipelineSchematic = () => {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
-
-  const colors: Record<
-    StepColor,
-    { fill: string; stroke: string; text: string }
-  > = {
-    blue: {
-      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
-      stroke: theme.palette.primary?.main ?? '#1976d2',
-      text: isDark ? '#e0f2fe' : '#1e3a5f'
-    },
-    green: {
-      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
-      stroke: theme.palette.success?.main ?? '#2e7d32',
-      text: isDark ? '#d1fae5' : '#14532d'
-    },
-    purple: {
-      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
-      stroke: theme.palette.secondary?.main ?? '#9c27b0',
-      text: isDark ? '#ede9fe' : '#3b0764'
-    }
-  }
-
-  const arrowColor = isDark ? '#94a3b8' : '#64748b'
-  const arrowHead = `M0,0 L6,3 L0,6 Z`
-
-  const renderBox = (step: Step, x: number, y: number, key: string) => {
-    const c = colors[step.color]
-    const lineH = 14
-    const totalTextH = step.lines.length * lineH
-    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
-    return (
-      <g key={key}>
-        <rect
-          x={x}
-          y={y}
-          width={BOX_W}
-          height={BOX_H}
-          rx={6}
-          fill={c.fill}
-          stroke={c.stroke}
-          strokeWidth={1.5}
-        />
-        {step.lines.map((line, i) => (
-          <text
-            key={i}
-            x={x + BOX_W / 2}
-            y={textStartY + i * lineH}
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
-            fill={c.text}
-            fontWeight={500}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    )
-  }
-
-  const renderArrow = (x1: number, y: number, key: string) => (
-    <g key={key}>
-      <line
-        x1={x1}
-        y1={y + BOX_H / 2}
-        x2={x1 + GAP - 6}
-        y2={y + BOX_H / 2}
-        stroke={arrowColor}
-        strokeWidth={1.5}
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
-  const wrapArrow = (
-    <g key="wrap">
-      <polyline
-        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
-        fill="none"
-        stroke={arrowColor}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  return (
-    <svg
-      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-      style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD Auto pipeline schematic"
-    >
-      {ROW0.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r0-${i}`}>
-            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
-            {i < ROW0.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
-          </g>
-        )
-      })}
-      {wrapArrow}
-      {ROW1.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r1-${i}`}>
-            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
-            {i < ROW1.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
-          </g>
-        )
-      })}
-    </svg>
-  )
-}
+const AutoOpenMMPipelineSchematic = () => (
+  <PipelineSchematicBase
+    row0={ROW0}
+    row1={ROW1}
+    ariaLabel="BilboMD Auto pipeline schematic"
+  />
+)
 
 export default AutoOpenMMPipelineSchematic

--- a/apps/ui/src/features/autojob/AutoOpenMMPipelineSchematic.tsx
+++ b/apps/ui/src/features/autojob/AutoOpenMMPipelineSchematic.tsx
@@ -1,0 +1,179 @@
+import { useTheme } from '@mui/material/styles'
+
+type StepColor = 'blue' | 'green' | 'purple'
+
+interface Step {
+  lines: string[]
+  color: StepColor
+}
+
+const ROW0: Step[] = [
+  {
+    lines: ['AlphaFold *.pdb', 'AlphaFold pae.json', 'SAXS *.dat'],
+    color: 'blue'
+  },
+
+  { lines: ['PAE Analysis'], color: 'blue' },
+  { lines: ['OpenMM', 'Minimize'], color: 'green' },
+  { lines: ['OpenMM', 'Heat'], color: 'green' },
+  { lines: ['OpenMM', 'Coarse Grained MD'], color: 'green' }
+]
+
+const ROW1: Step[] = [
+  { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
+  { lines: ['FoXS'], color: 'purple' },
+  { lines: ['MultiFoXS'], color: 'purple' },
+  { lines: ['Gather Results'], color: 'blue' },
+  { lines: ['Notify'], color: 'blue' }
+]
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
+const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const AutoOpenMMPipelineSchematic = () => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const colors: Record<
+    StepColor,
+    { fill: string; stroke: string; text: string }
+  > = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    purple: {
+      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
+      stroke: theme.palette.secondary?.main ?? '#9c27b0',
+      text: isDark ? '#ede9fe' : '#3b0764'
+    }
+  }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: Step, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label="BilboMD Auto OpenMM pipeline schematic"
+    >
+      {ROW0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < ROW0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {ROW1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < ROW1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default AutoOpenMMPipelineSchematic

--- a/apps/ui/src/features/autojob/AutoOpenMMPipelineSchematic.tsx
+++ b/apps/ui/src/features/autojob/AutoOpenMMPipelineSchematic.tsx
@@ -149,7 +149,7 @@ const AutoOpenMMPipelineSchematic = () => {
     <svg
       viewBox={`0 0 ${SVG_W} ${SVG_H}`}
       style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD Auto OpenMM pipeline schematic"
+      aria-label="BilboMD Auto pipeline schematic"
     >
       {ROW0.map((step, i) => {
         const x = boxX(i)

--- a/apps/ui/src/features/autojob/PipelineSchematic.tsx
+++ b/apps/ui/src/features/autojob/PipelineSchematic.tsx
@@ -1,12 +1,13 @@
 import { Typography, Paper } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import HeaderBox from 'components/HeaderBox'
+import AutoOpenMMPipelineSchematic from './AutoOpenMMPipelineSchematic'
+import AutoCharmmPipelineSchematic from './AutoCharmmPipelineSchematic'
 
 const PipelineSchematic = ({
-  isDarkMode,
   mdEngine
 }: {
-  isDarkMode: boolean
+  isDarkMode?: boolean
   mdEngine: 'charmm' | 'openmm'
 }) => (
   <Grid size={{ xs: 12 }}>
@@ -14,15 +15,11 @@ const PipelineSchematic = ({
       <Typography>BilboMD Auto Schematic</Typography>
     </HeaderBox>
     <Paper sx={{ p: 2 }}>
-      <img
-        src={
-          isDarkMode
-            ? `/images/bilbomd-auto-schematic-${mdEngine}-dark.png`
-            : `/images/bilbomd-auto-schematic-${mdEngine}.png`
-        }
-        alt="Overview of BilboMD AF pipeline"
-        style={{ maxWidth: '100%', height: 'auto' }}
-      />
+      {mdEngine === 'openmm' ? (
+        <AutoOpenMMPipelineSchematic />
+      ) : (
+        <AutoCharmmPipelineSchematic />
+      )}
     </Paper>
   </Grid>
 )

--- a/apps/ui/src/features/help/Help.tsx
+++ b/apps/ui/src/features/help/Help.tsx
@@ -16,6 +16,7 @@ import { Grid } from '@mui/system'
 import { blue } from '@mui/material/colors'
 import { useTheme } from '@mui/material/styles'
 import BilboMDBibTeX from 'components/Common/BilboMDBibTeX'
+import AFOpenMMPipelineSchematic from 'features/alphafoldjob/AFOpenMMPipelineSchematic'
 
 const Help = ({ title = 'BilboMD: Help' }) => {
   useTitle(title)
@@ -217,13 +218,7 @@ const Help = ({ title = 'BilboMD: Help' }) => {
                     style={{ width: '100%' }}
                   />
                 )}
-                {tabValue === 3 && (
-                  <img
-                    src={`/images/bilbomd-af-schematic-openmm${theme.palette.mode === 'dark' ? '-dark' : ''}.png`}
-                    alt="BilboMD AF Schematic"
-                    style={{ width: '100%' }}
-                  />
-                )}
+                {tabValue === 3 && <AFOpenMMPipelineSchematic />}
               </Box>
             </Box>
           </Box>

--- a/apps/ui/src/features/help/Help.tsx
+++ b/apps/ui/src/features/help/Help.tsx
@@ -20,6 +20,7 @@ import AFOpenMMPipelineSchematic from 'features/alphafoldjob/AFOpenMMPipelineSch
 import ClassicPDBOpenMMPipelineSchematic from 'features/jobs/ClassicPDBOpenMMPipelineSchematic'
 import ClassicCRDPipelineSchematic from 'features/jobs/ClassicCRDPipelineSchematic'
 import AutoOpenMMPipelineSchematic from 'features/autojob/AutoOpenMMPipelineSchematic'
+import OF3OpenMMPipelineSchematic from 'features/openfoldjob/OF3OpenMMPipelineSchematic'
 
 const Help = ({ title = 'BilboMD: Help' }) => {
   useTitle(title)
@@ -81,8 +82,7 @@ const Help = ({ title = 'BilboMD: Help' }) => {
             variant="body2"
             sx={{ mx: 5, my: 2 }}
           >
-            Classen S, Del Mundo J, Kulkarni D, Prabhakar S, Hicks A, Hammel
-            M.{' '}
+            Classen S, Del Mundo J, Kulkarni D, Prabhakar S, Hicks A, Hammel M.{' '}
             <b>
               BilboMD: a web-accessible SAXS and AlphaFold-guided modeling
               pipeline.
@@ -168,8 +168,23 @@ const Help = ({ title = 'BilboMD: Help' }) => {
                   }}
                 >
                   <ListItemText
-                    primary="BilboMD AF (Alphafold)"
+                    primary="BilboMD AF (Alphafold2)"
                     secondary='This pipeline runs Alphafold2 on your input sequence. The "best" Alphafold model and PAE matrix are used as starting structures and to define flexible regions for the MD steps.'
+                  />
+                </ListItem>
+                <ListItem
+                  sx={{
+                    backgroundColor:
+                      tabValue === 4
+                        ? theme.palette.mode === 'dark'
+                          ? blue[700]
+                          : blue[100]
+                        : 'transparent'
+                  }}
+                >
+                  <ListItemText
+                    primary="BilboMD OF3 (OpenFold3)"
+                    secondary='This pipeline runs OpenFold3 on your input sequence. The "best" predicted model and PAE matrix are used as starting structures and to define flexible regions for the MD steps.'
                   />
                 </ListItem>
                 <ListItem>
@@ -197,6 +212,7 @@ const Help = ({ title = 'BilboMD: Help' }) => {
                   <Tab label="Classic CRD" />
                   <Tab label="Auto" />
                   <Tab label="AF" />
+                  <Tab label="OF3" />
                 </Tabs>
               </Box>
               <Box sx={{ mt: 2 }}>
@@ -204,6 +220,7 @@ const Help = ({ title = 'BilboMD: Help' }) => {
                 {tabValue === 1 && <ClassicCRDPipelineSchematic />}
                 {tabValue === 2 && <AutoOpenMMPipelineSchematic />}
                 {tabValue === 3 && <AFOpenMMPipelineSchematic />}
+                {tabValue === 4 && <OF3OpenMMPipelineSchematic />}
               </Box>
             </Box>
           </Box>

--- a/apps/ui/src/features/help/Help.tsx
+++ b/apps/ui/src/features/help/Help.tsx
@@ -17,6 +17,9 @@ import { blue } from '@mui/material/colors'
 import { useTheme } from '@mui/material/styles'
 import BilboMDBibTeX from 'components/Common/BilboMDBibTeX'
 import AFOpenMMPipelineSchematic from 'features/alphafoldjob/AFOpenMMPipelineSchematic'
+import ClassicPDBOpenMMPipelineSchematic from 'features/jobs/ClassicPDBOpenMMPipelineSchematic'
+import ClassicCRDPipelineSchematic from 'features/jobs/ClassicCRDPipelineSchematic'
+import AutoOpenMMPipelineSchematic from 'features/autojob/AutoOpenMMPipelineSchematic'
 
 const Help = ({ title = 'BilboMD: Help' }) => {
   useTitle(title)
@@ -197,27 +200,9 @@ const Help = ({ title = 'BilboMD: Help' }) => {
                 </Tabs>
               </Box>
               <Box sx={{ mt: 2 }}>
-                {tabValue === 0 && (
-                  <img
-                    src={`/images/bilbomd-classic-pdb-schematic-openmm${theme.palette.mode === 'dark' ? '-dark' : ''}.png`}
-                    alt="BilboMD Classic PDB Schematic"
-                    style={{ width: '100%' }}
-                  />
-                )}
-                {tabValue === 1 && (
-                  <img
-                    src={`/images/bilbomd-classic-crd-schematic${theme.palette.mode === 'dark' ? '-dark' : ''}.png`}
-                    alt="BilboMD Classic CRD Schematic"
-                    style={{ width: '100%' }}
-                  />
-                )}
-                {tabValue === 2 && (
-                  <img
-                    src={`/images/bilbomd-auto-schematic-openmm${theme.palette.mode === 'dark' ? '-dark' : ''}.png`}
-                    alt="BilboMD Auto Schematic"
-                    style={{ width: '100%' }}
-                  />
-                )}
+                {tabValue === 0 && <ClassicPDBOpenMMPipelineSchematic />}
+                {tabValue === 1 && <ClassicCRDPipelineSchematic />}
+                {tabValue === 2 && <AutoOpenMMPipelineSchematic />}
                 {tabValue === 3 && <AFOpenMMPipelineSchematic />}
               </Box>
             </Box>

--- a/apps/ui/src/features/jobs/ClassicCRDPipelineSchematic.tsx
+++ b/apps/ui/src/features/jobs/ClassicCRDPipelineSchematic.tsx
@@ -1,0 +1,174 @@
+import { useTheme } from '@mui/material/styles'
+
+type StepColor = 'blue' | 'green' | 'purple'
+
+interface Step {
+  lines: string[]
+  color: StepColor
+}
+
+const ROW0: Step[] = [
+  { lines: ['*.crd & *.psf', 'const.inp', 'SAXS *.dat'], color: 'blue' },
+  { lines: ['CHARMM', 'Minimize'], color: 'green' },
+  { lines: ['CHARMM', 'Heat'], color: 'green' },
+  { lines: ['CHARMM', 'Coarse Grained MD'], color: 'green' },
+  { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' }
+]
+
+const ROW1: Step[] = [
+  { lines: ['FoXS'], color: 'purple' },
+  { lines: ['MultiFoXS'], color: 'purple' },
+  { lines: ['Gather Results'], color: 'blue' },
+  { lines: ['Notify'], color: 'blue' }
+]
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
+const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const ClassicCRDPipelineSchematic = () => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const colors: Record<
+    StepColor,
+    { fill: string; stroke: string; text: string }
+  > = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    purple: {
+      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
+      stroke: theme.palette.secondary?.main ?? '#9c27b0',
+      text: isDark ? '#ede9fe' : '#3b0764'
+    }
+  }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: Step, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label="BilboMD Classic CRD pipeline schematic"
+    >
+      {ROW0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < ROW0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {ROW1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < ROW1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default ClassicCRDPipelineSchematic

--- a/apps/ui/src/features/jobs/ClassicCRDPipelineSchematic.tsx
+++ b/apps/ui/src/features/jobs/ClassicCRDPipelineSchematic.tsx
@@ -1,13 +1,8 @@
-import { useTheme } from '@mui/material/styles'
+import PipelineSchematicBase, {
+  PipelineStep
+} from 'features/shared/PipelineSchematicBase'
 
-type StepColor = 'blue' | 'green' | 'purple'
-
-interface Step {
-  lines: string[]
-  color: StepColor
-}
-
-const ROW0: Step[] = [
+const ROW0: PipelineStep[] = [
   { lines: ['*.crd & *.psf', 'const.inp', 'SAXS *.dat'], color: 'blue' },
   { lines: ['CHARMM', 'Minimize'], color: 'green' },
   { lines: ['CHARMM', 'Heat'], color: 'green' },
@@ -15,160 +10,19 @@ const ROW0: Step[] = [
   { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' }
 ]
 
-const ROW1: Step[] = [
+const ROW1: PipelineStep[] = [
   { lines: ['FoXS'], color: 'purple' },
   { lines: ['MultiFoXS'], color: 'purple' },
   { lines: ['Gather Results'], color: 'blue' },
   { lines: ['Notify'], color: 'blue' }
 ]
 
-const BOX_W = 110
-const BOX_H = 52
-const GAP = 28
-const LEFT_PAD = 26
-const RIGHT_PAD = 20
-const ROW_Y = [10, 90]
-
-const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
-const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
-const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
-const WRAP_LEFT_X = LEFT_PAD - 20
-const LEAD_IN = 20
-const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
-const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
-const WRAP_Y_MID =
-  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
-const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
-const SVG_H = ROW_Y[1] + BOX_H + 10
-
-const ClassicCRDPipelineSchematic = () => {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
-
-  const colors: Record<
-    StepColor,
-    { fill: string; stroke: string; text: string }
-  > = {
-    blue: {
-      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
-      stroke: theme.palette.primary?.main ?? '#1976d2',
-      text: isDark ? '#e0f2fe' : '#1e3a5f'
-    },
-    green: {
-      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
-      stroke: theme.palette.success?.main ?? '#2e7d32',
-      text: isDark ? '#d1fae5' : '#14532d'
-    },
-    purple: {
-      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
-      stroke: theme.palette.secondary?.main ?? '#9c27b0',
-      text: isDark ? '#ede9fe' : '#3b0764'
-    }
-  }
-
-  const arrowColor = isDark ? '#94a3b8' : '#64748b'
-  const arrowHead = `M0,0 L6,3 L0,6 Z`
-
-  const renderBox = (step: Step, x: number, y: number, key: string) => {
-    const c = colors[step.color]
-    const lineH = 14
-    const totalTextH = step.lines.length * lineH
-    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
-    return (
-      <g key={key}>
-        <rect
-          x={x}
-          y={y}
-          width={BOX_W}
-          height={BOX_H}
-          rx={6}
-          fill={c.fill}
-          stroke={c.stroke}
-          strokeWidth={1.5}
-        />
-        {step.lines.map((line, i) => (
-          <text
-            key={i}
-            x={x + BOX_W / 2}
-            y={textStartY + i * lineH}
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
-            fill={c.text}
-            fontWeight={500}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    )
-  }
-
-  const renderArrow = (x1: number, y: number, key: string) => (
-    <g key={key}>
-      <line
-        x1={x1}
-        y1={y + BOX_H / 2}
-        x2={x1 + GAP - 6}
-        y2={y + BOX_H / 2}
-        stroke={arrowColor}
-        strokeWidth={1.5}
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
-  const wrapArrow = (
-    <g key="wrap">
-      <polyline
-        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
-        fill="none"
-        stroke={arrowColor}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  return (
-    <svg
-      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-      style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD Classic CRD pipeline schematic"
-    >
-      {ROW0.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r0-${i}`}>
-            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
-            {i < ROW0.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
-          </g>
-        )
-      })}
-      {wrapArrow}
-      {ROW1.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r1-${i}`}>
-            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
-            {i < ROW1.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
-          </g>
-        )
-      })}
-    </svg>
-  )
-}
+const ClassicCRDPipelineSchematic = () => (
+  <PipelineSchematicBase
+    row0={ROW0}
+    row1={ROW1}
+    ariaLabel="BilboMD Classic CRD pipeline schematic"
+  />
+)
 
 export default ClassicCRDPipelineSchematic

--- a/apps/ui/src/features/jobs/ClassicPDBCharmmPipelineSchematic.tsx
+++ b/apps/ui/src/features/jobs/ClassicPDBCharmmPipelineSchematic.tsx
@@ -1,0 +1,175 @@
+import { useTheme } from '@mui/material/styles'
+
+type StepColor = 'blue' | 'green' | 'purple'
+
+interface Step {
+  lines: string[]
+  color: StepColor
+}
+
+const ROW0: Step[] = [
+  { lines: ['*.pdb / *.cif', ' const.inp', 'SAXS *.dat'], color: 'blue' },
+  { lines: ['Convert to', '*.crd / *.psf'], color: 'blue' },
+  { lines: ['CHARMM', 'Minimize'], color: 'green' },
+  { lines: ['CHARMM', 'Heat'], color: 'green' },
+  { lines: ['CHARMM', 'Coarse Grained MD'], color: 'green' },
+  { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' }
+]
+
+const ROW1: Step[] = [
+  { lines: ['FoXS'], color: 'purple' },
+  { lines: ['MultiFoXS'], color: 'purple' },
+  { lines: ['Gather Results'], color: 'blue' },
+  { lines: ['Notify'], color: 'blue' }
+]
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
+const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const ClassicPDBCharmmPipelineSchematic = () => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const colors: Record<
+    StepColor,
+    { fill: string; stroke: string; text: string }
+  > = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    purple: {
+      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
+      stroke: theme.palette.secondary?.main ?? '#9c27b0',
+      text: isDark ? '#ede9fe' : '#3b0764'
+    }
+  }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: Step, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label="BilboMD Classic PDB CHARMM pipeline schematic"
+    >
+      {ROW0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < ROW0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {ROW1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < ROW1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default ClassicPDBCharmmPipelineSchematic

--- a/apps/ui/src/features/jobs/ClassicPDBCharmmPipelineSchematic.tsx
+++ b/apps/ui/src/features/jobs/ClassicPDBCharmmPipelineSchematic.tsx
@@ -1,13 +1,8 @@
-import { useTheme } from '@mui/material/styles'
+import PipelineSchematicBase, {
+  PipelineStep
+} from 'features/shared/PipelineSchematicBase'
 
-type StepColor = 'blue' | 'green' | 'purple'
-
-interface Step {
-  lines: string[]
-  color: StepColor
-}
-
-const ROW0: Step[] = [
+const ROW0: PipelineStep[] = [
   { lines: ['*.pdb / *.cif', ' const.inp', 'SAXS *.dat'], color: 'blue' },
   { lines: ['Convert to', '*.crd / *.psf'], color: 'blue' },
   { lines: ['CHARMM', 'Minimize'], color: 'green' },
@@ -16,160 +11,19 @@ const ROW0: Step[] = [
   { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' }
 ]
 
-const ROW1: Step[] = [
+const ROW1: PipelineStep[] = [
   { lines: ['FoXS'], color: 'purple' },
   { lines: ['MultiFoXS'], color: 'purple' },
   { lines: ['Gather Results'], color: 'blue' },
   { lines: ['Notify'], color: 'blue' }
 ]
 
-const BOX_W = 110
-const BOX_H = 52
-const GAP = 28
-const LEFT_PAD = 26
-const RIGHT_PAD = 20
-const ROW_Y = [10, 90]
-
-const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
-const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
-const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
-const WRAP_LEFT_X = LEFT_PAD - 20
-const LEAD_IN = 20
-const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
-const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
-const WRAP_Y_MID =
-  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
-const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
-const SVG_H = ROW_Y[1] + BOX_H + 10
-
-const ClassicPDBCharmmPipelineSchematic = () => {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
-
-  const colors: Record<
-    StepColor,
-    { fill: string; stroke: string; text: string }
-  > = {
-    blue: {
-      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
-      stroke: theme.palette.primary?.main ?? '#1976d2',
-      text: isDark ? '#e0f2fe' : '#1e3a5f'
-    },
-    green: {
-      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
-      stroke: theme.palette.success?.main ?? '#2e7d32',
-      text: isDark ? '#d1fae5' : '#14532d'
-    },
-    purple: {
-      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
-      stroke: theme.palette.secondary?.main ?? '#9c27b0',
-      text: isDark ? '#ede9fe' : '#3b0764'
-    }
-  }
-
-  const arrowColor = isDark ? '#94a3b8' : '#64748b'
-  const arrowHead = `M0,0 L6,3 L0,6 Z`
-
-  const renderBox = (step: Step, x: number, y: number, key: string) => {
-    const c = colors[step.color]
-    const lineH = 14
-    const totalTextH = step.lines.length * lineH
-    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
-    return (
-      <g key={key}>
-        <rect
-          x={x}
-          y={y}
-          width={BOX_W}
-          height={BOX_H}
-          rx={6}
-          fill={c.fill}
-          stroke={c.stroke}
-          strokeWidth={1.5}
-        />
-        {step.lines.map((line, i) => (
-          <text
-            key={i}
-            x={x + BOX_W / 2}
-            y={textStartY + i * lineH}
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
-            fill={c.text}
-            fontWeight={500}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    )
-  }
-
-  const renderArrow = (x1: number, y: number, key: string) => (
-    <g key={key}>
-      <line
-        x1={x1}
-        y1={y + BOX_H / 2}
-        x2={x1 + GAP - 6}
-        y2={y + BOX_H / 2}
-        stroke={arrowColor}
-        strokeWidth={1.5}
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
-  const wrapArrow = (
-    <g key="wrap">
-      <polyline
-        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
-        fill="none"
-        stroke={arrowColor}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  return (
-    <svg
-      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-      style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD Classic PDB CHARMM pipeline schematic"
-    >
-      {ROW0.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r0-${i}`}>
-            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
-            {i < ROW0.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
-          </g>
-        )
-      })}
-      {wrapArrow}
-      {ROW1.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r1-${i}`}>
-            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
-            {i < ROW1.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
-          </g>
-        )
-      })}
-    </svg>
-  )
-}
+const ClassicPDBCharmmPipelineSchematic = () => (
+  <PipelineSchematicBase
+    row0={ROW0}
+    row1={ROW1}
+    ariaLabel="BilboMD Classic PDB CHARMM pipeline schematic"
+  />
+)
 
 export default ClassicPDBCharmmPipelineSchematic

--- a/apps/ui/src/features/jobs/ClassicPDBOpenMMPipelineSchematic.tsx
+++ b/apps/ui/src/features/jobs/ClassicPDBOpenMMPipelineSchematic.tsx
@@ -1,0 +1,174 @@
+import { useTheme } from '@mui/material/styles'
+
+type StepColor = 'blue' | 'green' | 'purple'
+
+interface Step {
+  lines: string[]
+  color: StepColor
+}
+
+const ROW0: Step[] = [
+  { lines: ['*.pdb / *.cif', ' const.inp', 'SAXS *.dat'], color: 'blue' },
+  { lines: ['OpenMM', 'Minimize'], color: 'green' },
+  { lines: ['OpenMM', 'Heat'], color: 'green' },
+  { lines: ['OpenMM', 'Coarse Grained MD'], color: 'green' },
+  { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' }
+]
+
+const ROW1: Step[] = [
+  { lines: ['FoXS'], color: 'purple' },
+  { lines: ['MultiFoXS'], color: 'purple' },
+  { lines: ['Gather Results'], color: 'blue' },
+  { lines: ['Notify'], color: 'blue' }
+]
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
+const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const ClassicPDBOpenMMPipelineSchematic = () => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const colors: Record<
+    StepColor,
+    { fill: string; stroke: string; text: string }
+  > = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    purple: {
+      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
+      stroke: theme.palette.secondary?.main ?? '#9c27b0',
+      text: isDark ? '#ede9fe' : '#3b0764'
+    }
+  }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: Step, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label="BilboMD Classic PDB pipeline schematic"
+    >
+      {ROW0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < ROW0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {ROW1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < ROW1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default ClassicPDBOpenMMPipelineSchematic

--- a/apps/ui/src/features/jobs/ClassicPDBOpenMMPipelineSchematic.tsx
+++ b/apps/ui/src/features/jobs/ClassicPDBOpenMMPipelineSchematic.tsx
@@ -1,13 +1,8 @@
-import { useTheme } from '@mui/material/styles'
+import PipelineSchematicBase, {
+  PipelineStep
+} from 'features/shared/PipelineSchematicBase'
 
-type StepColor = 'blue' | 'green' | 'purple'
-
-interface Step {
-  lines: string[]
-  color: StepColor
-}
-
-const ROW0: Step[] = [
+const ROW0: PipelineStep[] = [
   { lines: ['*.pdb / *.cif', ' const.inp', 'SAXS *.dat'], color: 'blue' },
   { lines: ['OpenMM', 'Minimize'], color: 'green' },
   { lines: ['OpenMM', 'Heat'], color: 'green' },
@@ -15,160 +10,19 @@ const ROW0: Step[] = [
   { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' }
 ]
 
-const ROW1: Step[] = [
+const ROW1: PipelineStep[] = [
   { lines: ['FoXS'], color: 'purple' },
   { lines: ['MultiFoXS'], color: 'purple' },
   { lines: ['Gather Results'], color: 'blue' },
   { lines: ['Notify'], color: 'blue' }
 ]
 
-const BOX_W = 110
-const BOX_H = 52
-const GAP = 28
-const LEFT_PAD = 26
-const RIGHT_PAD = 20
-const ROW_Y = [10, 90]
-
-const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
-const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
-const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
-const WRAP_LEFT_X = LEFT_PAD - 20
-const LEAD_IN = 20
-const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
-const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
-const WRAP_Y_MID =
-  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
-const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
-const SVG_H = ROW_Y[1] + BOX_H + 10
-
-const ClassicPDBOpenMMPipelineSchematic = () => {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
-
-  const colors: Record<
-    StepColor,
-    { fill: string; stroke: string; text: string }
-  > = {
-    blue: {
-      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
-      stroke: theme.palette.primary?.main ?? '#1976d2',
-      text: isDark ? '#e0f2fe' : '#1e3a5f'
-    },
-    green: {
-      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
-      stroke: theme.palette.success?.main ?? '#2e7d32',
-      text: isDark ? '#d1fae5' : '#14532d'
-    },
-    purple: {
-      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
-      stroke: theme.palette.secondary?.main ?? '#9c27b0',
-      text: isDark ? '#ede9fe' : '#3b0764'
-    }
-  }
-
-  const arrowColor = isDark ? '#94a3b8' : '#64748b'
-  const arrowHead = `M0,0 L6,3 L0,6 Z`
-
-  const renderBox = (step: Step, x: number, y: number, key: string) => {
-    const c = colors[step.color]
-    const lineH = 14
-    const totalTextH = step.lines.length * lineH
-    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
-    return (
-      <g key={key}>
-        <rect
-          x={x}
-          y={y}
-          width={BOX_W}
-          height={BOX_H}
-          rx={6}
-          fill={c.fill}
-          stroke={c.stroke}
-          strokeWidth={1.5}
-        />
-        {step.lines.map((line, i) => (
-          <text
-            key={i}
-            x={x + BOX_W / 2}
-            y={textStartY + i * lineH}
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
-            fill={c.text}
-            fontWeight={500}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    )
-  }
-
-  const renderArrow = (x1: number, y: number, key: string) => (
-    <g key={key}>
-      <line
-        x1={x1}
-        y1={y + BOX_H / 2}
-        x2={x1 + GAP - 6}
-        y2={y + BOX_H / 2}
-        stroke={arrowColor}
-        strokeWidth={1.5}
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
-  const wrapArrow = (
-    <g key="wrap">
-      <polyline
-        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
-        fill="none"
-        stroke={arrowColor}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  return (
-    <svg
-      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-      style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD Classic PDB pipeline schematic"
-    >
-      {ROW0.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r0-${i}`}>
-            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
-            {i < ROW0.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
-          </g>
-        )
-      })}
-      {wrapArrow}
-      {ROW1.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r1-${i}`}>
-            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
-            {i < ROW1.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
-          </g>
-        )
-      })}
-    </svg>
-  )
-}
+const ClassicPDBOpenMMPipelineSchematic = () => (
+  <PipelineSchematicBase
+    row0={ROW0}
+    row1={ROW1}
+    ariaLabel="BilboMD Classic PDB pipeline schematic"
+  />
+)
 
 export default ClassicPDBOpenMMPipelineSchematic

--- a/apps/ui/src/features/jobs/PipelineSchematic.tsx
+++ b/apps/ui/src/features/jobs/PipelineSchematic.tsx
@@ -1,37 +1,20 @@
 import { Typography, Paper } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import HeaderBox from 'components/HeaderBox'
+import ClassicPDBOpenMMPipelineSchematic from './ClassicPDBOpenMMPipelineSchematic'
+import ClassicPDBCharmmPipelineSchematic from './ClassicPDBCharmmPipelineSchematic'
+import ClassicCRDPipelineSchematic from './ClassicCRDPipelineSchematic'
 
 const PipelineSchematic = ({
-  isDarkMode,
   pipeline,
   mdEngine
 }: {
-  isDarkMode: boolean
+  isDarkMode?: boolean
   pipeline: string
   mdEngine: 'charmm' | 'openmm'
 }) => {
   // Safeguard: CRD/PSF is only compatible with CHARMM
   const effectiveMdEngine = pipeline === 'crd_psf' ? 'charmm' : mdEngine
-
-  const getSchematicPath = (): string => {
-    const baseTheme = isDarkMode ? '-dark' : ''
-
-    if (pipeline === 'pdb') {
-      return `/images/bilbomd-classic-pdb-schematic-${effectiveMdEngine}${baseTheme}.png`
-    } else {
-      // CRD/PSF pipeline always uses CHARMM
-      return `/images/bilbomd-classic-crd-schematic${baseTheme}.png`
-    }
-  }
-
-  const getAltText = (): string => {
-    if (pipeline === 'pdb') {
-      return `Overview of BilboMD PDB pipeline using ${effectiveMdEngine.toUpperCase()}`
-    } else {
-      return 'Overview of BilboMD CRD/PSF pipeline using CHARMM'
-    }
-  }
 
   return (
     <Grid size={{ xs: 12 }}>
@@ -44,11 +27,13 @@ const PipelineSchematic = ({
         </Typography>
       </HeaderBox>
       <Paper sx={{ p: 2 }}>
-        <img
-          src={getSchematicPath()}
-          alt={getAltText()}
-          style={{ maxWidth: '100%', height: 'auto' }}
-        />
+        {pipeline === 'pdb' && effectiveMdEngine === 'openmm' ? (
+          <ClassicPDBOpenMMPipelineSchematic />
+        ) : pipeline === 'pdb' && effectiveMdEngine === 'charmm' ? (
+          <ClassicPDBCharmmPipelineSchematic />
+        ) : (
+          <ClassicCRDPipelineSchematic />
+        )}
       </Paper>
     </Grid>
   )

--- a/apps/ui/src/features/openfoldjob/NewOpenFoldJobForm.tsx
+++ b/apps/ui/src/features/openfoldjob/NewOpenFoldJobForm.tsx
@@ -41,6 +41,7 @@ import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import { useTheme } from '@mui/material/styles'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
+import OF3OpenMMPipelineSchematic from './OF3OpenMMPipelineSchematic'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -164,21 +165,13 @@ const Instructions = () => (
   </Grid>
 )
 
-const PipelineSchematic = ({ isDarkMode }: { isDarkMode: boolean }) => (
+const PipelineSchematic = () => (
   <Grid size={{ xs: 12 }}>
     <HeaderBox>
       <Typography>BilboMD OF3 Schematic</Typography>
     </HeaderBox>
     <Paper sx={{ p: 2 }}>
-      <img
-        src={
-          isDarkMode
-            ? '/images/bilbomd-of3-schematic-openmm-dark.png'
-            : '/images/bilbomd-of3-schematic-openmm.png'
-        }
-        alt="Overview of BilboMD OF3 pipeline"
-        style={{ maxWidth: '100%', height: 'auto' }}
-      />
+      <OF3OpenMMPipelineSchematic />
     </Paper>
   </Grid>
 )
@@ -437,9 +430,6 @@ const NewOpenFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
       ? 'BilboMD: New OpenFold3 Job (anonymous)'
       : 'BilboMD: New OpenFold3 Job'
   )
-  const theme = useTheme()
-  const isDarkMode = theme.palette.mode === 'dark'
-
   const [
     addNewOpenFoldJob,
     { isSuccess: isAuthSuccess, data: authJobResponse }
@@ -539,7 +529,7 @@ const NewOpenFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
       spacing={2}
     >
       <Instructions />
-      <PipelineSchematic isDarkMode={isDarkMode} />
+      <PipelineSchematic />
       <Grid size={{ xs: 12 }}>
         <HeaderBox>
           <Typography>BilboMD OF3 Job Form</Typography>

--- a/apps/ui/src/features/openfoldjob/OF3OpenMMPipelineSchematic.tsx
+++ b/apps/ui/src/features/openfoldjob/OF3OpenMMPipelineSchematic.tsx
@@ -1,0 +1,177 @@
+import { useTheme } from '@mui/material/styles'
+
+type StepColor = 'blue' | 'green' | 'purple'
+
+interface Step {
+  lines: string[]
+  color: StepColor
+}
+
+const ROW0: Step[] = [
+  { lines: ['AA Sequence', 'SAXS *.dat'], color: 'blue' },
+  { lines: ['OpenFold3'], color: 'blue' },
+  { lines: ['Select Rank 1', 'prediction'], color: 'blue' },
+  { lines: ['PAE Analysis'], color: 'blue' },
+  { lines: ['OpenMM', 'Minimize'], color: 'green' },
+  { lines: ['OpenMM', 'Heat'], color: 'green' }
+]
+
+const ROW1: Step[] = [
+  { lines: ['OpenMM', 'Coarse Grained MD'], color: 'green' },
+  { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
+  { lines: ['FoXS'], color: 'purple' },
+  { lines: ['MultiFoXS'], color: 'purple' },
+  { lines: ['Gather Results'], color: 'blue' },
+  { lines: ['Notify'], color: 'blue' }
+]
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
+const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const OF3OpenMMPipelineSchematic = () => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const colors: Record<
+    StepColor,
+    { fill: string; stroke: string; text: string }
+  > = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    purple: {
+      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
+      stroke: theme.palette.secondary?.main ?? '#9c27b0',
+      text: isDark ? '#ede9fe' : '#3b0764'
+    }
+  }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: Step, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label="BilboMD OF3 pipeline schematic"
+    >
+      {ROW0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < ROW0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {ROW1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < ROW1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default OF3OpenMMPipelineSchematic

--- a/apps/ui/src/features/openfoldjob/OF3OpenMMPipelineSchematic.tsx
+++ b/apps/ui/src/features/openfoldjob/OF3OpenMMPipelineSchematic.tsx
@@ -1,13 +1,8 @@
-import { useTheme } from '@mui/material/styles'
+import PipelineSchematicBase, {
+  PipelineStep
+} from 'features/shared/PipelineSchematicBase'
 
-type StepColor = 'blue' | 'green' | 'purple'
-
-interface Step {
-  lines: string[]
-  color: StepColor
-}
-
-const ROW0: Step[] = [
+const ROW0: PipelineStep[] = [
   { lines: ['AA Sequence', 'SAXS *.dat'], color: 'blue' },
   { lines: ['OpenFold3'], color: 'blue' },
   { lines: ['Select Rank 1', 'prediction'], color: 'blue' },
@@ -16,7 +11,7 @@ const ROW0: Step[] = [
   { lines: ['OpenMM', 'Heat'], color: 'green' }
 ]
 
-const ROW1: Step[] = [
+const ROW1: PipelineStep[] = [
   { lines: ['OpenMM', 'Coarse Grained MD'], color: 'green' },
   { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' },
   { lines: ['FoXS'], color: 'purple' },
@@ -25,153 +20,12 @@ const ROW1: Step[] = [
   { lines: ['Notify'], color: 'blue' }
 ]
 
-const BOX_W = 110
-const BOX_H = 52
-const GAP = 28
-const LEFT_PAD = 26
-const RIGHT_PAD = 20
-const ROW_Y = [10, 90]
-
-const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
-const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
-const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
-const WRAP_LEFT_X = LEFT_PAD - 20
-const LEAD_IN = 20
-const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
-const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
-const WRAP_Y_MID =
-  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
-const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
-const SVG_H = ROW_Y[1] + BOX_H + 10
-
-const OF3OpenMMPipelineSchematic = () => {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
-
-  const colors: Record<
-    StepColor,
-    { fill: string; stroke: string; text: string }
-  > = {
-    blue: {
-      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
-      stroke: theme.palette.primary?.main ?? '#1976d2',
-      text: isDark ? '#e0f2fe' : '#1e3a5f'
-    },
-    green: {
-      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
-      stroke: theme.palette.success?.main ?? '#2e7d32',
-      text: isDark ? '#d1fae5' : '#14532d'
-    },
-    purple: {
-      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
-      stroke: theme.palette.secondary?.main ?? '#9c27b0',
-      text: isDark ? '#ede9fe' : '#3b0764'
-    }
-  }
-
-  const arrowColor = isDark ? '#94a3b8' : '#64748b'
-  const arrowHead = `M0,0 L6,3 L0,6 Z`
-
-  const renderBox = (step: Step, x: number, y: number, key: string) => {
-    const c = colors[step.color]
-    const lineH = 14
-    const totalTextH = step.lines.length * lineH
-    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
-    return (
-      <g key={key}>
-        <rect
-          x={x}
-          y={y}
-          width={BOX_W}
-          height={BOX_H}
-          rx={6}
-          fill={c.fill}
-          stroke={c.stroke}
-          strokeWidth={1.5}
-        />
-        {step.lines.map((line, i) => (
-          <text
-            key={i}
-            x={x + BOX_W / 2}
-            y={textStartY + i * lineH}
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
-            fill={c.text}
-            fontWeight={500}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    )
-  }
-
-  const renderArrow = (x1: number, y: number, key: string) => (
-    <g key={key}>
-      <line
-        x1={x1}
-        y1={y + BOX_H / 2}
-        x2={x1 + GAP - 6}
-        y2={y + BOX_H / 2}
-        stroke={arrowColor}
-        strokeWidth={1.5}
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  // Wrap-around arrow: right edge of last row-0 box → right → down (in gap) → left → down → into first row-1 box from left
-  const wrapArrow = (
-    <g key="wrap">
-      <polyline
-        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
-        fill="none"
-        stroke={arrowColor}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  return (
-    <svg
-      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-      style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD OF3 pipeline schematic"
-    >
-      {ROW0.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r0-${i}`}>
-            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
-            {i < ROW0.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
-          </g>
-        )
-      })}
-      {wrapArrow}
-      {ROW1.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r1-${i}`}>
-            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
-            {i < ROW1.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
-          </g>
-        )
-      })}
-    </svg>
-  )
-}
+const OF3OpenMMPipelineSchematic = () => (
+  <PipelineSchematicBase
+    row0={ROW0}
+    row1={ROW1}
+    ariaLabel="BilboMD OF3 pipeline schematic"
+  />
+)
 
 export default OF3OpenMMPipelineSchematic

--- a/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
+++ b/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
@@ -36,29 +36,21 @@ import {
   detectGaffCofactors,
   detectMetalCofactors
 } from 'schemas/ValidationFunctions'
-import { useTheme } from '@mui/material/styles'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
+import SANSPipelineSchematic from './SANSPipelineSchematic'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
 }
 
-const PipelineSchematic = ({ isDarkMode }: { isDarkMode: boolean }) => (
+const PipelineSchematic = () => (
   <Grid size={{ xs: 12 }}>
     <HeaderBox>
       <Typography>BilboMD SANS Schematic</Typography>
     </HeaderBox>
     <Paper sx={{ p: 2 }}>
-      <img
-        src={
-          isDarkMode
-            ? '/images/bilbomd-sans-schematic-dark.png'
-            : '/images/bilbomd-sans-schematic.png'
-        }
-        alt="Overview of BilboMD AF pipeline"
-        style={{ maxWidth: '100%', height: 'auto' }}
-      />
+      <SANSPipelineSchematic />
     </Paper>
   </Grid>
 )
@@ -69,9 +61,6 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
       ? 'BilboMD: New SANS Job (anonymous)'
       : 'BilboMD: New SANS Job'
   )
-
-  const theme = useTheme()
-  const isDarkMode = theme.palette.mode === 'dark'
 
   const [addNewSANSJob, { isSuccess: isAuthSuccess, data: authJobResponse }] =
     useAddNewSANSJobMutation()
@@ -212,7 +201,7 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
     >
       <NewSANSJobFormInstructions />
 
-      <PipelineSchematic isDarkMode={isDarkMode} />
+      <PipelineSchematic />
 
       <Grid size={{ xs: 12 }}>
         <HeaderBox>

--- a/apps/ui/src/features/sansjob/SANSPipelineSchematic.tsx
+++ b/apps/ui/src/features/sansjob/SANSPipelineSchematic.tsx
@@ -1,0 +1,173 @@
+import { useTheme } from '@mui/material/styles'
+
+type StepColor = 'blue' | 'green' | 'pink'
+
+interface Step {
+  lines: string[]
+  color: StepColor
+}
+
+const ROW0: Step[] = [
+  { lines: ['*.pdb ', ' const.inp', 'SANS *.dat'], color: 'blue' },
+  { lines: ['OpenMM', 'Minimize'], color: 'green' },
+  { lines: ['OpenMM', 'Heat'], color: 'green' },
+  { lines: ['OpenMM', 'Coarse Grained MD'], color: 'green' },
+  { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' }
+]
+
+const ROW1: Step[] = [
+  { lines: ['Pepsi-SANS'], color: 'pink' },
+  { lines: ['GA-SANS'], color: 'pink' },
+  { lines: ['Gather Results'], color: 'blue' },
+  { lines: ['Notify'], color: 'blue' }
+]
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
+const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const SANSPipelineSchematic = () => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const colors: Record<
+    StepColor,
+    { fill: string; stroke: string; text: string }
+  > = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    pink: {
+      fill: isDark ? '#831843' : '#fce7f3',
+      stroke: isDark ? '#ec4899' : '#db2777',
+      text: isDark ? '#fce7f3' : '#831843'
+    }
+  }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: Step, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label="BilboMD SANS pipeline schematic"
+    >
+      {ROW0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < ROW0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {ROW1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < ROW1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default SANSPipelineSchematic

--- a/apps/ui/src/features/sansjob/SANSPipelineSchematic.tsx
+++ b/apps/ui/src/features/sansjob/SANSPipelineSchematic.tsx
@@ -1,13 +1,8 @@
-import { useTheme } from '@mui/material/styles'
+import PipelineSchematicBase, {
+  PipelineStep
+} from 'features/shared/PipelineSchematicBase'
 
-type StepColor = 'blue' | 'green' | 'pink'
-
-interface Step {
-  lines: string[]
-  color: StepColor
-}
-
-const ROW0: Step[] = [
+const ROW0: PipelineStep[] = [
   { lines: ['*.pdb ', ' const.inp', 'SANS *.dat'], color: 'blue' },
   { lines: ['OpenMM', 'Minimize'], color: 'green' },
   { lines: ['OpenMM', 'Heat'], color: 'green' },
@@ -15,159 +10,28 @@ const ROW0: Step[] = [
   { lines: ['Extract PDB', 'from Trajectories'], color: 'blue' }
 ]
 
-const ROW1: Step[] = [
+const ROW1: PipelineStep[] = [
   { lines: ['Pepsi-SANS'], color: 'pink' },
   { lines: ['GA-SANS'], color: 'pink' },
   { lines: ['Gather Results'], color: 'blue' },
   { lines: ['Notify'], color: 'blue' }
 ]
 
-const BOX_W = 110
-const BOX_H = 52
-const GAP = 28
-const LEFT_PAD = 26
-const RIGHT_PAD = 20
-const ROW_Y = [10, 90]
-
-const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
-const LAST_BOX_RIGHT = boxX(ROW0.length - 1) + BOX_W
-const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
-const WRAP_LEFT_X = LEFT_PAD - 20
-const LEAD_IN = 20
-const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
-const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
-const WRAP_Y_MID =
-  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
-const SVG_W = LEFT_PAD + ROW0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
-const SVG_H = ROW_Y[1] + BOX_H + 10
-
-const SANSPipelineSchematic = () => {
-  const theme = useTheme()
-  const isDark = theme.palette.mode === 'dark'
-
-  const colors: Record<
-    StepColor,
-    { fill: string; stroke: string; text: string }
-  > = {
-    blue: {
-      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
-      stroke: theme.palette.primary?.main ?? '#1976d2',
-      text: isDark ? '#e0f2fe' : '#1e3a5f'
-    },
-    green: {
-      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
-      stroke: theme.palette.success?.main ?? '#2e7d32',
-      text: isDark ? '#d1fae5' : '#14532d'
-    },
-    pink: {
-      fill: isDark ? '#831843' : '#fce7f3',
-      stroke: isDark ? '#ec4899' : '#db2777',
-      text: isDark ? '#fce7f3' : '#831843'
-    }
+const extraColors = (isDark: boolean) => ({
+  pink: {
+    fill: isDark ? '#831843' : '#fce7f3',
+    stroke: isDark ? '#ec4899' : '#db2777',
+    text: isDark ? '#fce7f3' : '#831843'
   }
+})
 
-  const arrowColor = isDark ? '#94a3b8' : '#64748b'
-  const arrowHead = `M0,0 L6,3 L0,6 Z`
-
-  const renderBox = (step: Step, x: number, y: number, key: string) => {
-    const c = colors[step.color]
-    const lineH = 14
-    const totalTextH = step.lines.length * lineH
-    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
-    return (
-      <g key={key}>
-        <rect
-          x={x}
-          y={y}
-          width={BOX_W}
-          height={BOX_H}
-          rx={6}
-          fill={c.fill}
-          stroke={c.stroke}
-          strokeWidth={1.5}
-        />
-        {step.lines.map((line, i) => (
-          <text
-            key={i}
-            x={x + BOX_W / 2}
-            y={textStartY + i * lineH}
-            textAnchor="middle"
-            fontSize={10}
-            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
-            fill={c.text}
-            fontWeight={500}
-          >
-            {line}
-          </text>
-        ))}
-      </g>
-    )
-  }
-
-  const renderArrow = (x1: number, y: number, key: string) => (
-    <g key={key}>
-      <line
-        x1={x1}
-        y1={y + BOX_H / 2}
-        x2={x1 + GAP - 6}
-        y2={y + BOX_H / 2}
-        stroke={arrowColor}
-        strokeWidth={1.5}
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  const wrapArrow = (
-    <g key="wrap">
-      <polyline
-        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
-        fill="none"
-        stroke={arrowColor}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      <path
-        d={arrowHead}
-        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
-        fill={arrowColor}
-      />
-    </g>
-  )
-
-  return (
-    <svg
-      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-      style={{ width: '100%', display: 'block' }}
-      aria-label="BilboMD SANS pipeline schematic"
-    >
-      {ROW0.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r0-${i}`}>
-            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
-            {i < ROW0.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
-          </g>
-        )
-      })}
-      {wrapArrow}
-      {ROW1.map((step, i) => {
-        const x = boxX(i)
-        return (
-          <g key={`r1-${i}`}>
-            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
-            {i < ROW1.length - 1 &&
-              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
-          </g>
-        )
-      })}
-    </svg>
-  )
-}
+const SANSPipelineSchematic = () => (
+  <PipelineSchematicBase
+    row0={ROW0}
+    row1={ROW1}
+    ariaLabel="BilboMD SANS pipeline schematic"
+    extraColors={extraColors}
+  />
+)
 
 export default SANSPipelineSchematic

--- a/apps/ui/src/features/shared/PipelineOptions.tsx
+++ b/apps/ui/src/features/shared/PipelineOptions.tsx
@@ -1,4 +1,6 @@
+import React from 'react'
 import {
+  Box,
   List,
   Paper,
   Avatar,
@@ -12,18 +14,15 @@ import RocketLaunchIcon from '@mui/icons-material/RocketLaunch'
 interface PipelineType {
   title: string
   description: string
-  imagePath: {
-    light: string
-    dark: string
-  }
+  schematic: React.ReactNode
 }
 
 interface PipelineOptionsProps {
   pipelines: PipelineType[]
-  isLightMode: boolean
+  isLightMode?: boolean
 }
 
-const PipelineOptions = ({ pipelines, isLightMode }: PipelineOptionsProps) => (
+const PipelineOptions = ({ pipelines }: PipelineOptionsProps) => (
   <List>
     {pipelines.map((pipeline, index) => (
       <Paper
@@ -49,17 +48,9 @@ const PipelineOptions = ({ pipelines, isLightMode }: PipelineOptionsProps) => (
             secondary={pipeline.description}
             sx={{ flex: '1 1 auto', minWidth: '200px' }}
           />
-          <img
-            src={
-              isLightMode ? pipeline.imagePath.light : pipeline.imagePath.dark
-            }
-            alt={`Overview of ${pipeline.title}`}
-            style={{
-              maxWidth: '65%',
-              maxHeight: '200px',
-              objectFit: 'contain'
-            }}
-          />
+          <Box sx={{ maxWidth: '65%', width: '100%' }}>
+            {pipeline.schematic}
+          </Box>
         </ListItem>
       </Paper>
     ))}

--- a/apps/ui/src/features/shared/PipelineSchematicBase.tsx
+++ b/apps/ui/src/features/shared/PipelineSchematicBase.tsx
@@ -1,0 +1,170 @@
+import { useTheme } from '@mui/material/styles'
+
+export interface PipelineStep {
+  lines: string[]
+  color: string
+}
+
+type ColorDef = { fill: string; stroke: string; text: string }
+
+interface Props {
+  row0: PipelineStep[]
+  row1: PipelineStep[]
+  ariaLabel: string
+  extraColors?: (isDark: boolean) => Record<string, ColorDef>
+}
+
+const BOX_W = 110
+const BOX_H = 52
+const GAP = 28
+const LEFT_PAD = 26
+const RIGHT_PAD = 20
+const ROW_Y = [10, 90]
+const WRAP_LEFT_X = LEFT_PAD - 20
+const LEAD_IN = 20
+const ROW0_MID_Y = ROW_Y[0] + BOX_H / 2
+const ROW1_MID_Y = ROW_Y[1] + BOX_H / 2
+const WRAP_Y_MID =
+  ROW_Y[0] + BOX_H + Math.round((ROW_Y[1] - ROW_Y[0] - BOX_H) / 2)
+const SVG_H = ROW_Y[1] + BOX_H + 10
+
+const boxX = (i: number) => LEFT_PAD + i * (BOX_W + GAP)
+
+const PipelineSchematicBase = ({
+  row0,
+  row1,
+  ariaLabel,
+  extraColors
+}: Props) => {
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+
+  const LAST_BOX_RIGHT = boxX(row0.length - 1) + BOX_W
+  const WRAP_RIGHT_X = LAST_BOX_RIGHT + 14
+  const SVG_W = LEFT_PAD + row0.length * (BOX_W + GAP) - GAP + RIGHT_PAD
+
+  const defaultColors: Record<string, ColorDef> = {
+    blue: {
+      fill: isDark ? (theme.palette.primary?.dark ?? '#1565c0') : '#dbeafe',
+      stroke: theme.palette.primary?.main ?? '#1976d2',
+      text: isDark ? '#e0f2fe' : '#1e3a5f'
+    },
+    green: {
+      fill: isDark ? (theme.palette.success?.dark ?? '#1b5e20') : '#dcfce7',
+      stroke: theme.palette.success?.main ?? '#2e7d32',
+      text: isDark ? '#d1fae5' : '#14532d'
+    },
+    purple: {
+      fill: isDark ? (theme.palette.secondary?.dark ?? '#4a148c') : '#ede9fe',
+      stroke: theme.palette.secondary?.main ?? '#9c27b0',
+      text: isDark ? '#ede9fe' : '#3b0764'
+    }
+  }
+
+  const colors = { ...defaultColors, ...extraColors?.(isDark) }
+
+  const arrowColor = isDark ? '#94a3b8' : '#64748b'
+  const arrowHead = `M0,0 L6,3 L0,6 Z`
+
+  const renderBox = (step: PipelineStep, x: number, y: number, key: string) => {
+    const c = colors[step.color]
+    const lineH = 14
+    const totalTextH = step.lines.length * lineH
+    const textStartY = y + BOX_H / 2 - totalTextH / 2 + lineH * 0.75
+    return (
+      <g key={key}>
+        <rect
+          x={x}
+          y={y}
+          width={BOX_W}
+          height={BOX_H}
+          rx={6}
+          fill={c.fill}
+          stroke={c.stroke}
+          strokeWidth={1.5}
+        />
+        {step.lines.map((line, i) => (
+          <text
+            key={i}
+            x={x + BOX_W / 2}
+            y={textStartY + i * lineH}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily={theme.typography?.fontFamily ?? 'sans-serif'}
+            fill={c.text}
+            fontWeight={500}
+          >
+            {line}
+          </text>
+        ))}
+      </g>
+    )
+  }
+
+  const renderArrow = (x1: number, y: number, key: string) => (
+    <g key={key}>
+      <line
+        x1={x1}
+        y1={y + BOX_H / 2}
+        x2={x1 + GAP - 6}
+        y2={y + BOX_H / 2}
+        stroke={arrowColor}
+        strokeWidth={1.5}
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${x1 + GAP - 6}, ${y + BOX_H / 2 - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  const wrapArrow = (
+    <g key="wrap">
+      <polyline
+        points={`${LAST_BOX_RIGHT},${ROW0_MID_Y} ${WRAP_RIGHT_X},${ROW0_MID_Y} ${WRAP_RIGHT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${WRAP_Y_MID} ${WRAP_LEFT_X},${ROW1_MID_Y} ${WRAP_LEFT_X + LEAD_IN},${ROW1_MID_Y}`}
+        fill="none"
+        stroke={arrowColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <path
+        d={arrowHead}
+        transform={`translate(${WRAP_LEFT_X + LEAD_IN - 6}, ${ROW1_MID_Y - 3})`}
+        fill={arrowColor}
+      />
+    </g>
+  )
+
+  return (
+    <svg
+      viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+      style={{ width: '100%', display: 'block' }}
+      aria-label={ariaLabel}
+    >
+      {row0.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r0-${i}`}>
+            {renderBox(step, x, ROW_Y[0], `r0-box-${i}`)}
+            {i < row0.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[0], `r0-arr-${i}`)}
+          </g>
+        )
+      })}
+      {wrapArrow}
+      {row1.map((step, i) => {
+        const x = boxX(i)
+        return (
+          <g key={`r1-${i}`}>
+            {renderBox(step, x, ROW_Y[1], `r1-box-${i}`)}
+            {i < row1.length - 1 &&
+              renderArrow(x + BOX_W, ROW_Y[1], `r1-arr-${i}`)}
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+export default PipelineSchematicBase


### PR DESCRIPTION
## Summary

- Replace all 9 static PNG pipeline schematic images with inline SVG React components
- Each component is theme-aware via `useTheme()` — automatically adapts to MUI dark/light mode, eliminating the need for separate `-dark.png` variants
- SVGs scale cleanly at any resolution with no pixelation
- SANS schematic introduces a pink color for Pepsi-SANS / GA-SANS steps

## Pipelines covered

| Component | Pipeline |
|---|---|
| `AFOpenMMPipelineSchematic` | AlphaFold + OpenMM |
| `AFCharmmPipelineSchematic` | AlphaFold + CHARMM |
| `AutoOpenMMPipelineSchematic` | Auto + OpenMM |
| `AutoCharmmPipelineSchematic` | Auto + CHARMM |
| `ClassicPDBOpenMMPipelineSchematic` | Classic PDB + OpenMM |
| `ClassicPDBCharmmPipelineSchematic` | Classic PDB + CHARMM |
| `ClassicCRDPipelineSchematic` | Classic CRD/PSF |
| `OF3OpenMMPipelineSchematic` | OpenFold3 (replaces missing PNG) |
| `SANSPipelineSchematic` | SANS |

## Test plan

- [ ] Navigate to each job form and confirm the correct schematic renders
- [ ] Toggle dark mode — colors update without reload
- [ ] Resize browser window — SVG scales cleanly at all widths
- [ ] Confirm Help page AF tab renders SVG schematic
- [ ] Run `pnpm -F @bilbomd/ui lint && pnpm -F @bilbomd/ui build && pnpm -F @bilbomd/ui test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)