### PR TITLE
fix(ui): split job timing into Queued and Runtime columns

### DIFF
--- a/.changeset/ui-split-runtime-queued-columns.md
+++ b/.changeset/ui-split-runtime-queued-columns.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': minor
+---
+
+Split job timing into separate Queued and Runtime columns. Runtime now shows time from when processing started (time_started) to completion, excluding queue wait. The new Queued column shows time from submission until processing began (or until now for pending/submitted jobs).

--- a/apps/ui/src/features/jobs/Jobs.tsx
+++ b/apps/ui/src/features/jobs/Jobs.tsx
@@ -179,12 +179,37 @@ const getHoursInQueue = (nersc: INerscInfo | undefined, jobStatus?: string) => {
   return hrs > 0 ? `${hrs}hr${mins > 0 ? ` ${mins}min` : ''}` : `${mins}min`
 }
 
-const getTotalRuntime = (
+const getQueuedTime = (
   timeSubmitted: Date | undefined,
-  timeCompleted: Date | undefined,
+  timeStarted: Date | undefined,
   jobStatus?: string
 ) => {
   const start = parseDateSafe(timeSubmitted)
+  if (!start) return ''
+
+  const started = parseDateSafe(timeStarted)
+  const end =
+    started ??
+    (jobStatus === 'Submitted' || jobStatus === 'Pending' ? new Date() : null)
+  if (!end) return ''
+
+  const diffMs = end.getTime() - start.getTime()
+  if (diffMs < 0) return ''
+
+  const totalMinutes = Math.round(diffMs / 60000)
+  const hrs = Math.floor(totalMinutes / 60)
+  const mins = totalMinutes % 60
+
+  if (totalMinutes < 1) return '<1min'
+  return hrs > 0 ? `${hrs}hr${mins > 0 ? ` ${mins}min` : ''}` : `${mins}min`
+}
+
+const getTotalRuntime = (
+  timeStarted: Date | undefined,
+  timeCompleted: Date | undefined,
+  jobStatus?: string
+) => {
+  const start = parseDateSafe(timeStarted)
   if (!start) return ''
 
   let end: Date | null = null
@@ -536,8 +561,13 @@ const Jobs = () => {
       const nerscStatus = job.mongo.nersc?.state || ''
       const queueHours = getHoursInQueue(job.mongo.nersc, job.mongo.status)
       const runTimeHours = getRunTimeInHours(job.mongo.nersc, job.mongo.status)
-      const totalRuntime = getTotalRuntime(
+      const queuedTime = getQueuedTime(
         job.mongo.time_submitted,
+        job.mongo.time_started,
+        job.mongo.status
+      )
+      const totalRuntime = getTotalRuntime(
+        job.mongo.time_started,
         job.mongo.time_completed,
         job.mongo.status
       )
@@ -549,6 +579,7 @@ const Jobs = () => {
         nerscStatus: nerscStatus,
         queueHours: queueHours,
         runTimeHours: runTimeHours,
+        queuedTime: queuedTime,
         totalRuntime: totalRuntime,
         progress: job.mongo.progress
       }
@@ -578,6 +609,11 @@ const Jobs = () => {
         width: 150,
         valueGetter: (_value, row) => parseDateSafe(row.time_completed),
         valueFormatter: (value: unknown) => formatDateSafe(value)
+      },
+      {
+        field: 'queuedTime',
+        headerName: 'Queued',
+        width: 100
       },
       {
         field: 'totalRuntime',

--- a/apps/ui/src/features/jobs/__tests__/Jobs.test.tsx
+++ b/apps/ui/src/features/jobs/__tests__/Jobs.test.tsx
@@ -247,6 +247,10 @@ describe('Jobs table', () => {
           createMockJobDTO({
             mongo: createMockPdbMongo({
               status: 'Running',
+              // Use distinct mongo times so Queued(2min)/Runtime(7min) don't
+              // collide with NERSC Queue Time(5min) or Run Time(15min)
+              time_started: new Date('2025-01-01T00:02:00Z'),
+              time_completed: new Date('2025-01-01T00:09:00Z'),
               nersc: nerscTimes
             })
           })
@@ -264,8 +268,9 @@ describe('Jobs table', () => {
       screen.getByRole('columnheader', { name: /run time/i })
     ).toBeInTheDocument()
 
-    // Cells show computed durations (exact match avoids substring collisions)
+    // NERSC Queue Time (nersc.time_submitted→nersc.time_started = 5min)
     expect(await screen.findByText('5min')).toBeInTheDocument()
+    // NERSC Run Time (nersc.time_started→nersc.time_completed = 15min)
     expect(screen.getByText('15min')).toBeInTheDocument()
   })
 
@@ -292,6 +297,9 @@ describe('Jobs table', () => {
           createMockJobDTO({
             mongo: createMockPdbMongo({
               status: 'Running',
+              // Use distinct mongo times so Queued(2min)/Runtime(8min) don't
+              // collide with NERSC Queue Time(5min)
+              time_started: new Date('2025-01-01T00:02:00Z'),
               nersc: nerscTimesWithEpoch
             })
           })
@@ -309,7 +317,7 @@ describe('Jobs table', () => {
       screen.getByRole('columnheader', { name: /run time/i })
     ).toBeInTheDocument()
 
-    // Queue time should show (5 minutes from submit to start)
+    // NERSC Queue Time should show (5 minutes from nersc.time_submitted to nersc.time_started)
     expect(await screen.findByText('5min')).toBeInTheDocument()
 
     // Run time should NOT show 'Invalid' - it should calculate from start to now


### PR DESCRIPTION
Closes #795

## Summary

- **Runtime** column now uses `time_started → time_completed` (actual processing time only)
- New **Queued** column shows `time_submitted → time_started` (queue wait time), or `→ now` for jobs still in `Submitted`/`Pending` state
- If `time_started` is absent (e.g. older jobs), Runtime shows nothing rather than inflated queue-inclusive time
- `getQueuedTime` added alongside the updated `getTotalRuntime` in `Jobs.tsx`

## Test plan

- [x] `pnpm -F @bilbomd/ui lint` — passes
- [x] `pnpm -F @bilbomd/ui build` — passes
- [x] `pnpm -F @bilbomd/ui test` — 1072 tests pass; NERSC test mock data updated to give each column a unique value avoiding `findByText` collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)