### PR TITLE
fix(ui): hide OF3 nav item and swap Queued→Queue Time column on NERSC

### DIFF
--- a/.changeset/ui-nersc-nav-and-columns.md
+++ b/.changeset/ui-nersc-nav-and-columns.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Hide BilboMD OF3 nav item and Queued column when deployed to NERSC. Queue Time is shown instead of Queued on NERSC.

--- a/apps/ui/src/features/jobs/Jobs.tsx
+++ b/apps/ui/src/features/jobs/Jobs.tsx
@@ -610,11 +610,15 @@ const Jobs = () => {
         valueGetter: (_value, row) => parseDateSafe(row.time_completed),
         valueFormatter: (value: unknown) => formatDateSafe(value)
       },
-      {
-        field: 'queuedTime',
-        headerName: 'Queued',
-        width: 100
-      },
+      ...(!useNersc
+        ? [
+            {
+              field: 'queuedTime',
+              headerName: 'Queued',
+              width: 100
+            }
+          ]
+        : []),
       {
         field: 'totalRuntime',
         headerName: 'Runtime',

--- a/apps/ui/src/layout/MainLayout/index.tsx
+++ b/apps/ui/src/layout/MainLayout/index.tsx
@@ -123,6 +123,9 @@ export default function ClippedDrawer() {
   if (useNersc || !enableBilboMdScoper) {
     jobFormsGroup = jobFormsGroup.filter((item) => item.text !== 'Scoper')
   }
+  if (useNersc) {
+    jobFormsGroup = jobFormsGroup.filter((item) => item.text !== 'BilboMD OF3')
+  }
   if (!enableBilboMdSANS) {
     jobFormsGroup = jobFormsGroup.filter((item) => item.text !== 'BilboMD SANS')
   }


### PR DESCRIPTION
## Summary

- Hide **BilboMD OF3** from the left nav when `useNersc` is true (same pattern used for Scoper)
- Hide the **Queued** column from the jobs table on NERSC; **Queue Time** (NERSC queue hours) is already shown there instead

## Test plan

- [ ] On non-NERSC deploy: OF3 nav item visible, Queued column visible, Queue Time hidden
- [ ] On NERSC deploy: OF3 nav item hidden, Queued column hidden, Queue Time visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)