### PR TITLE
fix(backend): use redis@5 client for connect-redis session store

### DIFF
--- a/.changeset/fix-session-redis-client.md
+++ b/.changeset/fix-session-redis-client.md
@@ -1,0 +1,7 @@
+---
+'@bilbomd/backend': patch
+---
+
+Fix Redis syntax error in session store by using the official redis@5 client for connect-redis.
+
+connect-redis@9 expects the redis@5 client API (set with options object), but an ioredis client was being passed, causing ERR syntax error on every session write.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -36,6 +36,7 @@
     "axios": "^1.16.1",
     "bullmq": "^5.76.10",
     "connect-redis": "^9.0.0",
+    "redis": "^5.0.0",
     "cookie-parser": "~1.4.7",
     "cors": "^2.8.6",
     "cron": "^4.4.0",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -9,7 +9,7 @@ import { logger, requestLogger, assignRequestId } from './middleware/loggers.js'
 import cookieParser from 'cookie-parser'
 import session from 'express-session'
 import { RedisStore } from 'connect-redis'
-import { redis } from './queues/redisConn.js'
+import { sessionRedis } from './queues/sessionRedisConn.js'
 import { router as adminRoutes } from './routes/admin.js'
 import { bullmqAuthCheck } from './controllers/admin/bullmqAuthCheck.js'
 import mongoose from 'mongoose'
@@ -89,9 +89,12 @@ app.use(cookieParser())
 // shared across replicas. The ORCID flow uses req.session.orcidProfile as
 // the bridge between /orcid/callback and /orcid/finalize; an in-memory
 // store would strand mid-OAuth users on the confirmation page.
+// connect-redis@9 requires the official redis@5 client API (not ioredis).
+await sessionRedis.connect()
+
 app.use(
   session({
-    store: new RedisStore({ client: redis, prefix: 'bilbomd-sess:' }),
+    store: new RedisStore({ client: sessionRedis, prefix: 'bilbomd-sess:' }),
     name: 'bilbomd-session',
     secret: getEnvVar('SESSION_SECRET'),
     resave: false,

--- a/apps/backend/src/queues/sessionRedisConn.ts
+++ b/apps/backend/src/queues/sessionRedisConn.ts
@@ -1,0 +1,17 @@
+import { createClient } from 'redis'
+
+const port =
+  process.env.REDIS_PORT && !isNaN(parseInt(process.env.REDIS_PORT, 10))
+    ? parseInt(process.env.REDIS_PORT, 10)
+    : 6379
+
+const host = process.env.REDIS_HOST || 'localhost'
+const useTls = process.env.REDIS_TLS === 'true'
+
+const sessionRedis = createClient({
+  socket: useTls
+    ? { port, host, tls: true as const }
+    : { port, host }
+})
+
+export { sessionRedis }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       openid-client:
         specifier: ~6.8.4
         version: 6.8.4
+      redis:
+        specifier: ^5.0.0
+        version: 5.12.1
       swagger-jsdoc:
         specifier: ^6.2.8
         version: 6.2.8(openapi-types@12.1.3)


### PR DESCRIPTION
## Summary

- `connect-redis@9` expects the official `redis@5` client API (`set(key, val, { EX: ttl })`), but an `ioredis` client was being passed to `RedisStore`
- `ioredis` uses positional args for expiry, so the options object was serialized incorrectly → Redis returned `ERR syntax error` on every session write (every authenticated request)
- Added `redis@5` as a direct dependency, created `src/queues/sessionRedisConn.ts` with a proper `redis@5` client, and updated `app.ts` to use it for the session store

## Test plan

- [ ] Deploy backend and verify no more `ReplyError: ERR syntax error` in logs when hitting authenticated endpoints
- [ ] Verify sessions still work (login, JWT-authenticated requests, ORCID flow if enabled)
- [ ] All 452 backend unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)