### PR TITLE
feat(auth): gate ORCID login behind ORCID_AUTH_ENABLED feature flag

### DIFF
--- a/.changeset/orcid-auth-feature-flag.md
+++ b/.changeset/orcid-auth-feature-flag.md
@@ -1,0 +1,6 @@
+---
+'@bilbomd/backend': minor
+'@bilbomd/ui': minor
+---
+
+Add `ORCID_AUTH_ENABLED` feature flag (default `false`) that gates the ORCID OAuth login flow. When disabled, the backend does not register the `/api/v1/auth/orcid/*` routes and skips OIDC discovery on startup, and the UI `/login` page redirects to `/magicklink`. ORCID will stay disabled in production until the hardening work tracked in issue #817 is complete.

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -15,7 +15,7 @@ import { connectDB } from './config/dbConn.js'
 import { initOrcidClient } from './controllers/auth/orcidClientConfig.js'
 import { CronJob } from 'cron'
 import { deleteOldJobs } from './middleware/jobCleaner.js'
-import { getEnvVar } from './config/config.js'
+import { config, getEnvVar } from './config/config.js'
 import sfapiRoutes from './routes/sfapi.js'
 import registerRoutes from './routes/register.js'
 import verifyRoutes from './routes/verify.js'
@@ -56,8 +56,15 @@ mongoose.set('sanitizeFilter', true)
 // Connect to MongoDB
 connectDB()
 
-// Initialize the ORCID client configuration
-await initOrcidClient()
+// Initialize the ORCID client configuration only when ORCID auth is enabled.
+// See https://github.com/bl1231/bilbomd/issues/817 — ORCID is gated behind a
+// feature flag until the hardening work is complete.
+if (config.orcidAuthEnabled) {
+  await initOrcidClient()
+  logger.info('ORCID auth enabled')
+} else {
+  logger.info('ORCID auth disabled (ORCID_AUTH_ENABLED is not true)')
+}
 
 // custom middleware logger
 app.use(assignRequestId)

--- a/apps/backend/src/config/config.ts
+++ b/apps/backend/src/config/config.ts
@@ -45,5 +45,6 @@ export const config = {
     AlphaFoldEnabled: toBoolean(process.env.ENABLE_BILBOMD_ALPHAFOLD),
     MultiEnabled: toBoolean(process.env.ENABLE_BILBOMD_MULTI),
     ScoperEnabled: toBoolean(process.env.ENABLE_BILBOMD_SCOPER)
-  }
+  },
+  orcidAuthEnabled: toBoolean(process.env.ORCID_AUTH_ENABLED)
 }

--- a/apps/backend/src/controllers/configsController.ts
+++ b/apps/backend/src/controllers/configsController.ts
@@ -68,7 +68,8 @@ export const getConfigsStuff = async (
       'ENABLE_BILBOMD_OPENFOLD',
       'ENABLE_BILBOMD_SCOPER',
       'ENABLE_HOME_PAGE_ALERT',
-      'ENABLE_CHARMM_ENGINE'
+      'ENABLE_CHARMM_ENGINE',
+      'ORCID_AUTH_ENABLED'
     ]
 
     envVars.forEach((envVar) => {
@@ -90,6 +91,7 @@ export const getConfigsStuff = async (
       enableBilboMdScoper: process.env.ENABLE_BILBOMD_SCOPER || 'false',
       enableHomePageAlert: process.env.ENABLE_HOME_PAGE_ALERT || 'false',
       enableCharmmEngine: process.env.ENABLE_CHARMM_ENGINE || 'true',
+      orcidAuthEnabled: process.env.ORCID_AUTH_ENABLED || 'false',
       backendVersion: process.env.BILBOMD_BACKEND_VERSION || '0.0.0',
       backendGitHash: process.env.BILBOMD_BACKEND_GIT_HASH || 'abc123',
       workerVersion: workerInfo.version || '0.0.0',

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -5,6 +5,7 @@ import { handleOrcidCallback } from '../controllers/auth/handleOrcidCallback.js'
 import { loginLimiter } from '../middleware/loginLimiter.js'
 import { handleOrcidFinalize } from '../controllers/auth/handleOrcidFinalize.js'
 import { handleOrcidConfirmation } from '../controllers/auth/handleOrcidConfirmation.js'
+import { config } from '../config/config.js'
 
 const router = express.Router()
 
@@ -12,9 +13,11 @@ router.route('/otp').post(loginLimiter, otp)
 router.route('/refresh').get(refresh)
 router.route('/logout').post(logout)
 
-router.route('/orcid/login').get(handleOrcidLogin)
-router.route('/orcid/callback').get(handleOrcidCallback)
-router.route('/orcid/confirmation').get(handleOrcidConfirmation)
-router.route('/orcid/finalize').post(handleOrcidFinalize)
+if (config.orcidAuthEnabled) {
+  router.route('/orcid/login').get(handleOrcidLogin)
+  router.route('/orcid/callback').get(handleOrcidCallback)
+  router.route('/orcid/confirmation').get(handleOrcidConfirmation)
+  router.route('/orcid/finalize').post(handleOrcidFinalize)
+}
 
 export default router

--- a/apps/ui/src/features/auth/Login.tsx
+++ b/apps/ui/src/features/auth/Login.tsx
@@ -1,8 +1,23 @@
+import { Navigate } from 'react-router'
 import orcidLogo from '../../assets/orcid.png'
 import { Button, Container, Typography, Box } from '@mui/material'
 import LoginIcon from '@mui/icons-material/Login'
+import { useGetConfigsQuery } from 'slices/configsApiSlice'
 
 const LoginPage = () => {
+  const { data: configs, isLoading } = useGetConfigsQuery('configData')
+
+  if (isLoading) return null
+
+  if (configs?.orcidAuthEnabled !== 'true') {
+    return (
+      <Navigate
+        to='/magicklink'
+        replace
+      />
+    )
+  }
+
   const handleOrcidLogin = () => {
     window.location.href = '/api/v1/auth/orcid/login'
   }
@@ -11,12 +26,23 @@ const LoginPage = () => {
     <Container maxWidth='sm'>
       <Box sx={{ mt: 10, textAlign: 'center' }}>
         <Box sx={{ display: 'flex', justifyContent: 'center', mb: 2 }}>
-          <img src={orcidLogo} alt='ORCID iD logo' width={100} height='auto' />
+          <img
+            src={orcidLogo}
+            alt='ORCID iD logo'
+            width={100}
+            height='auto'
+          />
         </Box>
-        <Typography variant='h4' gutterBottom>
+        <Typography
+          variant='h4'
+          gutterBottom
+        >
           Sign in with ORCID
         </Typography>
-        <Typography variant='body1' sx={{ mb: 4 }}>
+        <Typography
+          variant='body1'
+          sx={{ mb: 4 }}
+        >
           BilboMD uses ORCID to authenticate users. Click below to log in
           securely using your ORCID iD.
         </Typography>

--- a/apps/ui/src/slices/configsApiSlice.ts
+++ b/apps/ui/src/slices/configsApiSlice.ts
@@ -5,6 +5,7 @@ export interface ConfigResponse {
   enableBilboMdAlphaFold?: string
   enableBilboMdOpenfold?: string
   enableCharmmEngine?: string
+  orcidAuthEnabled?: string
   [key: string]: string | undefined
 }
 

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -113,7 +113,13 @@ PREPARE_OMM_SLURM_SCRIPT=gen-sbatch-omm.py
 CP2CFS_SCRIPT=copy2cfs.sh
 
 # ORCID OAUTH stuff
-# Not implemented yet.
+# Feature flag — ORCID login is currently disabled in production while the
+# hardening work tracked in https://github.com/bl1231/bilbomd/issues/817
+# is completed. When 'false' (the default), the backend does not register
+# /api/v1/auth/orcid/* routes, skips OIDC discovery on startup, and the UI
+# /login page redirects to /magicklink. Set to 'true' only in dev/staging
+# while testing the hardened flow.
+ORCID_AUTH_ENABLED=false
 # SANDBOX
 ORCID_CLIENT_ID=APP-XXXXXXXXXXX
 ORCID_CLIENT_SECRET=XXXXXXXXXXXXXXXX


### PR DESCRIPTION
## Summary

- Adds an `ORCID_AUTH_ENABLED` env-driven feature flag (default `false`) that disables ORCID OAuth across the backend and UI until the hardening work in #817 is complete.
- When the flag is off: the backend skips registering `/api/v1/auth/orcid/*` routes, skips OIDC discovery on startup, exposes `orcidAuthEnabled: 'false'` via `/api/v1/configs`, and the UI `/login` page redirects to `/magicklink`.
- This is PR 0 of the remediation plan in #817 — production stays on magic-link/OTP while subsequent PRs land the security and correctness fixes.

## Why

ORCID login is currently the only entry point in the staging `Login.tsx`, but production still runs the legacy magic-link/OTP flow and the ORCID implementation has only been exercised against the sandbox. Although the production UI does not link to `/login`, the route is reachable by typing the URL — so the ORCID flow is one direct-link click away from real users. This change makes the disable explicit (not security-through-obscurity) so we can take our time with the hardening PRs.

## Test plan

- [ ] With `ORCID_AUTH_ENABLED=false` (default): `curl /api/v1/auth/orcid/login` returns 404
- [ ] With `ORCID_AUTH_ENABLED=false`: `curl /api/v1/configs` returns `"orcidAuthEnabled":"false"`
- [ ] With `ORCID_AUTH_ENABLED=false`: visiting `/login` in the browser redirects to `/magicklink`
- [ ] Backend startup log contains `ORCID auth disabled (ORCID_AUTH_ENABLED is not true)`
- [ ] With `ORCID_AUTH_ENABLED=true` (local dev): `/login` renders the ORCID button and the existing sandbox flow still works end-to-end
- [x] `pnpm lint && pnpm build && pnpm test` all green (1072 UI tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)