### PR TITLE
fix(ui,backend): OF3 fixes and Jobs runtime column

### DIFF
--- a/.changeset/of3-and-jobs-ui-improvements.md
+++ b/.changeset/of3-and-jobs-ui-improvements.md
@@ -1,0 +1,11 @@
+---
+'@bilbomd/ui': patch
+'@bilbomd/backend': patch
+---
+
+Fix OF3 pipeline issues and add Jobs runtime column.
+
+- Correct the OpenFold3 GitHub link in the OF3 job form instructions to point to the right repository (aqlaboratory/openfold-3)
+- Add "Experimental - Please report problems to Scott" label to the OF3 job form header
+- Fix 404 error on the OF3 "Download Example Data" button by wiring up the missing backend route and handler
+- Add a Runtime column to the Jobs table showing wall-clock duration from submission to completion for all job types (live for running jobs)

--- a/apps/backend/src/controllers/examples/getExampleData.ts
+++ b/apps/backend/src/controllers/examples/getExampleData.ts
@@ -13,6 +13,7 @@ type ExampleKey =
   | 'bilbomd-classic-crd'
   | 'bilbomd-auto'
   | 'bilbomd-af'
+  | 'bilbomd-of3'
   | 'bilbomd-sans'
   | 'scoper'
 
@@ -49,6 +50,10 @@ const exampleConfigMap: Record<ExampleKey, ExampleConfig> = {
   'bilbomd-af': {
     filePath: path.join(EXAMPLE_DATA_ROOT, 'bilbomd_af_example.tar.gz'),
     downloadName: 'bilbomd_af_example.tar.gz'
+  },
+  'bilbomd-of3': {
+    filePath: path.join(EXAMPLE_DATA_ROOT, 'bilbomd_of3_example.tar.gz'),
+    downloadName: 'bilbomd_of3_example.tar.gz'
   },
   'bilbomd-sans': {
     filePath: path.join(EXAMPLE_DATA_ROOT, 'bilbomd_sans_example.tar.gz'),
@@ -127,6 +132,12 @@ export const getClassicAfExample = (
   res: Response,
   next: NextFunction
 ) => sendExampleBundle('bilbomd-af', req, res, next)
+
+export const getClassicOf3Example = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => sendExampleBundle('bilbomd-of3', req, res, next)
 
 export const getClassicSansExample = (
   req: Request,

--- a/apps/backend/src/routes/examples.ts
+++ b/apps/backend/src/routes/examples.ts
@@ -4,6 +4,7 @@ import {
   getClassicCrdExample,
   getClassicAutoExample,
   getClassicAfExample,
+  getClassicOf3Example,
   getClassicSansExample,
   getClassicScoperExample
 } from '../controllers/examples/getExampleData.js'
@@ -14,6 +15,7 @@ router.route('/classic/pdb').get(getClassicPdbExample)
 router.route('/classic/crd').get(getClassicCrdExample)
 router.route('/auto').get(getClassicAutoExample)
 router.route('/af').get(getClassicAfExample)
+router.route('/of3').get(getClassicOf3Example)
 router.route('/sans').get(getClassicSansExample)
 router.route('/scoper').get(getClassicScoperExample)
 

--- a/apps/ui/src/features/jobs/Jobs.tsx
+++ b/apps/ui/src/features/jobs/Jobs.tsx
@@ -179,6 +179,40 @@ const getHoursInQueue = (nersc: INerscInfo | undefined, jobStatus?: string) => {
   return hrs > 0 ? `${hrs}hr${mins > 0 ? ` ${mins}min` : ''}` : `${mins}min`
 }
 
+const getTotalRuntime = (
+  timeSubmitted: Date | undefined,
+  timeCompleted: Date | undefined,
+  jobStatus?: string
+) => {
+  const start = parseDateSafe(timeSubmitted)
+  if (!start) return ''
+
+  let end: Date | null = null
+
+  const completed = parseDateSafe(timeCompleted)
+  if (completed && completed.getTime() > 0) {
+    end = completed
+  }
+
+  if (!end) {
+    if (jobStatus === 'Running') {
+      end = new Date()
+    } else {
+      return ''
+    }
+  }
+
+  const diffMs = end.getTime() - start.getTime()
+  if (diffMs < 0) return ''
+
+  const totalMinutes = Math.round(diffMs / 60000)
+  const hrs = Math.floor(totalMinutes / 60)
+  const mins = totalMinutes % 60
+
+  if (totalMinutes < 1) return '<1min'
+  return hrs > 0 ? `${hrs}hr${mins > 0 ? ` ${mins}min` : ''}` : `${mins}min`
+}
+
 const filteredJobCountChip = (count: number) => {
   return (
     <Chip
@@ -502,6 +536,11 @@ const Jobs = () => {
       const nerscStatus = job.mongo.nersc?.state || ''
       const queueHours = getHoursInQueue(job.mongo.nersc, job.mongo.status)
       const runTimeHours = getRunTimeInHours(job.mongo.nersc, job.mongo.status)
+      const totalRuntime = getTotalRuntime(
+        job.mongo.time_submitted,
+        job.mongo.time_completed,
+        job.mongo.status
+      )
 
       return {
         ...job.mongo,
@@ -510,6 +549,7 @@ const Jobs = () => {
         nerscStatus: nerscStatus,
         queueHours: queueHours,
         runTimeHours: runTimeHours,
+        totalRuntime: totalRuntime,
         progress: job.mongo.progress
       }
     })
@@ -538,6 +578,15 @@ const Jobs = () => {
         width: 150,
         valueGetter: (_value, row) => parseDateSafe(row.time_completed),
         valueFormatter: (value: unknown) => formatDateSafe(value)
+      },
+      {
+        field: 'totalRuntime',
+        headerName: 'Runtime',
+        width: 100,
+        cellClassName: (params: GridCellParams) => {
+          const status = params.row.status
+          return clsx({ running: status === 'Running' })
+        }
       },
       ...(useNersc
         ? [

--- a/apps/ui/src/features/jobs/__tests__/Jobs.test.tsx
+++ b/apps/ui/src/features/jobs/__tests__/Jobs.test.tsx
@@ -235,7 +235,7 @@ describe('Jobs table', () => {
     const nerscTimes: INerscInfo = {
       time_submitted: new Date('2025-01-01T00:00:00Z'),
       time_started: new Date('2025-01-01T00:05:00Z'),
-      time_completed: new Date('2025-01-01T00:15:00Z'),
+      time_completed: new Date('2025-01-01T00:20:00Z'), // 15min NERSC run time — avoids collision with 10min mongo totalRuntime
       jobid: '12345',
       state: 'RUNNING',
       qos: 'debug'
@@ -264,9 +264,9 @@ describe('Jobs table', () => {
       screen.getByRole('columnheader', { name: /run time/i })
     ).toBeInTheDocument()
 
-    // Cells show computed durations
-    expect(await screen.findByText(/5min/i)).toBeInTheDocument()
-    expect(screen.getByText(/10min/i)).toBeInTheDocument()
+    // Cells show computed durations (exact match avoids substring collisions)
+    expect(await screen.findByText('5min')).toBeInTheDocument()
+    expect(screen.getByText('15min')).toBeInTheDocument()
   })
 
   it('handles NERSC jobs with epoch placeholder for time_completed', async () => {

--- a/apps/ui/src/features/openfoldjob/NewOpenFoldJobForm.tsx
+++ b/apps/ui/src/features/openfoldjob/NewOpenFoldJobForm.tsx
@@ -532,7 +532,15 @@ const NewOpenFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
       <PipelineSchematic />
       <Grid size={{ xs: 12 }}>
         <HeaderBox>
-          <Typography>BilboMD OF3 Job Form</Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography>BilboMD OF3 Job Form</Typography>
+            <Typography
+              component="span"
+              sx={{ color: 'yellow', ml: 1 }}
+            >
+              *Experimental - Please report problems to Scott
+            </Typography>
+          </Box>
         </HeaderBox>
 
         <Paper sx={{ p: 2 }}>

--- a/apps/ui/src/features/openfoldjob/NewOpenFoldJobFormInstructions.tsx
+++ b/apps/ui/src/features/openfoldjob/NewOpenFoldJobFormInstructions.tsx
@@ -53,7 +53,7 @@ const NewOpenFoldJobFormInstructions = () => {
             <b>BilboMD OF3</b> takes your sequence information for Proteins,
             DNA, and RNA chains and runs{' '}
             <Link
-              href="https://github.com/OpenFold-consortium/openfold3"
+              href="https://github.com/aqlaboratory/openfold-3"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -87,7 +87,7 @@ const NewOpenFoldJobFormInstructions = () => {
             <Typography>
               <b>BilboMD OF3</b> uses{' '}
               <Link
-                href="https://github.com/OpenFold-consortium/openfold3"
+                href="https://github.com/aqlaboratory/openfold-3"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
## Summary

- Fix OF3 GitHub link to correct repository (`aqlaboratory/openfold-3`)
- Add \"Experimental - Please report problems to Scott\" label to OF3 job form header
- Fix 404 on OF3 \"Download Example Data\" button — adds missing `/of3` backend route and handler (serves `bilbomd_of3_example.tar.gz`)
- Add **Runtime** column to Jobs DataGrid showing wall-clock duration from submission to completion for all job types; shows live elapsed time for running jobs

## Test plan

- [ ] OF3 job form instructions link opens the correct GitHub repo
- [ ] Experimental label appears in the OF3 form header (yellow text)
- [ ] \"Download Example Data\" button on OF3 form no longer 404s (requires `bilbomd_of3_example.tar.gz` present on server)
- [ ] Jobs table shows a Runtime column with formatted durations (e.g. `12min`, `1hr 5min`)
- [ ] Runtime shows live elapsed time for a Running job and is empty for Submitted/Pending jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)