### PR TITLE
fix(ui): prevent stale index.html caching on nginx

### DIFF
--- a/apps/ui/nginx/nginx.default.conf
+++ b/apps/ui/nginx/nginx.default.conf
@@ -49,6 +49,21 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # index.html must never be cached — it references hashed assets whose
+    # names change on every build, so a stale index.html causes chunk 404s.
+    location = /index.html {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
+    # Hashed asset filenames are immutable; cache them aggressively.
+    location /assets/ {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;


### PR DESCRIPTION
## Summary

- Add `Cache-Control: no-cache` headers for `index.html` so browsers always re-fetch the entry point after a deployment
- Add `Cache-Control: public, max-age=31536000, immutable` for `/assets/` since Vite's hashed filenames are guaranteed unique

## Problem

Vite changes all chunk hashes on every build (any change to the module graph changes hashes). If the browser caches `index.html`, it keeps referencing old chunk names that no longer exist on the server, producing:

```
Failed to fetch dynamically imported module: .../assets/NewJobForm-CQHpy2Po.js
```

This was triggered by the SVG schematic refactor (PR #790) introducing `PipelineSchematicBase` as a new shared dependency, which reshuffled all chunk hashes on the next deploy.

## Test plan

- [ ] Deploy to dev and hard-refresh — confirm job form pages load correctly
- [ ] Deploy again and refresh normally (no hard-refresh) — confirm no chunk fetch errors
- [ ] Verify `/assets/` files are served with immutable cache headers

🤖 Generated with [Claude Code](https://claude.ai/claude-code)