### PR TITLE
fix(worker): surface CUDA fallback warning to UI when MD runs on CPU

### DIFF
--- a/.changeset/ui-cpu-fallback-warning.md
+++ b/.changeset/ui-cpu-fallback-warning.md
@@ -1,5 +1,6 @@
 ---
 '@bilbomd/ui': patch
+'@bilbomd/worker': patch
 ---
 
 Display a warning alert on the single job page and public job page when MD ran on CPU due to CUDA being unavailable.

--- a/.changeset/ui-cpu-fallback-warning.md
+++ b/.changeset/ui-cpu-fallback-warning.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Display a warning alert on the single job page and public job page when MD ran on CPU due to CUDA being unavailable.

--- a/apps/ui/src/features/jobs/SingleJobPage.tsx
+++ b/apps/ui/src/features/jobs/SingleJobPage.tsx
@@ -109,6 +109,9 @@ const SingleJobPage = () => {
       )?.message ?? null)
     : null
 
+  const cpuFallbackWarning =
+    job?.mongo?.steps?.md?.message?.includes('CUDA unavailable') ?? false
+
   useEffect(() => {
     const status = job?.mongo?.status
     if (!status) return
@@ -326,6 +329,21 @@ const SingleJobPage = () => {
             }}
           >
             <BilboMDNerscSteps job={job} />
+          </Grid>
+        )}
+
+        {/* CPU FALLBACK WARNING */}
+        {cpuFallbackWarning && (
+          <Grid size={{ xs: 12 }}>
+            <Alert
+              severity="warning"
+              variant="outlined"
+            >
+              <AlertTitle>MD ran on CPU</AlertTitle>
+              CUDA was unavailable on this server, so your molecular dynamics
+              simulation ran on CPU instead of GPU. Results are correct, but the
+              job may have taken significantly longer than usual.
+            </Alert>
           </Grid>
         )}
 

--- a/apps/ui/src/features/public/PublicJobPage.tsx
+++ b/apps/ui/src/features/public/PublicJobPage.tsx
@@ -169,6 +169,9 @@ const PublicJobPage = () => {
       )?.message ?? null)
     : null
 
+  const cpuFallbackWarning =
+    job.steps?.md?.message?.includes('CUDA unavailable') ?? false
+
   const calculateDuration = (): string | undefined => {
     if (!job.startedAt) return undefined
     const startTime = new Date(job.startedAt)
@@ -318,6 +321,21 @@ const PublicJobPage = () => {
             )}
           </Item>
         </Grid>
+
+        {/* CPU FALLBACK WARNING */}
+        {cpuFallbackWarning && (
+          <Grid size={{ xs: 12 }}>
+            <Alert
+              severity="warning"
+              variant="outlined"
+            >
+              <AlertTitle>MD ran on CPU</AlertTitle>
+              CUDA was unavailable on this server, so your molecular dynamics
+              simulation ran on CPU instead of GPU. Results are correct, but the
+              job may have taken significantly longer than usual.
+            </Alert>
+          </Grid>
+        )}
 
         {/* CREATE ACCOUNT ADVISORY */}
         {(job.status === 'Error' || job.status === 'Failed') && (

--- a/apps/worker/scripts/openmm/md.py
+++ b/apps/worker/scripts/openmm/md.py
@@ -128,7 +128,7 @@ def run_md_for_rg(rg, config_path, gpu_id=None):
             f"[GPU {gpu_id}] Initialized on platform: {platform} (CudaDeviceIndex={platform_props.get('CudaDeviceIndex', '-')})"
         )
     except Exception as e:
-        logger.warning(f"[GPU {gpu_id}] CUDA not available; falling back. Error: {e}")
+        logger.warning(f"BILBOMD_CPU_FALLBACK: CUDA unavailable on GPU {gpu_id} — MD is running on CPU and may be very slow. Reason: {e}")
         simulation = Simulation(modeller.topology, system, integrator)
         simulation.context.setState(state)
         platform = simulation.context.getPlatform().getName()

--- a/apps/worker/src/services/functions/openmm-functions.ts
+++ b/apps/worker/src/services/functions/openmm-functions.ts
@@ -482,6 +482,7 @@ const runOmmMD = async (
   )
 
   // Prepare job tracking
+  let cpuFallbackDetected = false
   const failureThreshold = opts?.failureThreshold ?? 0 // Default: no failures allowed
   const results: Array<{
     rg: number
@@ -515,8 +516,12 @@ const runOmmMD = async (
       timeoutMs: opts?.timeoutMs ?? 2 * 60 * 60 * 1000, // 2h default per run
       onStdoutLine: (line) =>
         logger.info(`[md rg=${rg} GPU=${assignedGpu}][stdout] ${line}`),
-      onStderrLine: (line) =>
+      onStderrLine: (line) => {
+        if (line.includes('BILBOMD_CPU_FALLBACK:')) {
+          cpuFallbackDetected = true
+        }
         logger.error(`[md rg=${rg} GPU=${assignedGpu}][stderr] ${line}`)
+      }
     })
 
     if (result.code !== 0) {
@@ -624,7 +629,11 @@ const runOmmMD = async (
   )
   await updateStepStatus(DBjob, stepKey, {
     status: 'Success',
-    message: `${stepName} has completed for ${rgs.length} Rg values (${failures.length} failures tolerated)`
+    message:
+      `${stepName} has completed for ${rgs.length} Rg values (${failures.length} failures tolerated)` +
+      (cpuFallbackDetected
+        ? ' — Warning: CUDA unavailable, MD ran on CPU and may have taken significantly longer than expected'
+        : '')
   })
 }
 


### PR DESCRIPTION
## Summary

- Adds a `BILBOMD_CPU_FALLBACK:` sentinel prefix to the existing `logger.warning()` in `md.py` when OpenMM cannot initialize a CUDA context and falls back to CPU
- Detects that sentinel in `runOmmMD`'s `onStderrLine` callback and sets a flag
- Appends a visible warning to the MD step's final success status message so users see it in the UI

## Motivation

When a GPU is present but CUDA context creation fails (e.g. wrong vGPU profile, missing container runtime config), OpenMM silently falls back to CPU. MD on CPU can take many times longer than on GPU. Previously this fallback was only visible deep in server logs; now it surfaces directly on the job's MD step status in the UI.

## Test plan

- [x] Verify all existing tests pass (no logic changes to the happy path)
- [x] On a system where CUDA is unavailable, confirm the MD step status message includes the CPU warning after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)