### PR TITLE
fix(worker): add Python logging and post-minimization energy gate to OpenMM scripts

### DIFF
--- a/.changeset/openmm-logging-energy-gate.md
+++ b/.changeset/openmm-logging-energy-gate.md
@@ -1,11 +1,16 @@
 ---
 '@bilbomd/worker': patch
+'@bilbomd/ui': patch
 ---
 
-Replace print() with Python logging in all OpenMM scripts and add a post-minimization energy gate.
+Replace print() with Python logging in all OpenMM scripts, add a post-minimization energy gate, and surface OpenMM stderr errors to the UI job status pages.
 
 All OpenMM Python scripts (minimize.py, heat.py, md.py, plot_rgyrs.py and all utils) now use a shared `utils/logger.py` logger. INFO-level output goes to stdout (visible as `[step][stdout]` in worker logs); WARNING and ERROR go to stderr (`[step][stderr]`), matching the log levels already applied by the Node.js worker.
 
 A post-minimization energy gate in minimize.py checks potential energy after `minimizeEnergy()` completes and exits with code 1 if the value is NaN/Inf or exceeds 1,000,000 kJ/mol — catching severe atom-clash failures at the correct step rather than as an opaque NaN crash during heating.
 
 The heating loop in heat.py now reports potential energy alongside temperature at each 1000-step checkpoint and includes NaN position detection with an early abort.
+
+A pre-minimization clash detection step (clash_check.py) was added to identify severe atom overlaps before minimization begins.
+
+The UI (SingleJobPage and PublicJobPage) now displays the stderr error message from the failed step in the job failure alert, giving users actionable feedback instead of a generic error message.

--- a/.changeset/openmm-logging-energy-gate.md
+++ b/.changeset/openmm-logging-energy-gate.md
@@ -1,0 +1,11 @@
+---
+'@bilbomd/worker': patch
+---
+
+Replace print() with Python logging in all OpenMM scripts and add a post-minimization energy gate.
+
+All OpenMM Python scripts (minimize.py, heat.py, md.py, plot_rgyrs.py and all utils) now use a shared `utils/logger.py` logger. INFO-level output goes to stdout (visible as `[step][stdout]` in worker logs); WARNING and ERROR go to stderr (`[step][stderr]`), matching the log levels already applied by the Node.js worker.
+
+A post-minimization energy gate in minimize.py checks potential energy after `minimizeEnergy()` completes and exits with code 1 if the value is NaN/Inf or exceeds 1,000,000 kJ/mol — catching severe atom-clash failures at the correct step rather than as an opaque NaN crash during heating.
+
+The heating loop in heat.py now reports potential energy alongside temperature at each 1000-step checkpoint and includes NaN position detection with an early abort.

--- a/apps/ui/src/features/jobs/SingleJobPage.tsx
+++ b/apps/ui/src/features/jobs/SingleJobPage.tsx
@@ -103,6 +103,12 @@ const SingleJobPage = () => {
 
   const job = jobData as BilboMDJobDTO
 
+  const erroredStepMessage = job?.mongo?.steps
+    ? (Object.values(job.mongo.steps).find(
+        (step) => step != null && step.status === 'Error'
+      )?.message ?? null)
+    : null
+
   useEffect(() => {
     const status = job?.mongo?.status
     if (!status) return
@@ -559,13 +565,10 @@ const SingleJobPage = () => {
           </Grid>
         )}
 
-        {job.mongo.status === 'Error' && (
+        {(job.mongo.status === 'Error' || job.mongo.status === 'Failed') && (
           <Grid size={{ xs: 12 }}>
             <HeaderBox sx={{ py: '6px' }}>
-              <Typography>
-                {/* Error - {job.bullmq?.bullmq?.failedReason ?? 'Unknown error'} */}
-                Error in SingleJobPage Component
-              </Typography>
+              <Typography>Job Failed</Typography>
             </HeaderBox>
 
             <Item>
@@ -575,9 +578,21 @@ const SingleJobPage = () => {
                   variant="outlined"
                 >
                   <AlertTitle>Job Failed</AlertTitle>
-                  We&apos;ve logged the details of this job failure. Please
-                  contact Scott or Michal and reference your job ID for faster
-                  support:{' '}
+                  {erroredStepMessage && (
+                    <Box
+                      component="pre"
+                      sx={{
+                        mb: 1,
+                        fontSize: '0.82em',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word'
+                      }}
+                    >
+                      {erroredStepMessage}
+                    </Box>
+                  )}
+                  Please contact Scott or Michal and reference your job ID for
+                  faster support:{' '}
                   <Box
                     component="code"
                     sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
@@ -591,7 +606,19 @@ const SingleJobPage = () => {
                   variant="outlined"
                 >
                   <AlertTitle>Job Failed</AlertTitle>
-                  Something didn&apos;t work.{' '}
+                  {erroredStepMessage && (
+                    <Box
+                      component="pre"
+                      sx={{
+                        mb: 1,
+                        fontSize: '0.82em',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-word'
+                      }}
+                    >
+                      {erroredStepMessage}
+                    </Box>
+                  )}
                   <Link to="/register">Creating a free BilboMD account</Link>{' '}
                   allows us to investigate job failures and provide personalized
                   support. You can also try resubmitting.

--- a/apps/ui/src/features/public/PublicJobPage.tsx
+++ b/apps/ui/src/features/public/PublicJobPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router'
+import { useParams, Link } from 'react-router'
 import { useState, useEffect, lazy, Suspense } from 'react'
 import {
   Alert,
@@ -317,6 +317,32 @@ const PublicJobPage = () => {
             )}
           </Item>
         </Grid>
+
+        {/* CREATE ACCOUNT ADVISORY */}
+        {(job.status === 'Error' || job.status === 'Failed') && (
+          <Grid size={{ xs: 12 }}>
+            <Alert
+              severity="info"
+              action={
+                <Button
+                  component={Link}
+                  to="/register"
+                  color="inherit"
+                  size="small"
+                  variant="outlined"
+                >
+                  Register for free
+                </Button>
+              }
+            >
+              <AlertTitle>Get personalized support</AlertTitle>
+              Creating a free BilboMD account allows the BilboMD team to see
+              your failed jobs, diagnose whether this is a bug on our end or an
+              issue with your inputs (PDB file or SAXS data), and notify you
+              directly.
+            </Alert>
+          </Grid>
+        )}
 
         {/* ERROR / FAILED */}
         {(job.status === 'Error' || job.status === 'Failed') && (

--- a/apps/ui/src/features/public/PublicJobPage.tsx
+++ b/apps/ui/src/features/public/PublicJobPage.tsx
@@ -162,6 +162,12 @@ const PublicJobPage = () => {
     ? (job.steps[runningStepName as keyof typeof job.steps]?.message ?? '')
     : ''
 
+  const erroredStepMessage = job.steps
+    ? (Object.values(job.steps).find(
+        (step) => step != null && step.status === 'Error'
+      )?.message ?? null)
+    : null
+
   const calculateDuration = (): string | undefined => {
     if (!job.startedAt) return undefined
     const startTime = new Date(job.startedAt)
@@ -311,6 +317,26 @@ const PublicJobPage = () => {
             )}
           </Item>
         </Grid>
+
+        {/* ERROR / FAILED */}
+        {(job.status === 'Error' || job.status === 'Failed') && (
+          <Grid size={{ xs: 12 }}>
+            <HeaderBox sx={{ py: '6px' }}>
+              <Typography>Job Failed</Typography>
+            </HeaderBox>
+            <Item>
+              <Alert
+                severity="error"
+                variant="outlined"
+              >
+                <AlertTitle>Something went wrong</AlertTitle>
+                {erroredStepMessage
+                  ? erroredStepMessage
+                  : 'An unexpected error occurred. Please try resubmitting or creating a BilboMD account for support.'}
+              </Alert>
+            </Item>
+          </Grid>
+        )}
 
         {/* SCOPER RESULTS SUMMARY */}
         {job.results?.scoper && (

--- a/apps/ui/src/features/public/PublicJobPage.tsx
+++ b/apps/ui/src/features/public/PublicJobPage.tsx
@@ -158,9 +158,10 @@ const PublicJobPage = () => {
       )?.[0] ?? null)
     : null
 
-  const latestStepMessage = runningStepName && job.steps
-    ? (job.steps[runningStepName as keyof typeof job.steps]?.message ?? '')
-    : ''
+  const latestStepMessage =
+    runningStepName && job.steps
+      ? (job.steps[runningStepName as keyof typeof job.steps]?.message ?? '')
+      : ''
 
   const erroredStepMessage = job.steps
     ? (Object.values(job.steps).find(
@@ -323,15 +324,17 @@ const PublicJobPage = () => {
           <Grid size={{ xs: 12 }}>
             <Alert
               severity="info"
+              variant="outlined"
+              sx={{ backgroundColor: 'rgba(30, 136, 229, 0.08)' }}
               action={
                 <Button
                   component={Link}
                   to="/register"
-                  color="inherit"
+                  color="primary"
                   size="small"
-                  variant="outlined"
+                  variant="contained"
                 >
-                  Register for free
+                  Register
                 </Button>
               }
             >

--- a/apps/worker/scripts/openmm/heat.py
+++ b/apps/worker/scripts/openmm/heat.py
@@ -115,7 +115,7 @@ for step in range(nsteps):
         if any(math.isnan(v) for p in pos for v in (p.x, p.y, p.z)):
             logger.error(f"NaN detected in particle positions at step {step} — aborting.")
             sys.exit(1)
-        logger.info(f"Step {step}: Temperature = {temperature:.2f} K, PE = {pe:.1f} kJ/mol")
+        logger.info(f"Step {step}: Temperature = {temperature.value_in_unit(kelvin):.2f} K, PE = {pe:.1f} kJ/mol")
 
 logger.info("✅ Heating complete.")
 

--- a/apps/worker/scripts/openmm/heat.py
+++ b/apps/worker/scripts/openmm/heat.py
@@ -1,5 +1,6 @@
 """Python script to heat a protein structure using OpenMM."""
 
+import math
 import os
 import sys
 
@@ -14,13 +15,16 @@ from openmm.app import (
     Simulation,
 )
 from openmm.openmm import XmlSerializer
-from openmm.unit import kelvin, nanometer, picoseconds
+from openmm.unit import kelvin, kilojoules_per_mole, nanometer, picoseconds
 from utils.fixed_bodies import apply_fixed_body_constraints
+from utils.logger import get_logger
 from utils.model_prep import register_ligand_templates_for_topology
 from utils.rigid_body import create_rigid_bodies, get_rigid_bodies
 
+logger = get_logger("heat")
+
 if len(sys.argv) != 2:
-    print("Usage: python heat.py <config.yaml>")
+    logger.error("Usage: python heat.py <config.yaml>")
     sys.exit(1)
 
 config_path = sys.argv[1]
@@ -62,7 +66,7 @@ rigid_bodies_configs = config["constraints"]["rigid_bodies"]
 # ⚙️ Get all rigid bodies from the modeller based on our configurations.
 rigid_bodies = get_rigid_bodies(modeller, rigid_bodies_configs)
 
-print(f"Found {len(rigid_bodies)} rigid bodies to apply constraints.")
+logger.info(f"Found {len(rigid_bodies)} rigid bodies to apply constraints.")
 
 # ⚙️ Build system
 system = forcefield.createSystem(
@@ -75,11 +79,11 @@ system = forcefield.createSystem(
 )
 
 # 🔒 Apply fixed body constraints
-print("Applying fixed body constraints...")
+logger.info("Applying fixed body constraints...")
 apply_fixed_body_constraints(system, modeller, fixed_bodies_config)
 
 # 🔒 Apply rigid body constraints
-print("Applying rigid body constraints...")
+logger.info("Applying rigid body constraints...")
 create_rigid_bodies(system, modeller.positions, list(rigid_bodies.values()))
 
 
@@ -94,15 +98,26 @@ simulation = Simulation(modeller.topology, system, integrator)
 simulation.context.setPositions(modeller.positions)
 simulation.context.setVelocitiesToTemperature(start_temp)
 
-print(f"🔥 Starting heating from {start_temp} to {final_temp}...")
+logger.info(f"🔥 Starting heating from {start_temp} to {final_temp}...")
 for step in range(nsteps):
     temperature = start_temp + temperature_increment * step
     integrator.setTemperature(temperature)
-    simulation.step(1)
-    if step % 1000 == 0:
-        print(f"Step {step}: Temperature = {temperature}")
+    try:
+        simulation.step(1)
+    except Exception as e:
+        logger.error(f"OpenMM exception at heating step {step}: {e}")
+        sys.exit(1)
 
-print("✅ Heating complete.")
+    if step % 1000 == 0:
+        state = simulation.context.getState(getEnergy=True, getPositions=True)
+        pe = state.getPotentialEnergy().value_in_unit(kilojoules_per_mole)
+        pos = state.getPositions()
+        if any(math.isnan(v) for p in pos for v in (p.x, p.y, p.z)):
+            logger.error(f"NaN detected in particle positions at step {step} — aborting.")
+            sys.exit(1)
+        logger.info(f"Step {step}: Temperature = {temperature:.2f} K, PE = {pe:.1f} kJ/mol")
+
+logger.info("✅ Heating complete.")
 
 # Save output structure
 positions = simulation.context.getState(getPositions=True).getPositions()
@@ -116,4 +131,4 @@ with open(os.path.join(heat_dir, output_restart_file_name), "w", encoding="utf-8
     state = simulation.context.getState(getPositions=True, getVelocities=True)
     f.write(XmlSerializer.serialize(state))
 
-print(f"✅ Saved {output_pdb_file_name} and {output_restart_file_name} in {heat_dir}")
+logger.info(f"✅ Saved {output_pdb_file_name} and {output_restart_file_name} in {heat_dir}")

--- a/apps/worker/scripts/openmm/md.py
+++ b/apps/worker/scripts/openmm/md.py
@@ -16,10 +16,13 @@ from openmm.app import (
 )
 from openmm.unit import angstroms
 from utils.fixed_bodies import apply_fixed_body_constraints
+from utils.logger import get_logger
 from utils.model_prep import register_ligand_templates_for_topology
 from utils.pdb_writer import PositionCapture
 from utils.rgyr import RadiusOfGyrationCVForce, RgyrDmaxCapture
 from utils.rigid_body import create_rigid_bodies, get_rigid_bodies
+
+logger = get_logger("md")
 
 
 def run_md_for_rg(rg, config_path, gpu_id=None):
@@ -62,7 +65,7 @@ def run_md_for_rg(rg, config_path, gpu_id=None):
     # Get all rigid bodies from the modeller based on our configurations.
     rigid_bodies = get_rigid_bodies(modeller, rigid_bodies_configs)
     for name, atoms in rigid_bodies.items():
-        print(
+        logger.info(
             f"[GPU {gpu_id}] Rigid body '{name}': {len(atoms)} atoms — indices: "
             f"{atoms[:10]}{'...' if len(atoms) > 10 else ''}"
         )
@@ -79,10 +82,10 @@ def run_md_for_rg(rg, config_path, gpu_id=None):
     )
 
     # 🔒 Apply fixed body constraints and rigid bodies
-    print(f"[GPU {gpu_id}] Applying fixed body constraints...")
+    logger.info(f"[GPU {gpu_id}] Applying fixed body constraints...")
     apply_fixed_body_constraints(system, modeller, fixed_bodies_config)
 
-    print(f"[GPU {gpu_id}] Applying rigid body constraints...")
+    logger.info(f"[GPU {gpu_id}] Applying rigid body constraints...")
     create_rigid_bodies(system, modeller.positions, list(rigid_bodies.values()))
 
     # ⛓️ RG restraint — applied to CA atoms only so it is consistent with the
@@ -93,7 +96,7 @@ def run_md_for_rg(rg, config_path, gpu_id=None):
     pdb_report_interval = int(config["steps"]["md"]["pdb_report_interval"])
     report_interval = int(config["steps"]["md"]["rgyr"]["report_interval"])
     rgyr_report = config["steps"]["md"]["rgyr"]["filename"]
-    print(f"\n[GPU {gpu_id}] 🔁 Running MD with Rg target: {rg} Å")
+    logger.info(f"\n[GPU {gpu_id}] 🔁 Running MD with Rg target: {rg} Å")
 
     atom_indices = [a.index for a in modeller.topology.atoms() if a.name == "CA"]
     # Convert kcal/mol/Å^2 → kJ/mol/nm^2
@@ -121,15 +124,15 @@ def run_md_for_rg(rg, config_path, gpu_id=None):
         )
         simulation.context.setState(state)
         platform = simulation.context.getPlatform().getName()
-        print(
+        logger.info(
             f"[GPU {gpu_id}] Initialized on platform: {platform} (CudaDeviceIndex={platform_props.get('CudaDeviceIndex', '-')})"
         )
     except Exception as e:
-        print(f"[GPU {gpu_id}] [WARNING] CUDA not available; falling back. Error: {e}")
+        logger.warning(f"[GPU {gpu_id}] CUDA not available; falling back. Error: {e}")
         simulation = Simulation(modeller.topology, system, integrator)
         simulation.context.setState(state)
         platform = simulation.context.getPlatform().getName()
-        print(f"[GPU {gpu_id}] Initialized on platform: {platform}")
+        logger.info(f"[GPU {gpu_id}] Initialized on platform: {platform}")
 
     rg_label = str(int(rg)) if float(rg).is_integer() else str(rg)
     rg_md_dir = os.path.join(md_dir, f"rg_{rg_label}")
@@ -163,13 +166,13 @@ def run_md_for_rg(rg, config_path, gpu_id=None):
 
     simulation.step(nsteps)
 
-    print(f"[GPU {gpu_id}] Writing {len(capture.frames)} PDB frames to {rg_md_dir}...")
+    logger.info(f"[GPU {gpu_id}] Writing {len(capture.frames)} PDB frames to {rg_md_dir}...")
     for step, positions in capture.frames:
         fname = f"{base_name}_{int(step):09d}.pdb"
         out_path = os.path.join(rg_md_dir, fname)
         with open(out_path, "w", encoding="utf-8") as fh:
             PDBFile.writeFile(simulation.topology, positions, fh, keepIds=True)
-    print(f"[GPU {gpu_id}] PDB frames written.")
+    logger.info(f"[GPU {gpu_id}] PDB frames written.")
 
     rgyr_capture.write_csv(rgyr_file_path)
 
@@ -184,7 +187,7 @@ def run_md_for_rg(rg, config_path, gpu_id=None):
     ) as out_pdb:
         PDBFile.writeFile(simulation.topology, final_state.getPositions(), out_pdb, keepIds=True)
 
-    print(f"[GPU {gpu_id}] ✅ Completed MD with Rg {rg}. Results in {rg_md_dir}")
+    logger.info(f"[GPU {gpu_id}] ✅ Completed MD with Rg {rg}. Results in {rg_md_dir}")
 
 
 def _env_int(name: str, default: int) -> int:
@@ -230,12 +233,12 @@ def select_gpu_for_standalone():
             if 0 <= gpu_id < available_gpus:
                 return gpu_id
             else:
-                print(
-                    f"[md.py] Warning: OMM_GPU_ID={gpu_id} out of range (0-{available_gpus - 1}), using 0"
+                logger.warning(
+                    f"OMM_GPU_ID={gpu_id} out of range (0-{available_gpus - 1}), using 0"
                 )
                 return 0
         except (ValueError, TypeError):
-            print(f"[md.py] Warning: Invalid OMM_GPU_ID='{gpu_override}', using 0")
+            logger.warning(f"Invalid OMM_GPU_ID='{gpu_override}', using 0")
             return 0
 
     # Default: use GPU 0, but this could be enhanced with load balancing
@@ -266,28 +269,28 @@ if __name__ == "__main__":
         try:
             rg = float(omm_rg)
             gpu_id = select_gpu_for_standalone()
-            print(f"[md.py] Standalone mode: running single Rg={rg} on GPU {gpu_id}")
+            logger.info(f"Standalone mode: running single Rg={rg} on GPU {gpu_id}")
             run_md_for_rg(rg, args.config_path, gpu_id=gpu_id)
-            print(f"[md.py] Standalone mode: completed Rg={rg}")
+            logger.info(f"Standalone mode: completed Rg={rg}")
             sys.exit(0)
         except (ValueError, TypeError) as e:
-            print(f"[md.py] Invalid OMM_RG value '{omm_rg}': {e}")
+            logger.error(f"Invalid OMM_RG value '{omm_rg}': {e}")
             sys.exit(1)
 
     # Fallback to Slurm mode
     rg_sets = config["steps"]["md"]["rgyr"].get("rg_sets", [])
     if not rg_sets:
-        print("No rg_sets found in config.")
+        logger.error("No rg_sets found in config.")
         sys.exit(1)
     if args.rg_set < 0 or args.rg_set >= len(rg_sets):
-        print(
+        logger.error(
             f"Invalid rg_set index {args.rg_set}. Available sets: 0 to {len(rg_sets) - 1}"
         )
         sys.exit(1)
 
     rgs = list(rg_sets[args.rg_set])
     if not rgs:
-        print(f"rg_set {args.rg_set} is empty.")
+        logger.error(f"rg_set {args.rg_set} is empty.")
         sys.exit(1)
 
     # Slurm task metadata
@@ -304,28 +307,28 @@ if __name__ == "__main__":
     # Shard the Rg list to this task (round-robin)
     my_rgs = rgs[task_id::world_sz]
 
-    print(f"[md.py] SLURM_JOB_ID={jobid} STEP={stepid} TASK={task_id}/{world_sz - 1}")
-    print(
-        f"[md.py] CUDA_VISIBLE_DEVICES='{cvis}' -> using local GPU index {gpu_local_index}"
+    logger.info(f"SLURM_JOB_ID={jobid} STEP={stepid} TASK={task_id}/{world_sz - 1}")
+    logger.info(
+        f"CUDA_VISIBLE_DEVICES='{cvis}' -> using local GPU index {gpu_local_index}"
     )
-    print(f"[md.py] Using rg_set {args.rg_set}: {rgs}")
-    print(f"[md.py] Rg assignments for this task: {my_rgs}")
+    logger.info(f"Using rg_set {args.rg_set}: {rgs}")
+    logger.info(f"Rg assignments for this task: {my_rgs}")
 
     if not my_rgs:
-        print(f"[md.py] Task {task_id}: no work (rgs shorter than ntasks). Exiting.")
+        logger.info(f"Task {task_id}: no work (rgs shorter than ntasks). Exiting.")
         sys.exit(0)
 
     # Run assigned Rg targets sequentially on this task/GPU
     failures = 0
     for rg in my_rgs:
         try:
-            print(f"[md.py] Task {task_id}: running Rg={rg}")
+            logger.info(f"Task {task_id}: running Rg={rg}")
             run_md_for_rg(rg, args.config_path, gpu_id=gpu_local_index)
-            print(f"[md.py] Task {task_id}: done Rg={rg}")
+            logger.info(f"Task {task_id}: done Rg={rg}")
         except Exception as e:
             failures += 1
-            print(f"[md.py] Task {task_id}: FAILED Rg={rg} -> {e}", flush=True)
+            logger.error(f"Task {task_id}: FAILED Rg={rg} -> {e}")
 
     if failures:
-        print(f"[md.py] Task {task_id}: {failures} failures.", flush=True)
+        logger.error(f"Task {task_id}: {failures} failures.")
         sys.exit(1)

--- a/apps/worker/scripts/openmm/minimize.py
+++ b/apps/worker/scripts/openmm/minimize.py
@@ -2,22 +2,27 @@
 This module provides functionality for energy minimization of a molecular system using OpenMM.
 """
 
+import math
 import os
 import sys
+
 import yaml
-from openmm.app import (
-    ForceField,
-    Simulation,
-    PDBFile,
-    CutoffNonPeriodic,
-    HBonds,
-)
 from openmm import LangevinIntegrator
-from openmm.unit import kelvin, picoseconds, nanometer
+from openmm.app import (
+    CutoffNonPeriodic,
+    ForceField,
+    HBonds,
+    PDBFile,
+    Simulation,
+)
+from openmm.unit import kelvin, kilojoules_per_mole, nanometer, picoseconds
+from utils.logger import get_logger
 from utils.model_prep import prepare_modeller
 
+logger = get_logger("minimize")
+
 if len(sys.argv) != 2:
-    print("Usage: python minimize.py <config.yaml>")
+    logger.error("Usage: python minimize.py <config.yaml>")
     sys.exit(1)
 
 config_path = sys.argv[1]
@@ -56,13 +61,31 @@ integrator = LangevinIntegrator(300 * kelvin, 1 / picoseconds, 0.002 * picosecon
 simulation = Simulation(modeller.topology, system, integrator)
 simulation.context.setPositions(modeller.positions)
 
-print("Minimizing energy...")
+logger.info("Minimizing energy...")
 simulation.minimizeEnergy()
-print("✅ Minimization complete.")
+logger.info("✅ Minimization complete.")
+
+# Energy gate: check that the minimized structure is physically reasonable.
+# A well-minimized protein is typically in the range of -50,000 to +10,000 kJ/mol.
+# Values above 1e6 kJ/mol indicate unresolved atom clashes that will cause NaN in MD.
+state = simulation.context.getState(getEnergy=True)
+pe = state.getPotentialEnergy().value_in_unit(kilojoules_per_mole)
+logger.info(f"Post-minimization potential energy: {pe:.1f} kJ/mol")
+
+if math.isnan(pe) or math.isinf(pe):
+    logger.error("Potential energy is NaN/Inf after minimization — bad input structure.")
+    sys.exit(1)
+
+if pe > 1_000_000:
+    logger.error(
+        f"Potential energy ({pe:.1f} kJ/mol) is too high after minimization — "
+        "severe atom clashes remain. Heating will fail."
+    )
+    sys.exit(1)
 
 # Step 4: Save structure
 positions = simulation.context.getState(getPositions=True).getPositions()
 with open(os.path.join(min_dir, output_pdb_file_name), "w", encoding="utf-8") as f:
     PDBFile.writeFile(modeller.topology, positions, f, keepIds=True)
 
-print(f"✅ Saved {output_pdb_file_name}")
+logger.info(f"✅ Saved {output_pdb_file_name}")

--- a/apps/worker/scripts/openmm/minimize.py
+++ b/apps/worker/scripts/openmm/minimize.py
@@ -16,6 +16,7 @@ from openmm.app import (
     Simulation,
 )
 from openmm.unit import kelvin, kilojoules_per_mole, nanometer, picoseconds
+from utils.clash_check import check_clashes
 from utils.logger import get_logger
 from utils.model_prep import prepare_modeller
 
@@ -46,7 +47,23 @@ for d in [output_dir, min_dir, heat_dir, md_dir]:
 forcefield = ForceField(*config["input"]["forcefield"])
 modeller = prepare_modeller(initial_pdb_file, config, forcefield)
 
-# Step 2: Build the system
+# Step 2: Clash check — fail fast before spending time on minimization
+hard_clashes, soft_clashes, examples = check_clashes(modeller)
+if hard_clashes:
+    logger.error(
+        f"Found {hard_clashes} inter-residue atom pair(s) closer than 0.5 Å — "
+        "input structure has severely overlapping atoms (possibly multiple molecules superimposed)."
+    )
+    for ex in examples:
+        logger.error(f"  {ex}")
+    sys.exit(1)
+if soft_clashes:
+    logger.warning(
+        f"Found {soft_clashes} inter-residue atom pair(s) closer than 1.5 Å. "
+        "Minimization may be slow or fail."
+    )
+
+# Step 3: Build the system
 system = forcefield.createSystem(
     modeller.topology,
     nonbondedMethod=CutoffNonPeriodic,
@@ -56,7 +73,7 @@ system = forcefield.createSystem(
     solventDielectric=78.5,
 )
 
-# Step 3: Energy minimization
+# Step 4: Energy minimization
 integrator = LangevinIntegrator(300 * kelvin, 1 / picoseconds, 0.002 * picoseconds)
 simulation = Simulation(modeller.topology, system, integrator)
 simulation.context.setPositions(modeller.positions)
@@ -83,7 +100,7 @@ if pe > 1_000_000:
     )
     sys.exit(1)
 
-# Step 4: Save structure
+# Step 5: Save structure
 positions = simulation.context.getState(getPositions=True).getPositions()
 with open(os.path.join(min_dir, output_pdb_file_name), "w", encoding="utf-8") as f:
     PDBFile.writeFile(modeller.topology, positions, f, keepIds=True)

--- a/apps/worker/scripts/openmm/plot_rgyrs.py
+++ b/apps/worker/scripts/openmm/plot_rgyrs.py
@@ -2,9 +2,12 @@ import os
 import pandas as pd
 import matplotlib.pyplot as plt
 import sys
+from utils.logger import get_logger
+
+logger = get_logger("plot_rgyrs")
 
 if len(sys.argv) != 2:
-    print("Usage: python plot_rgyrs.py <md_directory>")
+    logger.error("Usage: python plot_rgyrs.py <md_directory>")
     sys.exit(1)
 
 base_dir = sys.argv[1]
@@ -18,7 +21,7 @@ for subdir in sorted(os.listdir(base_dir)):
         # Look for a CSV in the subdir
         csv_files = [f for f in os.listdir(full_path) if f.endswith(".csv")]
         if not csv_files:
-            print(f"No CSV found in {full_path}")
+            logger.warning(f"No CSV found in {full_path}")
             continue
         csv_path = os.path.join(full_path, csv_files[0])
         if os.path.exists(csv_path):
@@ -50,4 +53,4 @@ plt.tight_layout()
 # Save to file
 output_file = f"rgyr_plot.png"
 plt.savefig(output_file, dpi=300)
-print(f"Plot saved to {output_file}")
+logger.info(f"Plot saved to {output_file}")

--- a/apps/worker/scripts/openmm/utils/clash_check.py
+++ b/apps/worker/scripts/openmm/utils/clash_check.py
@@ -1,0 +1,76 @@
+"""Inter-atomic clash detection for OpenMM input structures."""
+
+import numpy as np
+from openmm.unit import nanometer
+from utils.logger import get_logger
+
+logger = get_logger("clash_check")
+
+# Physically impossible for non-bonded atoms — exit immediately
+HARD_THRESHOLD_NM = 0.05  # 0.5 Å
+# Very severe clash — warn, but allow minimization to attempt recovery
+SOFT_THRESHOLD_NM = 0.15  # 1.5 Å
+# Cap for O(N²) pairwise check; sample uniformly for larger systems
+_SAMPLE_SIZE = 1500
+
+
+def check_clashes(modeller) -> tuple[int, int, list[str]]:
+    """Check for inter-residue atom clashes in the modeller positions.
+
+    Samples up to _SAMPLE_SIZE heavy atoms and computes pairwise distances.
+    Returns (hard_count, soft_count, examples) where:
+      - hard_count: pairs closer than HARD_THRESHOLD_NM (0.5 Å) — catastrophic
+      - soft_count: pairs between HARD and SOFT threshold (0.5–1.5 Å) — severe
+      - examples: up to 5 human-readable descriptions of the worst clashes
+    """
+    atoms = list(modeller.topology.atoms())
+    positions = modeller.positions
+
+    heavy = [
+        (i, a)
+        for i, a in enumerate(atoms)
+        if a.element is not None and a.element.symbol != "H"
+    ]
+    if len(heavy) < 2:
+        return 0, 0, []
+
+    sampled = heavy
+    if len(heavy) > _SAMPLE_SIZE:
+        step = len(heavy) // _SAMPLE_SIZE
+        sampled = heavy[::step]
+        logger.info(f"Clash check: sampling {len(sampled)} of {len(heavy)} heavy atoms.")
+
+    indices = [i for i, _ in sampled]
+    atom_objs = [a for _, a in sampled]
+
+    coords = np.array(
+        [list(positions[i].value_in_unit(nanometer)) for i in indices],
+        dtype=float,
+    )
+    res_indices = np.array([a.residue.index for a in atom_objs])
+
+    # Pairwise squared distances — upper triangle, inter-residue pairs only
+    diff = coords[:, None, :] - coords[None, :, :]  # (N, N, 3)
+    dist2 = np.sum(diff ** 2, axis=2)               # (N, N)
+
+    n = len(coords)
+    triu = np.triu(np.ones((n, n), dtype=bool), k=1)
+    diff_res = res_indices[:, None] != res_indices[None, :]
+
+    hard_mask = (dist2 < HARD_THRESHOLD_NM ** 2) & triu & diff_res
+    soft_mask = (dist2 < SOFT_THRESHOLD_NM ** 2) & (dist2 >= HARD_THRESHOLD_NM ** 2) & triu & diff_res
+
+    hard_count = int(np.sum(hard_mask))
+    soft_count = int(np.sum(soft_mask))
+
+    examples: list[str] = []
+    for idx_i, idx_j in np.argwhere(hard_mask)[:5]:
+        ai, aj = atom_objs[idx_i], atom_objs[idx_j]
+        d_ang = float(np.sqrt(dist2[idx_i, idx_j])) * 10  # nm → Å
+        examples.append(
+            f"{ai.residue.name}{ai.residue.id}.{ai.name} — "
+            f"{aj.residue.name}{aj.residue.id}.{aj.name} "
+            f"({d_ang:.2f} Å)"
+        )
+
+    return hard_count, soft_count, examples

--- a/apps/worker/scripts/openmm/utils/fixed_bodies.py
+++ b/apps/worker/scripts/openmm/utils/fixed_bodies.py
@@ -2,6 +2,9 @@
 
 from openmm import unit
 from openmm import CustomExternalForce
+from utils.logger import get_logger
+
+logger = get_logger("fixed_bodies")
 
 
 def apply_fixed_body_constraints_zero_mass(system, modeller, fixed_bodies):
@@ -27,13 +30,12 @@ def apply_fixed_body_constraints_zero_mass(system, modeller, fixed_bodies):
                     if start <= res_id < stop:
                         system.setParticleMass(atom.index, 0.0 * unit.amu)
                         break
-    # Debug: Print atoms with zero mass
     zero_mass_atoms = [
         i
         for i in range(system.getNumParticles())
         if system.getParticleMass(i)._value == 0
     ]
-    print(f"Zero-mass atoms: {zero_mass_atoms}")
+    logger.debug(f"Zero-mass atoms: {zero_mass_atoms}")
 
 
 def apply_fixed_body_constraints(system, modeller, fixed_bodies, kfixed=100000.0):
@@ -68,11 +70,3 @@ def apply_fixed_body_constraints(system, modeller, fixed_bodies, kfixed=100000.0
                         break  # Move to next atom once matched
 
     system.addForce(force)
-
-    # Debug: Print atoms with zero mass
-    zero_mass_atoms = [
-        i
-        for i in range(system.getNumParticles())
-        if system.getParticleMass(i)._value == 0
-    ]
-    print(f"Zero-mass atoms: {zero_mass_atoms}")

--- a/apps/worker/scripts/openmm/utils/glycam_rename.py
+++ b/apps/worker/scripts/openmm/utils/glycam_rename.py
@@ -30,6 +30,9 @@ import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Optional
+from utils.logger import get_logger
+
+logger = get_logger("glycam_rename")
 
 
 # ---------------------------------------------------------------------------
@@ -544,11 +547,11 @@ def _main() -> None:
         f.write(modified_text)
 
     if log_lines:
-        print("GLYCAM renames applied:")
+        logger.info("GLYCAM renames applied:")
         for line in log_lines:
-            print(line)
+            logger.info(line)
     else:
-        print("No GLYCAM renames needed.")
+        logger.info("No GLYCAM renames needed.")
 
     log_file = args.pdb_file.replace(".pdb", "_glycam_rename.log")
     with open(log_file, "w", encoding="utf-8") as f:

--- a/apps/worker/scripts/openmm/utils/logger.py
+++ b/apps/worker/scripts/openmm/utils/logger.py
@@ -1,0 +1,26 @@
+"""Shared logging configuration for BilboMD OpenMM scripts."""
+
+import logging
+import sys
+
+
+def get_logger(name: str = "bilbomd-openmm") -> logging.Logger:
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.DEBUG)
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.DEBUG)
+    stdout_handler.addFilter(lambda record: record.levelno < logging.WARNING)
+    stdout_handler.setFormatter(logging.Formatter("%(message)s"))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.WARNING)
+    stderr_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+
+    logger.addHandler(stdout_handler)
+    logger.addHandler(stderr_handler)
+
+    return logger

--- a/apps/worker/scripts/openmm/utils/model_prep.py
+++ b/apps/worker/scripts/openmm/utils/model_prep.py
@@ -19,6 +19,9 @@ from openmm.app import ForceField, Modeller, PDBFile
 from pdbfixer import PDBFixer
 
 from utils.glycam_rename import rename_glycam_residues
+from utils.logger import get_logger
+
+logger = get_logger("model_prep")
 
 
 # ---------------------------------------------------------------------------
@@ -90,7 +93,7 @@ def _repair_glycam_protein_topology(topology) -> int:
             topology.addBond(a1, a2)
             existing_bonds.add((a1.index, a2.index))
             existing_bonds.add((a2.index, a1.index))
-            print(f"  Repaired bond: {label}")
+            logger.info(f"  Repaired bond: {label}")
             added += 1
 
     for i, res in enumerate(res_list):
@@ -189,7 +192,7 @@ def _remove_5prime_terminal_phosphates(modeller: Modeller) -> None:
                     atoms_to_delete.append(atom)
     if atoms_to_delete:
         names = [a.name for a in atoms_to_delete]
-        print(f"  Removing {len(atoms_to_delete)} spurious 5'-terminal phosphate atom(s): {names}")
+        logger.info(f"  Removing {len(atoms_to_delete)} spurious 5'-terminal phosphate atom(s): {names}")
         modeller.delete(atoms_to_delete)
 
 
@@ -226,14 +229,14 @@ def _find_organic_ligand_sdfs(input_dir: str, unknown_resnames: list[str]) -> di
             found[name] = path
         else:
             url = f"https://files.rcsb.org/ligands/download/{name}_ideal.sdf"
-            print(f"  No SDF for {name}, attempting download from RCSB...")
+            logger.info(f"  No SDF for {name}, attempting download from RCSB...")
             try:
                 urllib.request.urlretrieve(url, path)
-                print(f"  Downloaded {name}.sdf from RCSB.")
+                logger.info(f"  Downloaded {name}.sdf from RCSB.")
                 found[name] = path
             except urllib.error.URLError as e:
-                print(f"  Warning: could not download {name}.sdf from RCSB ({e}). "
-                      f"Residue will be removed.")
+                logger.warning(f"  Could not download {name}.sdf from RCSB ({e}). "
+                               f"Residue will be removed.")
     return found
 
 
@@ -271,7 +274,7 @@ def _register_gaff_generator(forcefield: ForceField, sdf_map: dict[str, str]) ->
         try:
             mol = _load_sdf_molecule(sdf_path)
             mol.name = resname
-            print(f"  Loaded {resname} from {sdf_path} ({mol.n_atoms} atoms)")
+            logger.info(f"  Loaded {resname} from {sdf_path} ({mol.n_atoms} atoms)")
 
             # Gasteiger charges: ~8ms via RDKit, no QM required
             mol.assign_partial_charges("gasteiger")
@@ -289,12 +292,12 @@ def _register_gaff_generator(forcefield: ForceField, sdf_map: dict[str, str]) ->
 
             forcefield.loadFile(StringIO(ffxml_renamed))
             gaff_resnames.add(resname)
-            print(f"  GAFF2 template for {resname} loaded (Gasteiger charges)")
+            logger.info(f"  GAFF2 template for {resname} loaded (Gasteiger charges)")
         except Exception as e:
-            print(f"  Warning: could not parameterize {resname}: {e}")
+            logger.warning(f"  Could not parameterize {resname}: {e}")
 
     if gaff_resnames:
-        print(f"GAFF2 templates ready for: {sorted(gaff_resnames)}")
+        logger.info(f"GAFF2 templates ready for: {sorted(gaff_resnames)}")
 
     return gaff_resnames
 
@@ -434,7 +437,7 @@ def _generate_ligand_hydrogen_definitions(modeller: Modeller, sdf_map: dict[str,
             mol = _load_sdf_molecule(sdf_path)
             mapping = _map_heavy_atoms(residue, mol)
             if mapping is None:
-                print(f"  Warning: could not map heavy-atom graph for {resname}; skipping ligand hydrogen definitions.")
+                logger.warning(f"  Could not map heavy-atom graph for {resname}; skipping ligand hydrogen definitions.")
                 continue
 
             residue_heavy_atoms, _, existing_h = _build_residue_heavy_graph(residue)
@@ -459,7 +462,7 @@ def _generate_ligand_hydrogen_definitions(modeller: Modeller, sdf_map: dict[str,
                     ET.SubElement(residue_elem, "H", {"name": h_name, "parent": atom.name})
             loaded_any = True
         except Exception as e:
-            print(f"  Warning: failed to prepare ligand hydrogen definitions for {resname}: {e}")
+            logger.warning(f"  Failed to prepare ligand hydrogen definitions for {resname}: {e}")
 
     if not loaded_any:
         return ""
@@ -480,9 +483,9 @@ def _remove_unknown_residues(
         and res.name not in gaff_resnames
     ]
     if unknown:
-        print(f"Warning: removing {len(unknown)} residue(s) with no force field template:")
+        logger.warning(f"Removing {len(unknown)} residue(s) with no force field template:")
         for res in unknown:
-            print(f"  {res.name} (chain {res.chain.id}, resSeq {res.id})")
+            logger.warning(f"  {res.name} (chain {res.chain.id}, resSeq {res.id})")
         modeller.delete([atom for res in unknown for atom in res.atoms()])
 
 
@@ -503,7 +506,7 @@ def register_ligand_templates_for_topology(
     if not unknown_organic_resnames:
         return set(), {}
 
-    print(f"Unknown organic residues detected: {sorted(unknown_organic_resnames)}")
+    logger.info(f"Unknown organic residues detected: {sorted(unknown_organic_resnames)}")
     sdf_map = _find_organic_ligand_sdfs(input_dir, unknown_organic_resnames)
     if not sdf_map:
         return set(), {}
@@ -538,7 +541,7 @@ def _repair_backbone_bonds(topology, charmm36_resnames: frozenset[str]) -> int:
             topology.addBond(a1, a2)
             existing_bonds.add((a1.index, a2.index))
             existing_bonds.add((a2.index, a1.index))
-            print(f"  Repaired bond: {label}")
+            logger.info(f"  Repaired bond: {label}")
             added += 1
 
     for i, res in enumerate(res_list):
@@ -664,17 +667,17 @@ def prepare_modeller(
         # sequence aligner, causing findMissingResidues() to return {} even when
         # chain gaps exist. Running PDBFixer first on standard names ensures gaps
         # (e.g. missing loops) are correctly detected and repaired.
-        print("Glycoprotein mode: running PDBFixer on original PDB to fix chain gaps...")
+        logger.info("Glycoprotein mode: running PDBFixer on original PDB to fix chain gaps...")
         pre_fixer = PDBFixer(pdbfile=StringIO(_normalize_charmm_nucleic_names(raw_pdb)))
         pre_fixer.findMissingResidues()
-        print(f"Missing residues found by PDBFixer: {pre_fixer.missingResidues}")
+        logger.info(f"Missing residues found by PDBFixer: {pre_fixer.missingResidues}")
         pre_fixer.findNonstandardResidues()
         if pre_fixer.nonstandardResidues:
             truly_nonstandard = [(r, s) for r, s in pre_fixer.nonstandardResidues if r.name != s]
             if truly_nonstandard:
-                print("Replacing nonstandard residues with standard equivalents:")
+                logger.info("Replacing nonstandard residues with standard equivalents:")
                 for r, s in truly_nonstandard:
-                    print(f"  {r.name} → {s}")
+                    logger.info(f"  {r.name} → {s}")
                 pre_fixer.nonstandardResidues = truly_nonstandard
                 pre_fixer.replaceNonstandardResidues()
         pre_fixer.findMissingAtoms()
@@ -691,41 +694,41 @@ def prepare_modeller(
         PDBFile.writeFile(pre_fixer.topology, pre_fixer.positions, fixed_pdb_io, keepIds=True)
         fixed_pdb_text = fixed_pdb_io.getvalue()
 
-        print("Glycoprotein mode: applying GLYCAM residue renaming to fixed PDB...")
+        logger.info("Glycoprotein mode: applying GLYCAM residue renaming to fixed PDB...")
         renamed_pdb, glycam_log = rename_glycam_residues(fixed_pdb_text)
         log_path = os.path.join(config["input"]["dir"], "glycam_rename.log")
         with open(log_path, "w", encoding="utf-8") as f:
             f.write("\n".join(glycam_log) + "\n")
-        print(f"GLYCAM rename log written to {log_path}")
+        logger.info(f"GLYCAM rename log written to {log_path}")
         for line in glycam_log:
-            print(line)
+            logger.info(line)
 
         fixer = PDBFixer(pdbfile=StringIO(renamed_pdb))
         fixer.findNonstandardResidues()
         if fixer.nonstandardResidues:
-            print("Nonstandard residues found (GLYCAM names expected here, not replaced):")
+            logger.info("Nonstandard residues found (GLYCAM names expected here, not replaced):")
             for residue in fixer.nonstandardResidues:
-                print(f" - {residue}")
+                logger.info(f" - {residue}")
         # OpenMM's PDB reader doesn't establish C→N backbone bonds when the destination
         # residue is a GLYCAM protein residue (NLN, OLS, OLT) unknown to its templates.
         n_repaired = _repair_glycam_protein_topology(fixer.topology)
         if n_repaired:
-            print(f"Repaired {n_repaired} missing bond(s) for GLYCAM protein residues.")
+            logger.info(f"Repaired {n_repaired} missing bond(s) for GLYCAM protein residues.")
         # Skip addMissingHydrogens: it triggers CCD downloads for GLYCAM residue names
         # whose mmCIF entries contain '?' coordinates that PDBFixer cannot parse.
         # Hydrogens are added below via modeller.addHydrogens() using GLYCAM_06j-1.xml.
-        print("Glycoprotein mode: skipping PDBFixer.addMissingHydrogens() to avoid GLYCAM CCD downloads.")
+        logger.info("Glycoprotein mode: skipping PDBFixer.addMissingHydrogens() to avoid GLYCAM CCD downloads.")
     else:
         normalized_pdb = _normalize_charmm_nucleic_names(raw_pdb)
         fixer = PDBFixer(pdbfile=StringIO(normalized_pdb))
         fixer.findMissingResidues()
         fixer.findNonstandardResidues()
         if fixer.nonstandardResidues:
-            print("Nonstandard residues found:")
+            logger.info("Nonstandard residues found:")
             for residue in fixer.nonstandardResidues:
-                print(f" - {residue}")
+                logger.info(f" - {residue}")
         else:
-            print("No nonstandard residues found.")
+            logger.info("No nonstandard residues found.")
         fixer.findMissingAtoms()
         fixer.addMissingAtoms()
         fixer.addMissingHydrogens(pH=7.0)
@@ -738,18 +741,18 @@ def prepare_modeller(
     if charmm36_resnames:
         n_repaired = _repair_backbone_bonds(modeller.topology, charmm36_resnames)
         if n_repaired:
-            print(f"Repaired {n_repaired} missing backbone bond(s) for CHARMM36 residues.")
+            logger.info(f"Repaired {n_repaired} missing backbone bond(s) for CHARMM36 residues.")
         # Normalise phosphate oxygen names (OP1/OP2/OP3 → O1P/O2P/O3P) to match
         # the CHARMM36 template. pdbNames.xml only has this alias for Nucleic residues.
         n_renamed = _rename_charmm36_atoms(modeller.topology, charmm36_resnames)
         if n_renamed:
-            print(f"Renamed {n_renamed} phosphate oxygen atom(s) to CHARMM36 convention.")
+            logger.info(f"Renamed {n_renamed} phosphate oxygen atom(s) to CHARMM36 convention.")
         # Add intra-residue heavy-atom bonds from the CHARMM36 templates. PDBFixer
         # leaves non-standard residues unconnected internally; without these bonds
         # the graph-based template matcher in createSystem cannot match TPO/SEP/PTR.
         n_bonds = _add_charmm36_intra_bonds(modeller.topology, charmm36_resnames, forcefield)
         if n_bonds:
-            print(f"Added {n_bonds} intra-residue bond(s) for CHARMM36 residues.")
+            logger.info(f"Added {n_bonds} intra-residue bond(s) for CHARMM36 residues.")
 
     # PDBFixer.addMissingAtoms() incorrectly adds P/OP1/OP2 to the 5' terminus
     # of DNA/RNA chains. Strip them before addHydrogens() to avoid template mismatch.
@@ -812,10 +815,7 @@ def prepare_modeller(
     except ValueError as e:
         info = _extract_template_error_info(str(e))
         if info:
-            print(
-                f"BILBOMD_OPENMM_ERROR: {json.dumps({**info, 'message': str(e)})}",
-                flush=True,
-            )
+            logger.info(f"BILBOMD_OPENMM_ERROR: {json.dumps({**info, 'message': str(e)})}")
         raise
 
     return modeller

--- a/apps/worker/scripts/openmm/utils/rgyr.py
+++ b/apps/worker/scripts/openmm/utils/rgyr.py
@@ -3,6 +3,9 @@ from openmm import CustomCVForce, CustomCentroidBondForce
 from openmm.unit import nanometer, dalton, angstroms
 import csv
 import numpy as np
+from utils.logger import get_logger
+
+logger = get_logger("rgyr")
 
 
 class MinimalReporter:
@@ -13,7 +16,7 @@ class MinimalReporter:
         return (self.interval, True, False, False, False)
 
     def report(self, simulation, state):
-        print(f"MinimalReporter called at step {simulation.currentStep}")
+        logger.debug(f"MinimalReporter called at step {simulation.currentStep}")
 
 
 class TestReporter:
@@ -24,7 +27,7 @@ class TestReporter:
         return (self.interval, False, False, False, False)
 
     def report(self, simulation, state):
-        print(f"TestReporter triggered at step {simulation.currentStep}")
+        logger.debug(f"TestReporter triggered at step {simulation.currentStep}")
 
 
 class RgyrDmaxCapture:
@@ -57,7 +60,7 @@ class RgyrDmaxCapture:
             writer = csv.writer(f)
             writer.writerow(["Step", "Rgyr_A", "Dmax_A"])
             writer.writerows(self.rows)
-        print(f"Wrote {len(self.rows)} Rgyr/Dmax rows to {filepath}")
+        logger.info(f"Wrote {len(self.rows)} Rgyr/Dmax rows to {filepath}")
 
 
 class RgyrDmaxReporter:
@@ -97,11 +100,11 @@ class RgyrDmaxReporter:
             dmax = np.max(np.sqrt(np.sum(diff ** 2, axis=-1)))
             self.writer.writerow([simulation.currentStep, rg, dmax])
             self.csvfile.flush()
-            print(
+            logger.debug(
                 f"Step {simulation.currentStep}: Rgyr = {rg:.4f} Å, Dmax = {dmax:.4f} Å"
             )
         except Exception as e:
-            print(f"Exception in RgyrDmaxReporter: {e}")
+            logger.debug(f"Exception in RgyrDmaxReporter: {e}")
 
     def __del__(self):
         if hasattr(self, "csvfile") and not self.csvfile.closed:
@@ -129,7 +132,7 @@ class RadiusOfGyrationCVForce(CustomCVForce):
             force_group (int): Force group to assign.
         """
         num_atoms = len(atom_indices)
-        print(f"num_atoms in Rg calc: {num_atoms}")
+        logger.debug(f"num_atoms in Rg calc: {num_atoms}")
 
         # Define expression: mean squared distance between atoms and group centroid
         rg2_force = CustomCentroidBondForce(2, f"(distance(g1, g2)^2)/{num_atoms}")
@@ -150,21 +153,21 @@ class RadiusOfGyrationCVForce(CustomCVForce):
 
         rg2_force.addGroup(atom_indices, weights)  # g2
 
-        print("Added groups to rg2_force")
+        logger.debug("Added groups to rg2_force")
         # Add bonds between atom-groups (g1) and centroid (g2)
         for i in range(num_atoms):
             rg2_force.addBond(
                 [i, num_atoms]
             )  # last group is full group (index = num_atoms)
 
-        print("Added bonds to rg2_force")
+        logger.debug("Added bonds to rg2_force")
         # Create CV force based on sqrt(Rg²)
         super().__init__("0.5 * k_rg * (sqrt(cv) - rg0)^2")
         self.addGlobalParameter("k_rg", k_rg)
         self.addGlobalParameter("rg0", rg0)
         self.addCollectiveVariable("cv", rg2_force)
         self.setForceGroup(force_group)
-        print("Done creating CVForce object for Rg")
+        logger.debug("Done creating CVForce object for Rg")
 
 
 def compute_radius_of_gyration(positions, atom_indices, masses):

--- a/apps/worker/scripts/openmm/utils/rigid_body.py
+++ b/apps/worker/scripts/openmm/utils/rigid_body.py
@@ -7,6 +7,9 @@ import openmm as omm
 from openmm import unit, Vec3
 from openmm.app import Topology
 from openmm.unit import amu, nanometer
+from utils.logger import get_logger
+
+logger = get_logger("rigid_body")
 
 
 def apply_rigid_body_constraint(
@@ -35,9 +38,9 @@ def apply_rigid_body_constraint(
             for atom in topology.atoms()
             if atom.index in atom_indices
         }
-        print(f"Applying rigid body constraints to atoms: {atom_info}")
+        logger.info(f"Applying rigid body constraints to atoms: {atom_info}")
     else:
-        print(f"Applying rigid body constraints to atoms: {atom_indices}")
+        logger.info(f"Applying rigid body constraints to atoms: {atom_indices}")
 
     # Add constraints for each unique pair of atoms
     added_pairs = set()
@@ -66,7 +69,7 @@ def apply_rigid_body_constraint(
             if not exists:
                 system.addConstraint(a1, a2, d)
                 added_pairs.add(pair)
-    print("Rigid body constraints applied successfully.")
+    logger.info("Rigid body constraints applied successfully.")
     return system
 
 

--- a/apps/worker/src/services/functions/openmm-functions.ts
+++ b/apps/worker/src/services/functions/openmm-functions.ts
@@ -340,6 +340,7 @@ const runOmmStep = async (
     }
 
     let ommErrorDetail: string | null = null
+    let lastStderrError: string | null = null
     const result = await runPythonStep(scriptPath, configYamlPath, {
       cwd: opts?.cwd,
       pythonBin: opts?.pythonBin ?? config.openmmPythonBin,
@@ -353,6 +354,9 @@ const runOmmStep = async (
       },
       onStderrLine: (line) => {
         logger.error(`[${stepKey}][stderr] ${line}`)
+        if (line.startsWith('ERROR: ')) {
+          lastStderrError = line.slice('ERROR: '.length).trim()
+        }
       }
     })
 
@@ -370,9 +374,10 @@ const runOmmStep = async (
         }
       }
       throw new Error(
-        `${stepName} failed (exit ${result.code}${
-          result.signal ? `, signal ${result.signal}` : ''
-        })${detail}`
+        lastStderrError ??
+          `${stepName} failed (exit ${result.code}${
+            result.signal ? `, signal ${result.signal}` : ''
+          })${detail}`
       )
     }
 

--- a/infra/docker-compose-epyc.dev.yml
+++ b/infra/docker-compose-epyc.dev.yml
@@ -87,7 +87,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   backend:
-    image: ghcr.io/bl1231/bilbomd-backend:2.8.4
+    image: ghcr.io/bl1231/bilbomd-backend:2.8.5
     pull_policy: missing
     security_opt:
       - no-new-privileges:true
@@ -121,7 +121,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   worker:
-    image: ghcr.io/bl1231/bilbomd-worker:2.13.0
+    image: ghcr.io/bl1231/bilbomd-worker:pr-798-5ce526de
     pull_policy: missing
     security_opt:
       - no-new-privileges:true
@@ -251,7 +251,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   ui:
-    image: ghcr.io/bl1231/bilbomd-ui:2.17.0
+    image: ghcr.io/bl1231/bilbomd-ui:pr-798-5ce526de
     pull_policy: missing
     security_opt:
       - seccomp:./seccomp/bilbomd-seccomp.json

--- a/infra/docker-compose-epyc.prod.yml
+++ b/infra/docker-compose-epyc.prod.yml
@@ -83,7 +83,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   backend:
-    image: ghcr.io/bl1231/bilbomd-backend:2.8.3
+    image: ghcr.io/bl1231/bilbomd-backend:2.8.5
     pull_policy: missing
     security_opt:
       - no-new-privileges:true
@@ -117,7 +117,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   worker:
-    image: ghcr.io/bl1231/bilbomd-worker:2.12.0
+    image: ghcr.io/bl1231/bilbomd-worker:2.13.1
     pull_policy: missing
     security_opt:
       - no-new-privileges:true
@@ -247,7 +247,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   ui:
-    image: ghcr.io/bl1231/bilbomd-ui:2.16.1
+    image: ghcr.io/bl1231/bilbomd-ui:2.18.0
     pull_policy: missing
     security_opt:
       - seccomp:./seccomp/bilbomd-seccomp.json


### PR DESCRIPTION
## Summary

- Adds `utils/logger.py` — a shared logging utility that routes `INFO`/`DEBUG` to stdout and `WARNING`/`ERROR` to stderr, matching the Node.js worker's existing `[step][stdout]` → `logger.info` / `[step][stderr]` → `logger.error` tagging
- Replaces all `print()` calls across all 9 OpenMM Python scripts with appropriate logger calls
- Adds a **post-minimization energy gate** in `minimize.py`: checks potential energy after `minimizeEnergy()` and exits with code 1 if NaN/Inf or above 1,000,000 kJ/mol — catching severe atom-clash failures at the correct step with a clear diagnostic message instead of an opaque NaN crash during heating
- Expands `heat.py` per-checkpoint logging to include potential energy alongside temperature every 1000 steps, with NaN position detection and graceful early abort

## Motivation

A production job failed with `openmm.OpenMMException: Particle coordinate is NaN` at step 0 of heating. The root cause was a minimized structure with residual atom clashes, but there was no early warning — the failure appeared one step after the actual problem. With this change, bad structures fail at `minimize` with a logged energy value rather than crashing silently in `heat`.

## Test plan

- [x] All 132 worker tests pass (`pnpm -F @bilbomd/worker test`)
- [ ] Deploy to Hyperion and run a `BilboMdPDB` job end-to-end — confirm `[minimize][stdout]` logs show the post-minimization energy value
- [ ] Confirm that a job with a bad input structure now fails at the `minimize` step with a clear energy message on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)