### PR TITLE
feat(auth): ORCID data hygiene & UX — opaque username, drop persisted tokens, read-only confirmation

### DIFF
--- a/.changeset/orcid-data-hygiene.md
+++ b/.changeset/orcid-data-hygiene.md
@@ -1,0 +1,26 @@
+---
+'@bilbomd/backend': minor
+'@bilbomd/mongodb-schema': minor
+'@bilbomd/ui': minor
+---
+
+ORCID data hygiene & UX (PR 3 of issue #817). Separates the internal `username` (an opaque, URL-safe identifier) from the human-readable `displayName`, removes dead OAuth-token storage, and aligns the sign-in UI with ORCID's official branding guidelines.
+
+**Option A: separate internal ID from display label**
+- ORCID accounts now get an opaque `username = orcid-${orcidId}` (e.g., `orcid-0000-0002-1234-5678`). Deterministic, unique by construction, URL-safe, and decoupled from any human name.
+- New backend helper `userDisplayName()` derives a display label from `firstName + lastName`, falling back to `username` for legacy users with no name fields populated.
+- Access-token JWT payload now includes a `displayName` claim, computed at sign time. The UI `useAuth` hook exposes it; legacy tokens without the claim fall back to `username`.
+- UI display sites (`Breadcrumbs`, `Settings` → `UserAvatar`) now show `displayName` instead of `username`. URL routes, job-ownership filters, and admin-edit forms still use `username`.
+- Admin-edit username regex relaxed from `[a-zA-Z0-9_]+` to `[a-zA-Z0-9_-]+` so ORCID-derived usernames pass validation.
+
+**H3: stop persisting ORCID access/refresh tokens**
+- Dropped `accessToken`, `refreshToken`, `tokenType`, `scope`, and `expiresIn` from the User schema `oauth[]` subdocument and from the OAuth session profile. We never call ORCID APIs on the user's behalf after sign-in, so persisting the bearer token only enlarged the blast radius if the database were leaked. Existing data on old user docs is harmless and will fall off on next login.
+
+**H4: confirmation page becomes read-only**
+- `OrcidConfirmation` is no longer a misleading editable form — Formik + Yup + `TextField` are gone. Replaced with read-only display rows that surface First Name, Last Name, Email, ORCID iD, the derived BilboMD display name, and the opaque BilboMD account ID. Clicking "Confirm and Continue" calls finalize with an empty body (the backend has always trusted the session profile, not the request body).
+
+**L4: branding text**
+- `Login.tsx` heading and button updated from "Sign in with ORCID" to "Sign in with ORCID iD" per ORCID's official sign-in guidelines.
+
+**L5: ORCID brand asset**
+- The existing `apps/ui/src/assets/orcid.png` is the ORCID wordmark. ORCID's sign-in guidelines call for the circular green iD icon on sign-in buttons; the wordmark is for "about" contexts. Flagged for replacement before the production-credential review demo.

--- a/apps/backend/src/controllers/auth/__tests__/authTokens.test.ts
+++ b/apps/backend/src/controllers/auth/__tests__/authTokens.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import jwt from 'jsonwebtoken'
+import type { Response } from 'express'
+import type { IUser } from '@bilbomd/mongodb-schema'
+
+vi.mock('../../../config/config.js', () => ({
+  config: { logLevel: 'info', sendEmailNotifications: false },
+  getEnvVar: vi.fn().mockReturnValue('test-secret')
+}))
+
+import { issueTokensAndSetCookie } from '../authTokens.js'
+
+const makeUser = (overrides: Partial<IUser> = {}): IUser =>
+  ({
+    username: 'orcid-0000-0002-1234-5678',
+    email: 'scott@example.com',
+    firstName: 'Scott',
+    lastName: 'Classen',
+    roles: ['User'],
+    ...overrides
+  }) as unknown as IUser
+
+const makeRes = (): Response => {
+  const res = {} as Response
+  res.cookie = vi.fn().mockReturnValue(res)
+  return res
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('issueTokensAndSetCookie', () => {
+  it('includes displayName claim derived from firstName + lastName', async () => {
+    const accessToken = await issueTokensAndSetCookie(makeUser(), makeRes())
+    const decoded = jwt.verify(accessToken, 'test-secret') as {
+      UserInfo: { username: string; displayName: string; email: string }
+    }
+
+    expect(decoded.UserInfo.displayName).toBe('Scott Classen')
+    expect(decoded.UserInfo.username).toBe('orcid-0000-0002-1234-5678')
+    expect(decoded.UserInfo.email).toBe('scott@example.com')
+  })
+
+  it('falls back to username when firstName + lastName are absent', async () => {
+    const accessToken = await issueTokensAndSetCookie(
+      makeUser({
+        firstName: null as unknown as string,
+        lastName: null as unknown as string,
+        username: 'legacy_user'
+      }),
+      makeRes()
+    )
+    const decoded = jwt.verify(accessToken, 'test-secret') as {
+      UserInfo: { displayName: string }
+    }
+
+    expect(decoded.UserInfo.displayName).toBe('legacy_user')
+  })
+
+  it('sets the refresh token cookie', async () => {
+    const res = makeRes()
+    await issueTokensAndSetCookie(makeUser(), res)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      'jwt',
+      expect.any(String),
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: 'lax',
+        maxAge: 7 * 24 * 60 * 60 * 1000
+      })
+    )
+  })
+})

--- a/apps/backend/src/controllers/auth/__tests__/displayName.test.ts
+++ b/apps/backend/src/controllers/auth/__tests__/displayName.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { userDisplayName } from '../displayName.js'
+
+describe('userDisplayName', () => {
+  it('returns "First Last" when both names are present', () => {
+    expect(
+      userDisplayName({
+        username: 'orcid-0000-0002-1234-5678',
+        firstName: 'Scott',
+        lastName: 'Classen'
+      })
+    ).toBe('Scott Classen')
+  })
+
+  it('returns just the first name when last name is absent', () => {
+    expect(
+      userDisplayName({
+        username: 'orcid-x',
+        firstName: 'Scott',
+        lastName: null
+      })
+    ).toBe('Scott')
+  })
+
+  it('returns just the last name when first name is absent', () => {
+    expect(
+      userDisplayName({
+        username: 'orcid-x',
+        firstName: undefined,
+        lastName: 'Classen'
+      })
+    ).toBe('Classen')
+  })
+
+  it('falls back to username when both names are missing', () => {
+    expect(
+      userDisplayName({
+        username: 'legacy_user',
+        firstName: null,
+        lastName: null
+      })
+    ).toBe('legacy_user')
+  })
+
+  it('trims whitespace from first and last names', () => {
+    expect(
+      userDisplayName({
+        username: 'u',
+        firstName: '  Scott  ',
+        lastName: '  Classen  '
+      })
+    ).toBe('Scott Classen')
+  })
+
+  it('treats whitespace-only names as missing and falls back to username', () => {
+    expect(
+      userDisplayName({
+        username: 'fallback',
+        firstName: '   ',
+        lastName: '   '
+      })
+    ).toBe('fallback')
+  })
+})

--- a/apps/backend/src/controllers/auth/__tests__/handleOrcidCallback.test.ts
+++ b/apps/backend/src/controllers/auth/__tests__/handleOrcidCallback.test.ts
@@ -288,5 +288,22 @@ describe('handleOrcidCallback', () => {
         })
       )
     })
+
+    it('does NOT persist ORCID access/refresh tokens in the session (H3)', async () => {
+      tokensWithEmail([
+        { email: 'scott@example.com', primary: true, verified: true }
+      ])
+      findOneMock.mockResolvedValue(null)
+
+      const req = makeReq()
+      await handleOrcidCallback(req, makeRes())
+
+      const stored = req.session.orcidProfile as Record<string, unknown>
+      expect(stored).not.toHaveProperty('accessToken')
+      expect(stored).not.toHaveProperty('refreshToken')
+      expect(stored).not.toHaveProperty('tokenType')
+      expect(stored).not.toHaveProperty('scope')
+      expect(stored).not.toHaveProperty('expiresIn')
+    })
   })
 })

--- a/apps/backend/src/controllers/auth/__tests__/handleOrcidFinalize.test.ts
+++ b/apps/backend/src/controllers/auth/__tests__/handleOrcidFinalize.test.ts
@@ -43,11 +43,6 @@ const makeReq = (overrides: Partial<Request['session']> = {}): Request =>
         givenName: 'Scott',
         familyName: 'Classen',
         orcidId: ORCID_ID,
-        accessToken: 'orcid-access',
-        tokenType: 'bearer',
-        refreshToken: 'orcid-refresh',
-        scope: 'openid',
-        expiresIn: 3600,
         name: 'Scott Classen'
       },
       ...overrides
@@ -118,7 +113,7 @@ describe('handleOrcidFinalize', () => {
   })
 
   describe('happy path', () => {
-    it('creates a new Active user and issues tokens when no email collision', async () => {
+    it('creates a new Active user with opaque ORCID-derived username', async () => {
       findOneMock.mockResolvedValue(null)
 
       const res = makeRes()
@@ -126,16 +121,38 @@ describe('handleOrcidFinalize', () => {
 
       expect(UserConstructor).toHaveBeenCalledWith(
         expect.objectContaining({
+          username: `orcid-${ORCID_ID}`,
           email: 'scott@example.com',
-          status: 'Active',
-          oauth: [
-            expect.objectContaining({ provider: 'orcid', id: ORCID_ID })
-          ]
+          firstName: 'Scott',
+          lastName: 'Classen',
+          status: 'Active'
         })
       )
       expect(userSaveMock).toHaveBeenCalled()
       expect(issueTokensAndSetCookie).toHaveBeenCalled()
       expect(res.status).toHaveBeenCalledWith(200)
+    })
+
+    it('does NOT persist ORCID access/refresh tokens on the User document (H3)', async () => {
+      findOneMock.mockResolvedValue(null)
+
+      await handleOrcidFinalize(makeReq(), makeRes())
+
+      const constructorArg = UserConstructor.mock.calls[0]?.[0] as {
+        oauth: Array<Record<string, unknown>>
+      }
+      const oauthEntry = constructorArg.oauth[0]
+
+      expect(oauthEntry).toEqual({
+        provider: 'orcid',
+        id: ORCID_ID,
+        name: 'Scott Classen'
+      })
+      expect(oauthEntry).not.toHaveProperty('accessToken')
+      expect(oauthEntry).not.toHaveProperty('refreshToken')
+      expect(oauthEntry).not.toHaveProperty('tokenType')
+      expect(oauthEntry).not.toHaveProperty('scope')
+      expect(oauthEntry).not.toHaveProperty('expiresIn')
     })
   })
 

--- a/apps/backend/src/controllers/auth/authTokens.ts
+++ b/apps/backend/src/controllers/auth/authTokens.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken'
 import { Response } from 'express'
 import { IUser } from '@bilbomd/mongodb-schema'
 import { getEnvVar } from '../../config/config.js'
+import { userDisplayName } from './displayName.js'
 
 const accessTokenSecret = getEnvVar('ACCESS_TOKEN_SECRET')
 const refreshTokenSecret = getEnvVar('REFRESH_TOKEN_SECRET')
@@ -14,6 +15,7 @@ export async function issueTokensAndSetCookie(
     {
       UserInfo: {
         username: user.username,
+        displayName: userDisplayName(user),
         roles: user.roles,
         email: user.email
       }

--- a/apps/backend/src/controllers/auth/displayName.ts
+++ b/apps/backend/src/controllers/auth/displayName.ts
@@ -1,0 +1,18 @@
+// User-facing label derived from profile fields. Lives separate from the
+// internal `username` (which is an opaque identifier used in URL paths,
+// the JWT `username` claim, and job-ownership filters). See PR 3 of
+// https://github.com/bl1231/bilbomd/issues/817.
+export interface DisplayNameSource {
+  username: string
+  firstName?: string | null
+  lastName?: string | null
+}
+
+export const userDisplayName = (user: DisplayNameSource): string => {
+  const first = user.firstName?.trim()
+  const last = user.lastName?.trim()
+  if (first && last) return `${first} ${last}`
+  if (first) return first
+  if (last) return last
+  return user.username
+}

--- a/apps/backend/src/controllers/auth/handleOrcidCallback.ts
+++ b/apps/backend/src/controllers/auth/handleOrcidCallback.ts
@@ -134,18 +134,16 @@ export async function handleOrcidCallback(req: Request, res: Response) {
     }
   }
 
-  // New user — stash the verified profile for the confirmation step. Only
-  // fields the finalize handler actually needs are persisted to the session.
+  // New user — stash the verified profile for the confirmation step. We
+  // intentionally do NOT persist the ORCID access/refresh tokens here
+  // (H3, PR 3 of issue #817): the finalize handler does not need them
+  // and they would otherwise sit in the session store and on the User
+  // document with no consumer.
   req.session.orcidProfile = {
     email: selectedEmail,
     givenName,
     familyName,
     orcidId,
-    accessToken: tokens.access_token,
-    tokenType: tokens.token_type,
-    refreshToken: tokens.refresh_token,
-    scope: tokens.scope,
-    expiresIn: tokens.expires_in,
     name: displayName
   }
 

--- a/apps/backend/src/controllers/auth/handleOrcidFinalize.ts
+++ b/apps/backend/src/controllers/auth/handleOrcidFinalize.ts
@@ -13,23 +13,18 @@ export async function handleOrcidFinalize(req: Request, res: Response) {
       return
     }
 
-    const {
-      email,
-      givenName,
-      familyName,
-      orcidId,
-      accessToken,
-      tokenType,
-      refreshToken,
-      scope,
-      expiresIn,
-      name
-    } = profile
+    const { email, givenName, familyName, orcidId, name } = profile
 
     if (!name || typeof name !== 'string') {
-      res.status(400).send('Username is required')
+      res.status(400).send('Display name is required')
       return
     }
+
+    // Opaque internal identifier — deterministic, unique by construction,
+    // URL-safe, and decoupled from any human-readable display name. See
+    // PR 3 of issue #817 (Option A). The human-readable label is derived
+    // from firstName + lastName at JWT-sign time by userDisplayName().
+    const username = `orcid-${orcidId}`
 
     const existing = await User.findOne({ email })
 
@@ -61,28 +56,26 @@ export async function handleOrcidFinalize(req: Request, res: Response) {
     }
 
     const user = new User({
-      username: name,
+      username,
       email,
       firstName: givenName,
       lastName: familyName,
       roles: ['User'],
       status: 'Active',
+      // H3: we no longer persist ORCID access/refresh tokens. We never call
+      // ORCID APIs on the user's behalf after sign-in, so storing the
+      // bearer just enlarges the blast radius if the DB is leaked.
       oauth: [
         {
           provider: 'orcid',
           id: orcidId,
-          name,
-          accessToken,
-          refreshToken,
-          tokenType,
-          scope,
-          expiresIn
+          name
         }
       ]
     })
 
     await user.save()
-    logger.info(`New user created via ORCID: ${email}`)
+    logger.info(`New user created via ORCID: ${email} (${username})`)
 
     delete req.session.orcidProfile
 

--- a/apps/backend/src/controllers/usersController.ts
+++ b/apps/backend/src/controllers/usersController.ts
@@ -18,9 +18,11 @@ const isValidEmail = (email: string): boolean => {
   return emailRegex.test(email)
 }
 
-// Helper function to validate username format
+// Helper function to validate username format. Hyphens are allowed so
+// ORCID-derived opaque usernames like `orcid-0000-0002-1234-5678`
+// (issue #817 PR 3) pass admin-edit validation.
 const isValidUsername = (username: string): boolean => {
-  const usernameRegex = /^[a-zA-Z0-9_]+$/
+  const usernameRegex = /^[a-zA-Z0-9_-]+$/
   return usernameRegex.test(username)
 }
 

--- a/apps/backend/src/middleware/verifyJWT.ts
+++ b/apps/backend/src/middleware/verifyJWT.ts
@@ -5,6 +5,7 @@ import { getEnvVar } from '../config/config.js'
 interface DecodedJWT {
   UserInfo: {
     username: string
+    displayName?: string
     roles: string[]
     email: string
   }

--- a/apps/backend/src/types/express/session.d.ts
+++ b/apps/backend/src/types/express/session.d.ts
@@ -10,11 +10,6 @@ declare module 'express-session' {
       givenName?: string
       familyName?: string
       orcidId: string
-      accessToken: string
-      tokenType?: string
-      refreshToken?: string
-      scope?: string
-      expiresIn?: number
       name?: string
     }
   }

--- a/apps/ui/src/features/auth/Login.tsx
+++ b/apps/ui/src/features/auth/Login.tsx
@@ -37,14 +37,14 @@ const LoginPage = () => {
           variant='h4'
           gutterBottom
         >
-          Sign in with ORCID
+          Sign in with ORCID iD
         </Typography>
         <Typography
           variant='body1'
           sx={{ mb: 4 }}
         >
-          BilboMD uses ORCID to authenticate users. Click below to log in
-          securely using your ORCID iD.
+          BilboMD uses ORCID to authenticate users. Click below to sign in
+          securely with your ORCID iD.
         </Typography>
         <Button
           variant='contained'
@@ -53,7 +53,7 @@ const LoginPage = () => {
           startIcon={<LoginIcon />}
           onClick={handleOrcidLogin}
         >
-          Sign in with ORCID
+          Sign in with ORCID iD
         </Button>
       </Box>
     </Container>

--- a/apps/ui/src/features/auth/OrcidConfirmation.tsx
+++ b/apps/ui/src/features/auth/OrcidConfirmation.tsx
@@ -1,121 +1,127 @@
-import React from 'react'
-import { useFormik } from 'formik'
-import * as Yup from 'yup'
 import {
   Box,
   Button,
   Container,
-  TextField,
-  Typography,
-  Paper
+  Divider,
+  Paper,
+  Stack,
+  Typography
 } from '@mui/material'
 import {
   useGetOrcidSessionQuery,
   useFinalizeOrcidMutation
 } from '../../slices/authApiSlice'
+import { userDisplayName } from 'utils/userDisplayName'
 
-interface OrcidProfile {
-  givenName: string
-  familyName: string
-  email: string
-  orcidId: string
+interface ProfileRowProps {
+  label: string
+  value: string
 }
 
-const validationSchema = Yup.object().shape({
-  givenName: Yup.string().required('First name is required'),
-  familyName: Yup.string().required('Last name is required'),
-  email: Yup.string().email('Invalid email').required('Email is required'),
-  orcidId: Yup.string().required('ORCID iD is required')
-})
+const ProfileRow = ({ label, value }: ProfileRowProps) => (
+  <Box>
+    <Typography
+      variant='caption'
+      color='text.secondary'
+      sx={{ textTransform: 'uppercase', letterSpacing: 0.5 }}
+    >
+      {label}
+    </Typography>
+    <Typography
+      variant='body1'
+      sx={{ fontFamily: 'inherit' }}
+    >
+      {value || '—'}
+    </Typography>
+  </Box>
+)
 
 export default function OrcidConfirmation() {
   const { data: profile, isLoading, isError } = useGetOrcidSessionQuery(undefined)
-  const [finalizeOrcid] = useFinalizeOrcidMutation()
+  const [finalizeOrcid, { isLoading: isFinalizing }] = useFinalizeOrcidMutation()
 
-  const formik = useFormik({
-    initialValues: profile || {
-      givenName: '',
-      familyName: '',
-      email: '',
-      orcidId: ''
-    },
-    enableReinitialize: true,
-    validationSchema,
-    onSubmit: async (values: OrcidProfile) => {
-      try {
-        await finalizeOrcid(values).unwrap()
-        window.location.href = '/welcome'
-      } catch (err) {
-        console.error(err)
-        window.location.href = '/auth/orcid-error?reason=finalize'
-      }
-    }
-  })
-
-  if (isLoading) return <Typography>Loading...</Typography>
+  if (isLoading) return <Typography>Loading…</Typography>
   if (isError || !profile) {
     window.location.href = '/auth/orcid-error?reason=session'
     return null
   }
 
+  const displayName = userDisplayName({
+    firstName: profile.givenName,
+    lastName: profile.familyName
+  })
+  const internalAccountId = `orcid-${profile.orcidId}`
+
+  const handleConfirm = async () => {
+    try {
+      await finalizeOrcid({}).unwrap()
+      window.location.href = '/welcome'
+    } catch (err) {
+      console.error(err)
+      window.location.href = '/auth/orcid-error?reason=finalize'
+    }
+  }
+
   return (
     <Container maxWidth='sm'>
       <Paper sx={{ padding: 3, marginTop: 4 }}>
-        <Typography variant='h5' gutterBottom>
-          Confirm ORCID Profile
+        <Typography
+          variant='h5'
+          gutterBottom
+        >
+          Confirm your ORCID profile
         </Typography>
-        <form onSubmit={formik.handleSubmit}>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <TextField
-              label='First Name'
-              name='givenName'
-              value={formik.values.givenName}
-              onChange={formik.handleChange}
-              error={
-                formik.touched.givenName && Boolean(formik.errors.givenName)
-              }
-              helperText={formik.touched.givenName && formik.errors.givenName}
-              slotProps={{ input: { readOnly: true } }}
-              fullWidth
-            />
+        <Typography
+          variant='body2'
+          color='text.secondary'
+          sx={{ mb: 3 }}
+        >
+          BilboMD will create a new account using the verified information
+          below. Nothing on this page is editable here — to change any of
+          these values, update them in your ORCID account and sign in again.
+        </Typography>
 
-            <TextField
-              label='Last Name'
-              name='familyName'
-              value={formik.values.familyName}
-              onChange={formik.handleChange}
-              error={
-                formik.touched.familyName && Boolean(formik.errors.familyName)
-              }
-              helperText={formik.touched.familyName && formik.errors.familyName}
-              slotProps={{ input: { readOnly: true } }}
-              fullWidth
-            />
+        <Stack
+          spacing={2}
+          divider={<Divider flexItem />}
+        >
+          <ProfileRow
+            label='First name'
+            value={profile.givenName}
+          />
+          <ProfileRow
+            label='Last name'
+            value={profile.familyName}
+          />
+          <ProfileRow
+            label='Email'
+            value={profile.email}
+          />
+          <ProfileRow
+            label='ORCID iD'
+            value={profile.orcidId}
+          />
+          <ProfileRow
+            label='BilboMD display name'
+            value={displayName}
+          />
+          <ProfileRow
+            label='BilboMD account ID'
+            value={internalAccountId}
+          />
+        </Stack>
 
-            <TextField
-              label='Email'
-              name='email'
-              value={formik.values.email}
-              onChange={formik.handleChange}
-              error={formik.touched.email && Boolean(formik.errors.email)}
-              helperText={formik.touched.email && formik.errors.email}
-              slotProps={{ input: { readOnly: true } }}
-              fullWidth
-            />
-
-            <TextField
-              label='ORCID iD'
-              name='orcidId'
-              value={formik.values.orcidId}
-              slotProps={{ input: { readOnly: true } }}
-              fullWidth
-            />
-
-            <Button type='submit' variant='contained' color='primary'>
-              Confirm and Continue
-            </Button>
-          </Box>
-        </form>
+        <Button
+          type='button'
+          variant='contained'
+          color='primary'
+          onClick={handleConfirm}
+          disabled={isFinalizing}
+          sx={{ mt: 3 }}
+          fullWidth
+        >
+          {isFinalizing ? 'Creating account…' : 'Confirm and Continue'}
+        </Button>
       </Paper>
     </Container>
   )

--- a/apps/ui/src/features/auth/__tests__/Login.test.tsx
+++ b/apps/ui/src/features/auth/__tests__/Login.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router'
+
+const getConfigsMock = vi.fn()
+vi.mock('slices/configsApiSlice', () => ({
+  useGetConfigsQuery: (...args: unknown[]) => getConfigsMock(...args)
+}))
+
+import LoginPage from '../Login'
+
+const renderLogin = () =>
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Routes>
+        <Route
+          path='/login'
+          element={<LoginPage />}
+        />
+        <Route
+          path='/magicklink'
+          element={<div>MagickLink page</div>}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { href: '' }
+  })
+})
+
+describe('LoginPage', () => {
+  it('renders the official "Sign in with ORCID iD" button when ORCID is enabled', () => {
+    getConfigsMock.mockReturnValue({
+      data: { orcidAuthEnabled: 'true' },
+      isLoading: false
+    })
+
+    renderLogin()
+
+    expect(
+      screen.getByRole('button', { name: /Sign in with ORCID iD/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Sign in with ORCID iD/i })
+    ).toBeInTheDocument()
+  })
+
+  it('redirects to /magicklink when ORCID is disabled', () => {
+    getConfigsMock.mockReturnValue({
+      data: { orcidAuthEnabled: 'false' },
+      isLoading: false
+    })
+
+    renderLogin()
+
+    expect(screen.getByText('MagickLink page')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Sign in/i })).toBeNull()
+  })
+
+  it('redirects when the orcidAuthEnabled flag is missing entirely', () => {
+    getConfigsMock.mockReturnValue({ data: {}, isLoading: false })
+
+    renderLogin()
+
+    expect(screen.getByText('MagickLink page')).toBeInTheDocument()
+  })
+
+  it('renders nothing while configs are still loading', () => {
+    getConfigsMock.mockReturnValue({ data: undefined, isLoading: true })
+
+    const { container } = renderLogin()
+
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/apps/ui/src/features/auth/__tests__/OrcidConfirmation.test.tsx
+++ b/apps/ui/src/features/auth/__tests__/OrcidConfirmation.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const { finalizeMock, getSessionMock } = vi.hoisted(() => ({
+  finalizeMock: vi.fn(),
+  getSessionMock: vi.fn()
+}))
+
+vi.mock('../../../slices/authApiSlice', () => ({
+  useGetOrcidSessionQuery: getSessionMock,
+  useFinalizeOrcidMutation: () => [finalizeMock, { isLoading: false }]
+}))
+
+import OrcidConfirmation from '../OrcidConfirmation'
+
+const sampleProfile = {
+  givenName: 'Scott',
+  familyName: 'Classen',
+  email: 'scott@example.com',
+  orcidId: '0000-0002-1234-5678'
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getSessionMock.mockReturnValue({
+    data: sampleProfile,
+    isLoading: false,
+    isError: false
+  })
+  finalizeMock.mockReturnValue({ unwrap: vi.fn().mockResolvedValue(undefined) })
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { href: '' }
+  })
+})
+
+describe('OrcidConfirmation', () => {
+  it('renders read-only profile fields from the session', () => {
+    render(<OrcidConfirmation />)
+
+    expect(screen.getByText('Scott')).toBeInTheDocument()
+    expect(screen.getByText('Classen')).toBeInTheDocument()
+    expect(screen.getByText('scott@example.com')).toBeInTheDocument()
+    expect(screen.getByText('0000-0002-1234-5678')).toBeInTheDocument()
+  })
+
+  it('surfaces the derived BilboMD display name and opaque account ID', () => {
+    render(<OrcidConfirmation />)
+
+    expect(screen.getByText('Scott Classen')).toBeInTheDocument()
+    expect(screen.getByText('orcid-0000-0002-1234-5678')).toBeInTheDocument()
+  })
+
+  it('does NOT render any text inputs', () => {
+    render(<OrcidConfirmation />)
+    expect(screen.queryAllByRole('textbox')).toHaveLength(0)
+  })
+
+  it('calls finalizeOrcid with an empty body when Confirm is clicked', async () => {
+    render(<OrcidConfirmation />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Confirm and Continue/i })
+    )
+
+    await waitFor(() => expect(finalizeMock).toHaveBeenCalledWith({}))
+    expect(window.location.href).toBe('/welcome')
+  })
+
+  it('redirects to the error page if finalize fails', async () => {
+    finalizeMock.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue(new Error('boom'))
+    })
+
+    render(<OrcidConfirmation />)
+    fireEvent.click(
+      screen.getByRole('button', { name: /Confirm and Continue/i })
+    )
+
+    await waitFor(() =>
+      expect(window.location.href).toBe('/auth/orcid-error?reason=finalize')
+    )
+  })
+})

--- a/apps/ui/src/features/auth/__tests__/RequireAuth.test.tsx
+++ b/apps/ui/src/features/auth/__tests__/RequireAuth.test.tsx
@@ -32,6 +32,7 @@ describe('RequireAuth', () => {
   it('renders Outlet when user has a matching role', () => {
     mockUseAuth.mockReturnValue({
       username: 'admin',
+      displayName: 'admin',
       roles: ['Admin'],
       status: 'Admin',
       isManager: false,
@@ -50,6 +51,7 @@ describe('RequireAuth', () => {
   it('renders Navigate when user has no matching role', () => {
     mockUseAuth.mockReturnValue({
       username: 'user',
+      displayName: 'user',
       roles: ['User'],
       status: 'User',
       isManager: false,
@@ -69,6 +71,7 @@ describe('RequireAuth', () => {
   it('passes location state to Navigate redirect', () => {
     mockUseAuth.mockReturnValue({
       username: 'user',
+      displayName: 'user',
       roles: ['User'],
       status: 'User',
       isManager: false,

--- a/apps/ui/src/features/auth/__tests__/Welcome.test.tsx
+++ b/apps/ui/src/features/auth/__tests__/Welcome.test.tsx
@@ -76,6 +76,7 @@ describe('Welcome Component', () => {
   it('displays loading message while fetching config', () => {
     vi.mocked(useAuth).mockReturnValue({
       username: 'testuser',
+      displayName: 'testuser',
       roles: [] as string[],
       status: 'active',
       isManager: false,
@@ -101,6 +102,7 @@ describe('Welcome Component', () => {
   it('displays error message when config fails to load', () => {
     vi.mocked(useAuth).mockReturnValue({
       username: 'testuser',
+      displayName: 'testuser',
       roles: [] as string[],
       status: 'active',
       isManager: false,
@@ -125,6 +127,7 @@ describe('Welcome Component', () => {
   it('displays Beamline 12.3.1 when not using NERSC', () => {
     vi.mocked(useAuth).mockReturnValue({
       username: 'testuser',
+      displayName: 'testuser',
       roles: [] as string[],
       status: 'active',
       isManager: false,
@@ -158,6 +161,7 @@ describe('Welcome Component', () => {
   it('displays NERSC status when using NERSC', async () => {
     vi.mocked(useAuth).mockReturnValue({
       username: 'testuser',
+      displayName: 'testuser',
       roles: [] as string[],
       status: 'active',
       isManager: false,
@@ -198,6 +202,7 @@ describe('Welcome Component', () => {
   it('displays contact information', () => {
     vi.mocked(useAuth).mockReturnValue({
       username: 'testuser',
+      displayName: 'testuser',
       roles: [] as string[],
       status: 'active',
       isManager: false,

--- a/apps/ui/src/features/jobs/__tests__/Jobs.test.tsx
+++ b/apps/ui/src/features/jobs/__tests__/Jobs.test.tsx
@@ -196,6 +196,7 @@ describe('Jobs table', () => {
   it('shows User → Engine → Status order for admins', async () => {
     vi.mocked(useAuth).mockReturnValue({
       username: 'admin',
+      displayName: 'admin',
       roles: ['Admin'],
       status: 'Admin',
       isManager: false,
@@ -346,6 +347,7 @@ describe('Jobs table', () => {
     beforeEach(() => {
       vi.mocked(useAuth).mockReturnValue({
         username: 'admin',
+        displayName: 'admin',
         roles: ['Admin'],
         status: 'Admin',
         isManager: false,

--- a/apps/ui/src/features/users/Settings.tsx
+++ b/apps/ui/src/features/users/Settings.tsx
@@ -77,7 +77,7 @@ const SettingsLayout = () => {
           Dashboard
         </Button>
         <UserAvatar
-          username={user.username}
+          displayName={user.displayName}
           email={user.email}
           status={user.status}
         />

--- a/apps/ui/src/features/users/UserAvatar.tsx
+++ b/apps/ui/src/features/users/UserAvatar.tsx
@@ -1,12 +1,12 @@
 import { Typography, Box, Chip } from '@mui/material'
 import { teal, purple } from '@mui/material/colors'
 interface UserAvatarProps {
-  username: string
+  displayName: string
   email: string
   status: string
 }
 
-const UserAvatar = ({ username, email, status }: UserAvatarProps) => {
+const UserAvatar = ({ displayName, email, status }: UserAvatarProps) => {
   return (
     <Box
       sx={{
@@ -19,7 +19,7 @@ const UserAvatar = ({ username, email, status }: UserAvatarProps) => {
         borderRadius: 1
       }}
     >
-      <Typography variant='subtitle1'>{username}</Typography>
+      <Typography variant='subtitle1'>{displayName}</Typography>
       <Typography variant='caption' color='textSecondary'>
         {email}
       </Typography>

--- a/apps/ui/src/hooks/__tests__/useAuth.test.tsx
+++ b/apps/ui/src/hooks/__tests__/useAuth.test.tsx
@@ -18,6 +18,7 @@ describe('useAuth', () => {
 
     expect(result.current).toEqual({
       username: '',
+      displayName: '',
       roles: [],
       status: 'User',
       email: '',
@@ -30,7 +31,8 @@ describe('useAuth', () => {
   it('should decode token and return user information', () => {
     const mockPayload = {
       UserInfo: {
-        username: 'testuser',
+        username: 'orcid-0000-0002-1234-5678',
+        displayName: 'Scott Classen',
         roles: ['Admin'],
         email: 'testuser@example.com'
       }
@@ -42,7 +44,8 @@ describe('useAuth', () => {
     const { result } = renderHook(() => useAuth())
 
     expect(result.current).toEqual({
-      username: 'testuser',
+      username: 'orcid-0000-0002-1234-5678',
+      displayName: 'Scott Classen',
       roles: ['Admin'],
       email: 'testuser@example.com',
       isManager: false,
@@ -56,6 +59,7 @@ describe('useAuth', () => {
     const mockPayload = {
       UserInfo: {
         username: 'manageradmin',
+        displayName: 'Manager Admin',
         roles: ['Manager', 'Admin'],
         email: 'manageradmin@example.com'
       }
@@ -68,6 +72,7 @@ describe('useAuth', () => {
 
     expect(result.current).toEqual({
       username: 'manageradmin',
+      displayName: 'Manager Admin',
       roles: ['Manager', 'Admin'],
       email: 'manageradmin@example.com',
       isManager: true,
@@ -75,6 +80,24 @@ describe('useAuth', () => {
       status: 'Admin',
       isAuthenticated: true
     })
+  })
+
+  it('falls back to username when token has no displayName claim (legacy token)', () => {
+    const mockPayload = {
+      UserInfo: {
+        username: 'legacy_user',
+        // displayName intentionally omitted — represents an access token
+        // issued before PR 3 of #817
+        roles: ['User'],
+        email: 'legacy@example.com'
+      }
+    }
+    ;(useAppSelector as Mock).mockReturnValue(createTestJWT(mockPayload))
+
+    const { result } = renderHook(() => useAuth())
+
+    expect(result.current.displayName).toBe('legacy_user')
+    expect(result.current.username).toBe('legacy_user')
   })
 })
 

--- a/apps/ui/src/hooks/useAuth.ts
+++ b/apps/ui/src/hooks/useAuth.ts
@@ -8,21 +8,23 @@ interface JwtPayload {
 
 interface BilboMDJwtPayload {
   username: string
+  // Added in PR 3 of issue #817. Older access tokens issued before the
+  // displayName claim was added won't have this; fall back to username
+  // so the UI keeps working until the next refresh.
+  displayName?: string
   roles: string[]
   email: string
 }
 
 const useAuth = () => {
   const token = useAppSelector(selectCurrentToken)
-  // console.log('useAuth: token from store:', token)
   let isManager = false
   let isAdmin = false
   let status = 'User'
 
   if (token) {
     const decoded = jwtDecode<JwtPayload>(token)
-    const { username, roles, email } = decoded.UserInfo
-    // console.log('useAuth1:', username, roles, email)
+    const { username, displayName, roles, email } = decoded.UserInfo
 
     isManager = roles.includes('Manager')
     isAdmin = roles.includes('Admin')
@@ -32,6 +34,7 @@ const useAuth = () => {
 
     return {
       username,
+      displayName: displayName || username,
       roles,
       status,
       isManager,
@@ -43,6 +46,7 @@ const useAuth = () => {
   // Returned if we do not have a token
   return {
     username: '',
+    displayName: '',
     roles: [],
     status,
     email: '',

--- a/apps/ui/src/layout/MainLayout/Breadcrumbs.tsx
+++ b/apps/ui/src/layout/MainLayout/Breadcrumbs.tsx
@@ -5,6 +5,7 @@ import { selectJobById } from 'slices/jobsApiSlice'
 import { selectUserById } from 'slices/usersApiSlice'
 import { useSelector } from 'react-redux'
 import type { RootState } from 'app/store'
+import { userDisplayName } from 'utils/userDisplayName'
 
 // Map of path segments to labels
 // This is used to convert the path segments to human-readable labels.
@@ -61,7 +62,7 @@ export default function AppBreadcrumbs() {
 
           if (segment === maybeId) {
             if (isJob && job?.mongo?.title) label = job.mongo.title
-            if (isUser && user?.username) label = user.username
+            if (isUser && user) label = userDisplayName(user)
           }
 
           const isLast = index === pathnames.length - 1

--- a/apps/ui/src/layout/MainLayout/Header/index.test.tsx
+++ b/apps/ui/src/layout/MainLayout/Header/index.test.tsx
@@ -73,6 +73,7 @@ describe('Header Component', () => {
   beforeEach(() => {
     vi.mocked(useAuth).mockReturnValue({
       username: 'testUser',
+      displayName: 'testUser',
       status: 'Active',
       roles: ['User'],
       isManager: false,

--- a/apps/ui/src/slices/__tests__/authApiSlice.test.ts
+++ b/apps/ui/src/slices/__tests__/authApiSlice.test.ts
@@ -154,10 +154,10 @@ describe('authApiSlice', () => {
 
   describe('finalizeOrcid', () => {
     it('should finalize ORCID authentication', async () => {
-      const body = { code: 'auth-code', state: 'state-123' }
-
+      // PR 3 of #817 — backend ignores the request body and trusts the
+      // server-side session profile, so callers send an empty object.
       const result = await storeRef.store.dispatch(
-        authApiSlice.endpoints.finalizeOrcid.initiate(body)
+        authApiSlice.endpoints.finalizeOrcid.initiate({})
       )
 
       expect(result.data).toBeDefined()
@@ -172,10 +172,7 @@ describe('authApiSlice', () => {
       )
 
       const result = await storeRef.store.dispatch(
-        authApiSlice.endpoints.finalizeOrcid.initiate({
-          code: 'invalid',
-          state: 'invalid'
-        })
+        authApiSlice.endpoints.finalizeOrcid.initiate({})
       )
 
       expect(result.error).toBeDefined()

--- a/apps/ui/src/slices/authApiSlice.ts
+++ b/apps/ui/src/slices/authApiSlice.ts
@@ -17,14 +17,9 @@ interface OrcidSessionResponse {
   orcidId: string
 }
 
-interface OrcidFinalizeRequest {
-  givenName?: string
-  familyName?: string
-  email?: string
-  orcidId?: string
-  code?: string
-  state?: string
-}
+// The backend ignores the request body and trusts the server-side
+// session profile; callers send an empty object.
+type OrcidFinalizeRequest = Record<string, never>
 
 export const authApiSlice = apiSlice.injectEndpoints({
   endpoints: (builder) => ({

--- a/apps/ui/src/utils/__tests__/userDisplayName.test.ts
+++ b/apps/ui/src/utils/__tests__/userDisplayName.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { userDisplayName } from '../userDisplayName'
+
+describe('userDisplayName (UI)', () => {
+  it('returns "First Last" when both names are present', () => {
+    expect(
+      userDisplayName({
+        username: 'orcid-x',
+        firstName: 'Scott',
+        lastName: 'Classen'
+      })
+    ).toBe('Scott Classen')
+  })
+
+  it('returns first name only when last is missing', () => {
+    expect(
+      userDisplayName({ username: 'u', firstName: 'Scott' })
+    ).toBe('Scott')
+  })
+
+  it('returns last name only when first is missing', () => {
+    expect(
+      userDisplayName({ username: 'u', lastName: 'Classen' })
+    ).toBe('Classen')
+  })
+
+  it('falls back to username when no names', () => {
+    expect(userDisplayName({ username: 'fallback' })).toBe('fallback')
+  })
+
+  it('falls back to empty string when even username is absent', () => {
+    expect(userDisplayName({})).toBe('')
+  })
+
+  it('treats null and undefined name fields equivalently', () => {
+    expect(
+      userDisplayName({
+        username: 'u',
+        firstName: null,
+        lastName: null
+      })
+    ).toBe('u')
+  })
+})

--- a/apps/ui/src/utils/userDisplayName.ts
+++ b/apps/ui/src/utils/userDisplayName.ts
@@ -1,0 +1,18 @@
+// Mirrors apps/backend/src/controllers/auth/displayName.ts so the UI can
+// derive a user's human-readable label from a UserDTO returned by the
+// `/users` endpoint, where the JWT-derived `displayName` from useAuth()
+// is not available. See PR 3 of issue #817.
+export interface DisplayNameSource {
+  username?: string
+  firstName?: string | null
+  lastName?: string | null
+}
+
+export const userDisplayName = (user: DisplayNameSource): string => {
+  const first = user.firstName?.trim()
+  const last = user.lastName?.trim()
+  if (first && last) return `${first} ${last}`
+  if (first) return first
+  if (last) return last
+  return user.username ?? ''
+}

--- a/packages/mongodb-schema/src/interfaces/userInterface.ts
+++ b/packages/mongodb-schema/src/interfaces/userInterface.ts
@@ -24,11 +24,6 @@ interface OAuthIdentity {
   provider: 'google' | 'orcid' | 'github' | string
   id: string
   name: string
-  accessToken?: string
-  refreshToken?: string
-  tokenType?: string
-  scope?: string
-  expiresIn?: number
   tokenIssuedAt?: Date
 }
 

--- a/packages/mongodb-schema/src/models/User.ts
+++ b/packages/mongodb-schema/src/models/User.ts
@@ -14,11 +14,6 @@ const userSchema = new Schema(
           provider: { type: String, required: true },
           id: { type: String, required: true },
           name: { type: String, required: true },
-          accessToken: { type: String },
-          refreshToken: { type: String },
-          tokenType: { type: String },
-          scope: { type: String },
-          expiresIn: { type: Number },
           tokenIssuedAt: { type: Date, default: Date.now }
         }
       ],


### PR DESCRIPTION
## Summary

PR 3 (final) of the ORCID OAuth hardening tracked in #817. Finishes the audit plan and clears the way to schedule the ORCID review demo.

### Option A — separate internal `username` from human-readable `displayName`

- ORCID accounts get an **opaque `username = orcid-${orcidId}`** (e.g. `orcid-0000-0002-1234-5678`). Deterministic, unique, URL-safe, decoupled from any human name.
- New backend `userDisplayName()` helper derives a human label from `firstName + lastName`, falling back to `username` for legacy users with no name fields set.
- Access-token JWT payload gains a **`displayName` claim** computed at sign time. UI `useAuth` hook exposes it; legacy tokens missing the claim fall back to `username` until next refresh.
- UI display sites updated: `Breadcrumbs` and `Settings → UserAvatar` show `displayName`. URL routes (`/users/:username/tokens`), job-ownership filters, and admin-edit forms still use `username`.
- `isValidUsername` regex relaxed from `[a-zA-Z0-9_]+` to `[a-zA-Z0-9_-]+` so ORCID-derived usernames pass admin-edit validation.

### H3 — stop persisting ORCID access/refresh tokens

Dropped `accessToken` / `refreshToken` / `tokenType` / `scope` / `expiresIn` from both the User schema `oauth[]` subdocument and the OAuth session profile. We never call ORCID APIs on behalf of users post-sign-in, so storing the bearer just enlarged blast radius. Existing data on old user docs is harmless and will fall off on next login — no migration required.

### H4 — `OrcidConfirmation` becomes read-only

Replaced the misleading editable-looking Formik form with read-only display rows. Now surfaces First Name, Last Name, Email, ORCID iD, **the derived BilboMD display name**, and **the opaque BilboMD account ID** — the user sees exactly what BilboMD will store before confirming. The backend has always trusted the session profile and ignored the request body; this PR makes that honest to the user.

### L4 — branding text

`Login.tsx` heading and button: "Sign in with ORCID" → **"Sign in with ORCID iD"** per ORCID's official sign-in guidelines.

### L5 — brand asset 🚧

The existing `apps/ui/src/assets/orcid.png` is the ORCID wordmark (gray "ORC" + green "iD"). ORCID's sign-in guidelines specify the **circular green iD icon** for sign-in buttons, with the wordmark reserved for "about" contexts. Not strictly broken, but worth swapping before the production-credential review demo. Asset left alone in this PR; flagged here so it isn't lost.

Builds on PRs #819 and #820. **Base branch is `feature/orcid-security-hardening`**, will need to be rebased onto `main` after both prior PRs merge.

## Tests

**Backend** (441 → 452):
- `displayName.test.ts` (6 cases): both names, one name, neither, whitespace trimming
- `authTokens.test.ts` (3 cases): displayName claim from firstName+lastName, username fallback for unnamed users, refresh-cookie set
- `handleOrcidFinalize.test.ts`: + assertion `username = orcid-{ORCID_ID}` and + assertion no token fields persisted on `oauth[]` entry
- `handleOrcidCallback.test.ts`: + assertion no token fields persisted in session profile

**UI** (1078 → 1094):
- `userDisplayName.test.ts` (6 cases) — UI helper for entity-from-API users (Breadcrumbs uses it)
- `Login.test.tsx` (4 cases) — button reads "Sign in with ORCID iD"; redirect to `/magicklink` when flag is off; loading state
- `OrcidConfirmation.test.tsx` (5 cases) — read-only fields render, derived display name + opaque ID surfaced, no textboxes present, finalize sends empty body, finalize error redirects
- `useAuth.test.tsx` — gains "legacy token without displayName claim falls back to username" case; existing mocks updated
- `authApiSlice.test.ts`, `RequireAuth.test.tsx`, `Welcome.test.tsx`, `Jobs.test.tsx`, `Header/index.test.tsx` — useAuth mocks include `displayName` field

## Test plan

- [ ] Local sandbox sign-in as a brand-new ORCID iD → confirmation page lists First Name, Last Name, Email, ORCID iD, the derived display name, and the opaque account ID; no editable inputs
- [ ] `db.users.findOne(...)` after sign-in shows `username: 'orcid-{ID}'`, `firstName`/`lastName` populated, and `oauth[0]` contains only `provider`, `id`, `name`, `tokenIssuedAt` — no `accessToken` / `refreshToken` / etc.
- [ ] Decoded access token contains `UserInfo.displayName` (e.g., "Scott Classen")
- [ ] Breadcrumbs on a user-detail page show "Scott Classen", not "orcid-0000-…"
- [ ] Settings sidebar UserAvatar shows the display name
- [ ] Admin edits a different user's username (e.g., to `orcid-0000-0002-9999-1234`) — passes validation (regex now allows hyphens)
- [ ] Login page button reads exactly "Sign in with ORCID iD"
- [x] `pnpm lint && pnpm build && pnpm test` all green

## Out of scope / follow-ups after this PR ships

- **Swap the brand asset** (L5) — replace `apps/ui/src/assets/orcid.png` with the official circular iD icon from the ORCID brand library before the review demo
- **Schedule the ORCID review demo** — once PRs #818, #819, #820, and this one are merged and exercised against ORCID sandbox in staging
- **Flip `ORCID_AUTH_ENABLED=true` in production** with production ORCID credentials after a successful demo
- Eventual removal of legacy magic-link/OTP code (separate effort, after ORCID is the sole live path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)