### PR TITLE
fix(worker,ui): mark jobs failed on step error + warn on large rg_max

### DIFF
--- a/.changeset/classic-rgmax-warning.md
+++ b/.changeset/classic-rgmax-warning.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Warn users on the Classic job form when the chosen Rg Max is more than 2× the measured Rg. Targets far above the measured Rg can cause numerical instability that crashes the MD simulation. The non-blocking warning shows the ratio, the AutoRg-suggested value, and a recommended Rg Max.

--- a/.changeset/openmm-step-failure-status.md
+++ b/.changeset/openmm-step-failure-status.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Mark jobs and the specific failing step as 'Error' in MongoDB when any pipeline step throws. Previously, a partial OpenMM MD failure (e.g. one Rg target diverging with "Particle coordinate is NaN") left the job stuck as 'Running' with the MD step showing "5/6 completed". Pipeline steps in all OpenMM-capable pipelines (pdb, auto, alphafold, openfold, sans) are now wrapped with a shared `runPipelineStep` helper that invokes `handleError` so failures are surfaced clearly to the user.

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -38,6 +38,7 @@ import { BilboMDClassicJobFormValues } from '../../types/classicJobForm'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from './JobSuccessAlert'
 import MdEngineField from 'components/MdEngineField'
+import { getRgMaxWarning } from './rgMaxWarning'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -100,6 +101,9 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
     qmin: number
     qmax: number
   } | null>(null)
+  // Rg Max suggested by AutoRg, kept so we can reference it if the user
+  // overrides Rg Max with an unreasonably large value.
+  const [suggestedRgMax, setSuggestedRgMax] = useState<string | null>(null)
 
   // RTK Query to fetch the configuration
   const {
@@ -283,6 +287,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             setUseExampleData(!useExampleData)
                             setSaxsData([])
                             setGuinierRegion(null)
+                            setSuggestedRgMax(null)
                             if (!useExampleData) {
                               if (values.bilbomd_mode === 'pdb') {
                                 void setFieldValue('pdb_file', '')
@@ -394,6 +399,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                           setPdbInfo('')
                           setSaxsData([])
                           setGuinierRegion(null)
+                          setSuggestedRgMax(null)
                           if (val === 'openmm') {
                             void setFieldValue('num_conf', '3')
                           }
@@ -639,6 +645,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             setAutoRgError(null)
                             setSaxsData([])
                             setGuinierRegion(null)
+                            setSuggestedRgMax(null)
 
                             // Parse SAXS data in the browser for the preview plot
                             try {
@@ -701,6 +708,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                   true,
                                   false
                                 )
+                                setSuggestedRgMax(String(rg_max))
                                 if (
                                   typeof qmin === 'number' &&
                                   typeof qmax === 'number'
@@ -709,6 +717,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                 }
                               } catch (error) {
                                 setSaxsData([])
+                                setSuggestedRgMax(null)
                                 setAutoRgError(
                                   `Failed to calculate Rg from *.dat file. Please check the file format and try again. ${error}`
                                 )
@@ -717,6 +726,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                               }
                             } else {
                               setSaxsData([])
+                              setSuggestedRgMax(null)
                               setAutoRgError(
                                 `Invalid *.dat file format. Please check the file format and try again.`
                               )
@@ -794,6 +804,26 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                         onBlur={handleBlur}
                       />
                     </Grid>
+                    {(() => {
+                      const warning = getRgMaxWarning(values.rg, values.rg_max)
+                      if (!warning) return null
+                      return (
+                        <Grid sx={{ mb: 2, width: '520px' }}>
+                          <Alert severity="warning">
+                            Your <b>Rg Max</b> ({warning.rgMax} Å) is{' '}
+                            {warning.ratio}× your measured Rg ({warning.rg} Å).
+                            Targeting an Rg this much larger than the measured
+                            value can cause numerical instability and may crash
+                            the MD simulation.
+                            {suggestedRgMax
+                              ? ` The auto-calculated suggestion was ${suggestedRgMax} Å.`
+                              : ''}{' '}
+                            Consider reducing <b>Rg Max</b> to around{' '}
+                            {warning.recommended} Å.
+                          </Alert>
+                        </Grid>
+                      )
+                    })()}
                     <Grid sx={{ my: 2, display: 'flex', width: '520px' }}>
                       <Field
                         name="num_conf"

--- a/apps/ui/src/features/jobs/__tests__/rgMaxWarning.test.ts
+++ b/apps/ui/src/features/jobs/__tests__/rgMaxWarning.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { getRgMaxWarning } from '../rgMaxWarning'
+
+describe('getRgMaxWarning', () => {
+  it('returns null when rg_max is within 2× the measured Rg', () => {
+    expect(getRgMaxWarning(23, 46)).toBeNull()
+    expect(getRgMaxWarning(33, 49)).toBeNull()
+    expect(getRgMaxWarning('23', '40')).toBeNull()
+  })
+
+  it('returns warning details when rg_max exceeds 2× the measured Rg', () => {
+    const warning = getRgMaxWarning(23, 100)
+    expect(warning).not.toBeNull()
+    expect(warning).toEqual({
+      rg: 23,
+      rgMax: 100,
+      ratio: '4.3',
+      recommended: 46
+    })
+  })
+
+  it('accepts string form values', () => {
+    const warning = getRgMaxWarning('20', '60')
+    expect(warning).toEqual({
+      rg: 20,
+      rgMax: 60,
+      ratio: '3.0',
+      recommended: 40
+    })
+  })
+
+  it('returns null for missing, empty, or non-numeric values', () => {
+    expect(getRgMaxWarning('', '')).toBeNull()
+    expect(getRgMaxWarning('abc', '100')).toBeNull()
+    expect(getRgMaxWarning('23', '')).toBeNull()
+    expect(getRgMaxWarning(NaN, NaN)).toBeNull()
+  })
+
+  it('returns null when rg is zero or negative', () => {
+    expect(getRgMaxWarning(0, 100)).toBeNull()
+    expect(getRgMaxWarning(-10, 100)).toBeNull()
+  })
+
+  it('does not warn at exactly the 2× boundary', () => {
+    expect(getRgMaxWarning(25, 50)).toBeNull()
+    // Just above the boundary should warn
+    expect(getRgMaxWarning(25, 51)).not.toBeNull()
+  })
+})

--- a/apps/ui/src/features/jobs/rgMaxWarning.ts
+++ b/apps/ui/src/features/jobs/rgMaxWarning.ts
@@ -1,0 +1,37 @@
+export interface RgMaxWarning {
+  rg: number
+  rgMax: number
+  ratio: string
+  recommended: number
+}
+
+// Threshold above which an Rg Max target is considered unreasonably large
+// relative to the measured Rg. AutoRg typically suggests ~1.5×, so anything
+// beyond 2× indicates a manual override that risks MD numerical instability.
+const RG_MAX_WARNING_MULTIPLIER = 2
+
+// Returns warning details when rgMax exceeds RG_MAX_WARNING_MULTIPLIER × rg,
+// otherwise null. Accepts strings (form values) or numbers.
+export const getRgMaxWarning = (
+  rg: string | number,
+  rgMax: string | number
+): RgMaxWarning | null => {
+  const rgVal = typeof rg === 'number' ? rg : parseFloat(rg)
+  const rgMaxVal = typeof rgMax === 'number' ? rgMax : parseFloat(rgMax)
+
+  if (
+    !isFinite(rgVal) ||
+    rgVal <= 0 ||
+    !isFinite(rgMaxVal) ||
+    rgMaxVal <= RG_MAX_WARNING_MULTIPLIER * rgVal
+  ) {
+    return null
+  }
+
+  return {
+    rg: rgVal,
+    rgMax: rgMaxVal,
+    ratio: (rgMaxVal / rgVal).toFixed(1),
+    recommended: Math.round(RG_MAX_WARNING_MULTIPLIER * rgVal)
+  }
+}

--- a/apps/worker/src/services/functions/__tests__/job-utils.test.ts
+++ b/apps/worker/src/services/functions/__tests__/job-utils.test.ts
@@ -5,7 +5,8 @@ import {
   makeDir,
   makeFile,
   generateInputFile,
-  handleError
+  handleError,
+  runPipelineStep
 } from '../job-utils.js'
 import { User, type IJob, type IUser } from '@bilbomd/mongodb-schema'
 import { Job as BullMQJob } from 'bullmq'
@@ -423,6 +424,55 @@ describe('job-utils', () => {
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to update job status')
       )
+    })
+  })
+
+  describe('runPipelineStep', () => {
+    it('logs start/end and runs the step function on success', async () => {
+      const mockMQJob = {
+        log: vi.fn().mockResolvedValue(undefined)
+      } as unknown as BullMQJob
+      const mockDBJob = {
+        _id: new Types.ObjectId(),
+        uuid: 'step-uuid'
+      } as unknown as IJob
+      const fn = vi.fn().mockResolvedValue(undefined)
+
+      await runPipelineStep(mockMQJob, mockDBJob, 'md', 'md', fn)
+
+      expect(fn).toHaveBeenCalledTimes(1)
+      expect(mockMQJob.log).toHaveBeenCalledWith('start md')
+      expect(mockMQJob.log).toHaveBeenCalledWith('end md')
+      expect(updateJobStatus).not.toHaveBeenCalled()
+    })
+
+    it('marks job + step as Error and re-throws when the step fails', async () => {
+      vi.mocked(updateJobStatus).mockResolvedValue(undefined)
+      const mockMQJob = {
+        log: vi.fn().mockResolvedValue(undefined)
+      } as unknown as BullMQJob
+      const mockDBJob = {
+        _id: new Types.ObjectId(),
+        uuid: 'step-uuid',
+        title: 'Step Test Job',
+        __t: 'BilboMDPDBJob',
+        status: 'Running'
+      } as unknown as IJob
+      const fn = vi.fn().mockRejectedValue(new Error('boom'))
+
+      await expect(
+        runPipelineStep(mockMQJob, mockDBJob, 'md', 'md', fn)
+      ).rejects.toThrow("BilboMD failed in step 'md': boom")
+
+      expect(updateJobStatus).toHaveBeenCalledWith(mockDBJob, 'Error')
+      expect(updateStepStatus).toHaveBeenCalledWith(
+        mockDBJob,
+        'md',
+        expect.objectContaining({ status: 'Error' })
+      )
+      // 'end md' must NOT be logged after a failure
+      expect(mockMQJob.log).toHaveBeenCalledWith('start md')
+      expect(mockMQJob.log).not.toHaveBeenCalledWith('end md')
     })
   })
 })

--- a/apps/worker/src/services/functions/job-utils.ts
+++ b/apps/worker/src/services/functions/job-utils.ts
@@ -131,6 +131,26 @@ const handleJobEmailNotification = async (
   }
 }
 
+// Run a single pipeline step: log start/end and, on failure, mark the job and
+// the specific step as 'Error' in MongoDB before re-throwing so BullMQ fails the
+// job (instead of leaving it stuck as 'Running').
+const runPipelineStep = async (
+  MQjob: BullMQJob,
+  DBjob: IJob,
+  label: string,
+  step: keyof IBilboMDSteps | undefined,
+  fn: () => Promise<void>
+): Promise<void> => {
+  await MQjob.log(`start ${label}`)
+  try {
+    await fn()
+  } catch (error) {
+    // handleError sets job + step status to 'Error' and re-throws.
+    await handleError(error, DBjob, step)
+  }
+  await MQjob.log(`end ${label}`)
+}
+
 const makeDir = async (directory: string) => {
   await fs.ensureDir(directory)
   logger.info(`Create Dir: ${directory}`)
@@ -323,6 +343,7 @@ const handleError = async (
 export {
   initializeJob,
   cleanupJob,
+  runPipelineStep,
   makeDir,
   makeFile,
   generateDCD2PDBInpFile,

--- a/apps/worker/src/services/pipelines/__tests__/bilbomd-alphafold.test.ts
+++ b/apps/worker/src/services/pipelines/__tests__/bilbomd-alphafold.test.ts
@@ -74,7 +74,18 @@ vi.mock('../../functions/bilbomd-step-functions-nersc.js', () => ({
 
 vi.mock('../../functions/job-utils.js', () => ({
   initializeJob: stub('initializeJob'),
-  cleanupJob: stub('cleanupJob')
+  cleanupJob: stub('cleanupJob'),
+  runPipelineStep: vi.fn(
+    async (
+      _mq: unknown,
+      _job: unknown,
+      _label: string,
+      _step: string | undefined,
+      fn: () => Promise<void>
+    ) => {
+      await fn()
+    }
+  )
 }))
 
 vi.mock('../../functions/usage-events.js', () => ({

--- a/apps/worker/src/services/pipelines/bilbomd-alphafold.ts
+++ b/apps/worker/src/services/pipelines/bilbomd-alphafold.ts
@@ -14,7 +14,11 @@ import {
 import { runPrepPdb } from '../functions/pdb-to-crd.js'
 import { runFoXS } from '../functions/foxs-functions.js'
 import { prepareBilboMDResults } from '../functions/bilbomd-step-functions-nersc.js'
-import { initializeJob, cleanupJob } from '../functions/job-utils.js'
+import {
+  initializeJob,
+  cleanupJob,
+  runPipelineStep
+} from '../functions/job-utils.js'
 import { runSingleFoXS } from '../functions/foxs-analysis.js'
 import { enqueueMakeMovie } from '../functions/movie-enqueuer.js'
 import {
@@ -64,71 +68,71 @@ const processBilboMDAlphaFoldJob = async (MQjob: BullMQJob) => {
   await progress.update(10)
 
   // ColabFold → af-rank1.pdb + af-pae.json. Sets pdb_file/pae_file on the job.
-  await MQjob.log('start alphafold')
-  await runAlphaFold(MQjob, foundJob)
-  await MQjob.log('end alphafold')
+  await runPipelineStep(MQjob, foundJob, 'alphafold', 'alphafold', () =>
+    runAlphaFold(MQjob, foundJob)
+  )
   await progress.update(25)
 
   // Remove waters and ions — incompatible with the implicit-solvent force field
-  await MQjob.log('start prep-pdb')
-  await runPrepPdb({
-    uuid: foundJob.uuid,
-    pdb_file: foundJob.pdb_file as string
-  })
-  await MQjob.log('end prep-pdb')
+  await runPipelineStep(MQjob, foundJob, 'prep-pdb', undefined, () =>
+    runPrepPdb({
+      uuid: foundJob.uuid,
+      pdb_file: foundJob.pdb_file as string
+    })
+  )
 
   // First openmm_config.yaml — bare config, no constraints yet.
-  await MQjob.log('start openmm-config')
-  await prepareOpenMMConfig(foundJob)
-  await MQjob.log('end openmm-config')
+  await runPipelineStep(MQjob, foundJob, 'openmm-config', undefined, () =>
+    prepareOpenMMConfig(foundJob)
+  )
 
   // PAE → openmm_const.yml.
-  await MQjob.log('start pae')
-  await runPaeToConstInp(MQjob, foundJob)
-  await MQjob.log('end pae')
+  await runPipelineStep(MQjob, foundJob, 'pae', 'pae', () =>
+    runPaeToConstInp(MQjob, foundJob)
+  )
   await progress.update(30)
 
   // Re-run prepareOpenMMConfig so openmm_const.yml is folded into openmm_config.yaml.
-  await MQjob.log('start openmm-config-merge')
-  await prepareOpenMMConfig(foundJob)
-  await MQjob.log('end openmm-config-merge')
+  await runPipelineStep(MQjob, foundJob, 'openmm-config-merge', undefined, () =>
+    prepareOpenMMConfig(foundJob)
+  )
 
-  await MQjob.log('start minimize')
-  await runOmmMinimize(MQjob, foundJob)
-  await MQjob.log('end minimize')
+  await runPipelineStep(MQjob, foundJob, 'minimize', 'minimize', () =>
+    runOmmMinimize(MQjob, foundJob)
+  )
   await progress.update(40)
 
-  await MQjob.log('start initfoxs')
-  await runSingleFoXS(foundJob)
-  await MQjob.log('end initfoxs')
+  await runPipelineStep(MQjob, foundJob, 'initfoxs', 'initfoxs', () =>
+    runSingleFoXS(foundJob)
+  )
   await progress.update(45)
 
-  await MQjob.log('start heat')
-  await runOmmHeat(MQjob, foundJob)
-  await MQjob.log('end heat')
+  await runPipelineStep(MQjob, foundJob, 'heat', 'heat', () =>
+    runOmmHeat(MQjob, foundJob)
+  )
   await progress.update(55)
 
-  await MQjob.log('start md')
-  await runOmmMD(MQjob, foundJob)
-  await MQjob.log('end md')
+  await runPipelineStep(MQjob, foundJob, 'md', 'md', () =>
+    runOmmMD(MQjob, foundJob)
+  )
   await progress.update(70)
 
   // Movie generation (fire-and-forget).
   enqueueMakeMovie(MQjob, foundJob)
 
-  await MQjob.log('start foxs')
-  await runFoXS(MQjob, foundJob)
-  await MQjob.log('end foxs')
+  await runPipelineStep(MQjob, foundJob, 'foxs', 'foxs', () =>
+    runFoXS(MQjob, foundJob)
+  )
   await progress.update(85)
 
-  await MQjob.log('start multifoxs')
-  await runMultiFoxs(MQjob, foundJob)
-  await MQjob.log('end multifoxs')
+  await runPipelineStep(MQjob, foundJob, 'multifoxs', 'multifoxs', () =>
+    runMultiFoxs(MQjob, foundJob)
+  )
   await progress.update(95)
 
-  await MQjob.log('start results')
-  await prepareBilboMDResults(foundJob)
-  await MQjob.log('end results')
+  await runPipelineStep(MQjob, foundJob, 'results', 'results', () =>
+    prepareBilboMDResults(foundJob)
+  )
   await progress.update(99)
 
   await cleanupJob(MQjob, foundJob)

--- a/apps/worker/src/services/pipelines/bilbomd-auto.ts
+++ b/apps/worker/src/services/pipelines/bilbomd-auto.ts
@@ -22,7 +22,11 @@ import {
 } from '../functions/bilbomd-functions.js'
 import { runFoXS } from '../functions/foxs-functions.js'
 import { prepareBilboMDResults } from '../functions/bilbomd-step-functions-nersc.js'
-import { initializeJob, cleanupJob } from '../functions/job-utils.js'
+import {
+  initializeJob,
+  cleanupJob,
+  runPipelineStep
+} from '../functions/job-utils.js'
 import { runSingleFoXS } from '../functions/foxs-analysis.js'
 import { enqueueMakeMovie } from '../functions/movie-enqueuer.js'
 import {
@@ -69,100 +73,100 @@ const processBilboMDAutoJob = async (MQjob: BullMQJob) => {
 
   // Convert CIF → PDB before any engine-specific processing
   if (foundJob.pdb_file?.toLowerCase().endsWith('.cif')) {
-    await MQjob.log('start cif-to-pdb')
-    foundJob.pdb_file = await runCifToPdb({
-      uuid: foundJob.uuid,
-      pdb_file: foundJob.pdb_file
+    await runPipelineStep(MQjob, foundJob, 'cif-to-pdb', undefined, async () => {
+      foundJob.pdb_file = await runCifToPdb({
+        uuid: foundJob.uuid,
+        pdb_file: foundJob.pdb_file
+      })
     })
-    await MQjob.log(`end cif-to-pdb: ${foundJob.pdb_file}`)
   }
 
   // Use PAE to construct const.inp file
-  await MQjob.log('start pae')
-  await runPaeToConstInp(MQjob, foundJob)
-  await MQjob.log('end pae')
+  await runPipelineStep(MQjob, foundJob, 'pae', 'pae', () =>
+    runPaeToConstInp(MQjob, foundJob)
+  )
   await progress.update(15)
 
   // Calculate Rg_min and Rg_max
-  await MQjob.log('start autorg')
-  await runAutoRg(foundJob)
-  await MQjob.log('end autorg')
+  await runPipelineStep(MQjob, foundJob, 'autorg', 'autorg', () =>
+    runAutoRg(foundJob)
+  )
   await progress.update(20)
 
   if (engine === 'CHARMM') {
     // Make sure CRD/PSF files are ready
-    await MQjob.log('start pdb2crd')
-    await runPdb2Crd(MQjob, foundJob)
-    await MQjob.log('end pdb2crd')
+    await runPipelineStep(MQjob, foundJob, 'pdb2crd', 'pdb2crd', () =>
+      runPdb2Crd(MQjob, foundJob)
+    )
 
     // CHARMM minimization
-    await MQjob.log('start minimize')
-    await runMinimize(MQjob, foundJob)
-    await MQjob.log('end minimize')
+    await runPipelineStep(MQjob, foundJob, 'minimize', 'minimize', () =>
+      runMinimize(MQjob, foundJob)
+    )
     await progress.update(25)
 
     // FoXS calculations on minimization_output.pdb
-    await MQjob.log('start initfoxs')
-    await runSingleFoXS(foundJob)
-    await MQjob.log('end initfoxs')
+    await runPipelineStep(MQjob, foundJob, 'initfoxs', 'initfoxs', () =>
+      runSingleFoXS(foundJob)
+    )
     await progress.update(30)
 
     // CHARMM heating
-    await MQjob.log('start heat')
-    await runHeat(MQjob, foundJob)
-    await MQjob.log('end heat')
+    await runPipelineStep(MQjob, foundJob, 'heat', 'heat', () =>
+      runHeat(MQjob, foundJob)
+    )
     await progress.update(40)
 
     // CHARMM molecular dynamics
-    await MQjob.log('start md')
-    await runMolecularDynamics(MQjob, foundJob)
-    await MQjob.log('end md')
+    await runPipelineStep(MQjob, foundJob, 'md', 'md', () =>
+      runMolecularDynamics(MQjob, foundJob)
+    )
     await progress.update(50)
 
     // Extract PDBs from DCDs
-    await MQjob.log('start dcd2pdb')
-    await extractPDBFilesFromDCD(MQjob, foundJob)
-    await MQjob.log('end dcd2pdb')
+    await runPipelineStep(MQjob, foundJob, 'dcd2pdb', 'dcd2pdb', () =>
+      extractPDBFilesFromDCD(MQjob, foundJob)
+    )
     await progress.update(60)
 
     // Remediate PDB files
-    await MQjob.log('start remediate')
-    await remediatePDBFiles(foundJob)
-    await MQjob.log('end remediate')
+    await runPipelineStep(MQjob, foundJob, 'remediate', 'pdb_remediate', () =>
+      remediatePDBFiles(foundJob)
+    )
     await progress.update(70)
   } else {
     // Remove waters and ions — incompatible with the implicit-solvent force field
-    await MQjob.log('start prep-pdb')
-    await runPrepPdb({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
-    await MQjob.log('end prep-pdb')
+    await runPipelineStep(MQjob, foundJob, 'prep-pdb', undefined, () =>
+      runPrepPdb({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
+    )
 
     // Prepare OpenMM config YAML
-    await MQjob.log('start openmm-config')
-    await prepareOpenMMConfig(foundJob)
-    await MQjob.log('end openmm-config')
+    await runPipelineStep(MQjob, foundJob, 'openmm-config', undefined, () =>
+      prepareOpenMMConfig(foundJob)
+    )
 
     // OpenMM minimization
-    await MQjob.log('start minimize')
-    await runOmmMinimize(MQjob, foundJob)
-    await MQjob.log('end minimize')
+    await runPipelineStep(MQjob, foundJob, 'minimize', 'minimize', () =>
+      runOmmMinimize(MQjob, foundJob)
+    )
     await progress.update(25)
 
     // FoXS calculations on minimization_output.pdb
-    await MQjob.log('start initfoxs')
-    await runSingleFoXS(foundJob)
-    await MQjob.log('end initfoxs')
+    await runPipelineStep(MQjob, foundJob, 'initfoxs', 'initfoxs', () =>
+      runSingleFoXS(foundJob)
+    )
     await progress.update(30)
 
     // OpenMM heating
-    await MQjob.log('start heat')
-    await runOmmHeat(MQjob, foundJob)
-    await MQjob.log('end heat')
+    await runPipelineStep(MQjob, foundJob, 'heat', 'heat', () =>
+      runOmmHeat(MQjob, foundJob)
+    )
     await progress.update(40)
 
     // OpenMM molecular dynamics
-    await MQjob.log('start md')
-    await runOmmMD(MQjob, foundJob)
-    await MQjob.log('end md')
+    await runPipelineStep(MQjob, foundJob, 'md', 'md', () =>
+      runOmmMD(MQjob, foundJob)
+    )
     await progress.update(50)
 
     // Generate MP4 movies from DCD files
@@ -172,21 +176,21 @@ const processBilboMDAutoJob = async (MQjob: BullMQJob) => {
   }
 
   // Calculate FoXS profiles
-  await MQjob.log('start foxs')
-  await runFoXS(MQjob, foundJob)
-  await MQjob.log('end foxs')
+  await runPipelineStep(MQjob, foundJob, 'foxs', 'foxs', () =>
+    runFoXS(MQjob, foundJob)
+  )
   await progress.update(80)
 
   // MultiFoXS
-  await MQjob.log('start multifoxs')
-  await runMultiFoxs(MQjob, foundJob)
-  await MQjob.log('end multifoxs')
+  await runPipelineStep(MQjob, foundJob, 'multifoxs', 'multifoxs', () =>
+    runMultiFoxs(MQjob, foundJob)
+  )
   await progress.update(95)
 
   // Prepare results
-  await MQjob.log('start results')
-  await prepareBilboMDResults(foundJob)
-  await MQjob.log('end results')
+  await runPipelineStep(MQjob, foundJob, 'results', 'results', () =>
+    prepareBilboMDResults(foundJob)
+  )
   await progress.update(99)
 
   // Cleanup & send email

--- a/apps/worker/src/services/pipelines/bilbomd-openfold.ts
+++ b/apps/worker/src/services/pipelines/bilbomd-openfold.ts
@@ -14,7 +14,11 @@ import {
 import { runPrepPdb } from '../functions/pdb-to-crd.js'
 import { runFoXS } from '../functions/foxs-functions.js'
 import { prepareBilboMDResults } from '../functions/bilbomd-step-functions-nersc.js'
-import { initializeJob, cleanupJob } from '../functions/job-utils.js'
+import {
+  initializeJob,
+  cleanupJob,
+  runPipelineStep
+} from '../functions/job-utils.js'
 import { runSingleFoXS } from '../functions/foxs-analysis.js'
 import { enqueueMakeMovie } from '../functions/movie-enqueuer.js'
 import {
@@ -61,66 +65,66 @@ const processBilboMDOpenFoldJob = async (MQjob: BullMQJob) => {
   await initializeJob(MQjob, foundJob)
   await progress.update(10)
 
-  await MQjob.log('start openfold')
-  await runOpenFold(MQjob, foundJob)
-  await MQjob.log('end openfold')
+  await runPipelineStep(MQjob, foundJob, 'openfold', 'openfold', () =>
+    runOpenFold(MQjob, foundJob)
+  )
   await progress.update(25)
 
-  await MQjob.log('start prep-pdb')
-  await runPrepPdb({
-    uuid: foundJob.uuid,
-    pdb_file: foundJob.pdb_file as string
-  })
-  await MQjob.log('end prep-pdb')
+  await runPipelineStep(MQjob, foundJob, 'prep-pdb', undefined, () =>
+    runPrepPdb({
+      uuid: foundJob.uuid,
+      pdb_file: foundJob.pdb_file as string
+    })
+  )
 
-  await MQjob.log('start openmm-config')
-  await prepareOpenMMConfig(foundJob)
-  await MQjob.log('end openmm-config')
+  await runPipelineStep(MQjob, foundJob, 'openmm-config', undefined, () =>
+    prepareOpenMMConfig(foundJob)
+  )
 
-  await MQjob.log('start pae')
-  await runPaeToConstInp(MQjob, foundJob)
-  await MQjob.log('end pae')
+  await runPipelineStep(MQjob, foundJob, 'pae', 'pae', () =>
+    runPaeToConstInp(MQjob, foundJob)
+  )
   await progress.update(30)
 
-  await MQjob.log('start openmm-config-merge')
-  await prepareOpenMMConfig(foundJob)
-  await MQjob.log('end openmm-config-merge')
+  await runPipelineStep(MQjob, foundJob, 'openmm-config-merge', undefined, () =>
+    prepareOpenMMConfig(foundJob)
+  )
 
-  await MQjob.log('start minimize')
-  await runOmmMinimize(MQjob, foundJob)
-  await MQjob.log('end minimize')
+  await runPipelineStep(MQjob, foundJob, 'minimize', 'minimize', () =>
+    runOmmMinimize(MQjob, foundJob)
+  )
   await progress.update(40)
 
-  await MQjob.log('start initfoxs')
-  await runSingleFoXS(foundJob)
-  await MQjob.log('end initfoxs')
+  await runPipelineStep(MQjob, foundJob, 'initfoxs', 'initfoxs', () =>
+    runSingleFoXS(foundJob)
+  )
   await progress.update(45)
 
-  await MQjob.log('start heat')
-  await runOmmHeat(MQjob, foundJob)
-  await MQjob.log('end heat')
+  await runPipelineStep(MQjob, foundJob, 'heat', 'heat', () =>
+    runOmmHeat(MQjob, foundJob)
+  )
   await progress.update(55)
 
-  await MQjob.log('start md')
-  await runOmmMD(MQjob, foundJob)
-  await MQjob.log('end md')
+  await runPipelineStep(MQjob, foundJob, 'md', 'md', () =>
+    runOmmMD(MQjob, foundJob)
+  )
   await progress.update(70)
 
   enqueueMakeMovie(MQjob, foundJob)
 
-  await MQjob.log('start foxs')
-  await runFoXS(MQjob, foundJob)
-  await MQjob.log('end foxs')
+  await runPipelineStep(MQjob, foundJob, 'foxs', 'foxs', () =>
+    runFoXS(MQjob, foundJob)
+  )
   await progress.update(85)
 
-  await MQjob.log('start multifoxs')
-  await runMultiFoxs(MQjob, foundJob)
-  await MQjob.log('end multifoxs')
+  await runPipelineStep(MQjob, foundJob, 'multifoxs', 'multifoxs', () =>
+    runMultiFoxs(MQjob, foundJob)
+  )
   await progress.update(95)
 
-  await MQjob.log('start results')
-  await prepareBilboMDResults(foundJob)
-  await MQjob.log('end results')
+  await runPipelineStep(MQjob, foundJob, 'results', 'results', () =>
+    prepareBilboMDResults(foundJob)
+  )
   await progress.update(99)
 
   await cleanupJob(MQjob, foundJob)

--- a/apps/worker/src/services/pipelines/bilbomd-pdb.ts
+++ b/apps/worker/src/services/pipelines/bilbomd-pdb.ts
@@ -19,7 +19,11 @@ import {
 } from '../functions/bilbomd-functions.js'
 import { runFoXS } from '../functions/foxs-functions.js'
 import { prepareBilboMDResults } from '../functions/bilbomd-step-functions-nersc.js'
-import { initializeJob, cleanupJob } from '../functions/job-utils.js'
+import {
+  initializeJob,
+  cleanupJob,
+  runPipelineStep
+} from '../functions/job-utils.js'
 import { runSingleFoXS } from '../functions/foxs-analysis.js'
 import { prepareOpenMMConfig } from '../functions/openmm-functions.js'
 import { enqueueMakeMovie } from '../functions/movie-enqueuer.js'
@@ -85,60 +89,57 @@ const processBilboMDPDBJob = async (MQjob: BullMQJob) => {
 
   // Convert CIF → PDB before any engine-specific processing
   if (foundJob.pdb_file?.toLowerCase().endsWith('.cif')) {
-    await MQjob.log('start cif-to-pdb')
-    foundJob.pdb_file = await runCifToPdb({
-      uuid: foundJob.uuid,
-      pdb_file: foundJob.pdb_file
+    await runPipelineStep(MQjob, foundJob, 'cif-to-pdb', undefined, async () => {
+      foundJob.pdb_file = await runCifToPdb({
+        uuid: foundJob.uuid,
+        pdb_file: foundJob.pdb_file
+      })
     })
-    await MQjob.log(`end cif-to-pdb: ${foundJob.pdb_file}`)
   }
 
   if (engine === 'CHARMM') {
     // PDB to CRD/PSF for 'pdb' mode
-    await MQjob.log('start pdb2crd')
-    await runPdb2Crd(MQjob, foundJob)
-    await MQjob.log('end pdb2crd')
+    await runPipelineStep(MQjob, foundJob, 'pdb2crd', 'pdb2crd', () =>
+      runPdb2Crd(MQjob, foundJob)
+    )
   } else {
     // Remove waters and ions — incompatible with the implicit-solvent force field
-    await MQjob.log('start prep-pdb')
-    await runPrepPdb({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
-    await MQjob.log('end prep-pdb')
+    await runPipelineStep(MQjob, foundJob, 'prep-pdb', undefined, () =>
+      runPrepPdb({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
+    )
 
     // Strip unsupported cofactors (FAD, HEM, PCA, etc.) — no bundled Amber parameters.
     // They are removed for MD only; the original uploaded PDB is used for FoXS.
-    // await MQjob.log('start strip-cofactors')
-    // await runStripCofactors({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
-    // await MQjob.log('end strip-cofactors')
 
     // Prepare OpenMM config YAML instead of pdb2crd
-    await MQjob.log('start openmm-config')
-    await prepareOpenMMConfig(foundJob)
-    await MQjob.log('end openmm-config')
+    await runPipelineStep(MQjob, foundJob, 'openmm-config', undefined, () =>
+      prepareOpenMMConfig(foundJob)
+    )
   }
   await progress.update(15)
 
   // Minimize
-  await MQjob.log('start minimize')
-  await runners.minimize(MQjob, foundJob)
-  await MQjob.log('end minimize')
+  await runPipelineStep(MQjob, foundJob, 'minimize', 'minimize', () =>
+    runners.minimize(MQjob, foundJob)
+  )
   await progress.update(25)
 
   // FoXS calculations on minimization_output.pdb
-  await MQjob.log('start initfoxs')
-  await runSingleFoXS(foundJob)
-  await MQjob.log('end initfoxs')
+  await runPipelineStep(MQjob, foundJob, 'initfoxs', 'initfoxs', () =>
+    runSingleFoXS(foundJob)
+  )
   await progress.update(30)
 
   // Heat
-  await MQjob.log('start heat')
-  await runners.heat(MQjob, foundJob)
-  await MQjob.log('end heat')
+  await runPipelineStep(MQjob, foundJob, 'heat', 'heat', () =>
+    runners.heat(MQjob, foundJob)
+  )
   await progress.update(40)
 
   // Molecular Dynamics
-  await MQjob.log('start md')
-  await runners.md(MQjob, foundJob)
-  await MQjob.log('end md')
+  await runPipelineStep(MQjob, foundJob, 'md', 'md', () =>
+    runners.md(MQjob, foundJob)
+  )
   await progress.update(50)
 
   // Generate MP4 movies from DCD files (OpenMM only, fire-and-forget)
@@ -148,36 +149,36 @@ const processBilboMDPDBJob = async (MQjob: BullMQJob) => {
 
   // Extract PDBs from DCDs
   if (engine === 'CHARMM') {
-    await MQjob.log('start dcd2pdb')
-    await extractPDBFilesFromDCD(MQjob, foundJob)
-    await MQjob.log('end dcd2pdb')
+    await runPipelineStep(MQjob, foundJob, 'dcd2pdb', 'dcd2pdb', () =>
+      extractPDBFilesFromDCD(MQjob, foundJob)
+    )
     await progress.update(60)
   }
 
   // Remediate PDB files
   if (engine === 'CHARMM') {
-    await MQjob.log('start remediate')
-    await remediatePDBFiles(foundJob)
-    await MQjob.log('end remediate')
+    await runPipelineStep(MQjob, foundJob, 'remediate', 'pdb_remediate', () =>
+      remediatePDBFiles(foundJob)
+    )
     await progress.update(70)
   }
 
   // Calculate FoXS profiles
-  await MQjob.log('start foxs')
-  await runFoXS(MQjob, foundJob)
-  await MQjob.log('end foxs')
+  await runPipelineStep(MQjob, foundJob, 'foxs', 'foxs', () =>
+    runFoXS(MQjob, foundJob)
+  )
   await progress.update(80)
 
   // MultiFoXS
-  await MQjob.log('start multifoxs')
-  await runMultiFoxs(MQjob, foundJob)
-  await MQjob.log('end multifoxs')
+  await runPipelineStep(MQjob, foundJob, 'multifoxs', 'multifoxs', () =>
+    runMultiFoxs(MQjob, foundJob)
+  )
   await progress.update(95)
 
   // Prepare results
-  await MQjob.log('start results')
-  await prepareBilboMDResults(foundJob)
-  await MQjob.log('end results')
+  await runPipelineStep(MQjob, foundJob, 'results', 'results', () =>
+    prepareBilboMDResults(foundJob)
+  )
   await progress.update(99)
 
   // Cleanup & send email

--- a/apps/worker/src/services/pipelines/bilbomd-sans.ts
+++ b/apps/worker/src/services/pipelines/bilbomd-sans.ts
@@ -25,7 +25,11 @@ import {
   prepareBilboMDSANSResults
 } from '../functions/bilbomd-sans-functions.js'
 // import { prepareBilboMDResults } from '../functions/bilbomd-step-functions-nersc'
-import { initializeJob, cleanupJob } from '../functions/job-utils.js'
+import {
+  initializeJob,
+  cleanupJob,
+  runPipelineStep
+} from '../functions/job-utils.js'
 import { enqueueMakeMovie } from '../functions/movie-enqueuer.js'
 import {
   recordWorkerUsageEvent,
@@ -71,90 +75,94 @@ const processBilboMDSANSJob = async (MQjob: BullMQJob) => {
 
   // Convert CIF → PDB before any engine-specific processing
   if (foundJob.pdb_file?.toLowerCase().endsWith('.cif')) {
-    await MQjob.log('start cif-to-pdb')
-    foundJob.pdb_file = await runCifToPdb({
-      uuid: foundJob.uuid,
-      pdb_file: foundJob.pdb_file
+    await runPipelineStep(MQjob, foundJob, 'cif-to-pdb', undefined, async () => {
+      foundJob.pdb_file = await runCifToPdb({
+        uuid: foundJob.uuid,
+        pdb_file: foundJob.pdb_file
+      })
     })
-    await MQjob.log(`end cif-to-pdb: ${foundJob.pdb_file}`)
   }
 
   if (engine === 'CHARMM') {
     // PDB to CRD/PSF for 'pdb' mode
-    await MQjob.log('start pdb2crd')
-    await runPdb2Crd(MQjob, foundJob)
-    await MQjob.log('end pdb2crd')
+    await runPipelineStep(MQjob, foundJob, 'pdb2crd', 'pdb2crd', () =>
+      runPdb2Crd(MQjob, foundJob)
+    )
     await progress.update(15)
 
     // CHARMM minimization
-    await MQjob.log('start minimize')
-    await runMinimize(MQjob, foundJob)
-    await MQjob.log('end minimize')
-    await progress.update(20)
-
-    // CHARMM heating
-    await MQjob.log('start heat')
-    await runHeat(MQjob, foundJob)
-    await MQjob.log('end heat')
-    await progress.update(30)
-
-    // CHARMM molecular dynamics
-    await MQjob.log('start md')
-    await runMolecularDynamics(MQjob, foundJob)
-    await MQjob.log('end md')
-    await progress.update(50)
-
-    // Extract PDBs from DCDs
-    await MQjob.log('start dcd2pdb')
-    await extractPDBFilesFromDCD(MQjob, foundJob)
-    await MQjob.log('end dcd2pdb')
-    await progress.update(60)
-
-    // Remediate PDB files
-    await MQjob.log('start remediate')
-    await remediatePDBFiles(foundJob)
-    await MQjob.log('end remediate')
-    await progress.update(70)
-  } else {
-    // Remove waters and ions — incompatible with the implicit-solvent force field
-    await MQjob.log('start prep-pdb')
-    await runPrepPdb({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
-    await MQjob.log('end prep-pdb')
-
-    // Prepare OpenMM config YAML
-    await MQjob.log('start openmm-config')
-    await prepareOpenMMConfig(foundJob)
-    await MQjob.log('end openmm-config')
-
-    // OpenMM minimization
-    await MQjob.log('start minimize')
-    await runOmmMinimize(MQjob, foundJob)
-    await MQjob.log('end minimize')
-    // Place minimized PDB at the job root so prepareBilboMDSANSResults can copy it.
-    const workDir = path.join(config.uploadDir, foundJob.uuid)
-    await fs.copy(
-      path.join(workDir, 'openmm', 'minimize', 'minimized.pdb'),
-      path.join(workDir, 'minimization_output.pdb'),
-      { overwrite: true }
+    await runPipelineStep(MQjob, foundJob, 'minimize', 'minimize', () =>
+      runMinimize(MQjob, foundJob)
     )
     await progress.update(20)
 
+    // CHARMM heating
+    await runPipelineStep(MQjob, foundJob, 'heat', 'heat', () =>
+      runHeat(MQjob, foundJob)
+    )
+    await progress.update(30)
+
+    // CHARMM molecular dynamics
+    await runPipelineStep(MQjob, foundJob, 'md', 'md', () =>
+      runMolecularDynamics(MQjob, foundJob)
+    )
+    await progress.update(50)
+
+    // Extract PDBs from DCDs
+    await runPipelineStep(MQjob, foundJob, 'dcd2pdb', 'dcd2pdb', () =>
+      extractPDBFilesFromDCD(MQjob, foundJob)
+    )
+    await progress.update(60)
+
+    // Remediate PDB files
+    await runPipelineStep(MQjob, foundJob, 'remediate', 'pdb_remediate', () =>
+      remediatePDBFiles(foundJob)
+    )
+    await progress.update(70)
+  } else {
+    // Remove waters and ions — incompatible with the implicit-solvent force field
+    await runPipelineStep(MQjob, foundJob, 'prep-pdb', undefined, () =>
+      runPrepPdb({ uuid: foundJob.uuid, pdb_file: foundJob.pdb_file })
+    )
+
+    // Prepare OpenMM config YAML
+    await runPipelineStep(MQjob, foundJob, 'openmm-config', undefined, () =>
+      prepareOpenMMConfig(foundJob)
+    )
+
+    // OpenMM minimization
+    await runPipelineStep(MQjob, foundJob, 'minimize', 'minimize', async () => {
+      await runOmmMinimize(MQjob, foundJob)
+      // Place minimized PDB at the job root so prepareBilboMDSANSResults can copy it.
+      const workDir = path.join(config.uploadDir, foundJob.uuid)
+      await fs.copy(
+        path.join(workDir, 'openmm', 'minimize', 'minimized.pdb'),
+        path.join(workDir, 'minimization_output.pdb'),
+        { overwrite: true }
+      )
+    })
+    await progress.update(20)
+
     // OpenMM heating
-    await MQjob.log('start heat')
-    await runOmmHeat(MQjob, foundJob)
-    await MQjob.log('end heat')
+    await runPipelineStep(MQjob, foundJob, 'heat', 'heat', () =>
+      runOmmHeat(MQjob, foundJob)
+    )
     await progress.update(30)
 
     // OpenMM molecular dynamics
-    await MQjob.log('start md')
-    await runOmmMD(MQjob, foundJob)
-    await MQjob.log('end md')
+    await runPipelineStep(MQjob, foundJob, 'md', 'md', () =>
+      runOmmMD(MQjob, foundJob)
+    )
     await progress.update(50)
 
     // Mirror PDB frames from openmm/md/rg_{N}/ into pepsisans/rg{N}/
-    await MQjob.log('start mirror-md-to-pepsisans')
-    await mirrorOmmMdToPepsiSANS(foundJob)
-    await MQjob.log('end mirror-md-to-pepsisans')
+    await runPipelineStep(
+      MQjob,
+      foundJob,
+      'mirror-md-to-pepsisans',
+      undefined,
+      () => mirrorOmmMdToPepsiSANS(foundJob)
+    )
 
     // Generate MP4 movies from DCD files — fire and forget.
     enqueueMakeMovie(MQjob, foundJob)
@@ -163,21 +171,21 @@ const processBilboMDSANSJob = async (MQjob: BullMQJob) => {
   }
 
   // Calculate Pepsi-SANS profiles
-  await MQjob.log('start pepsisans')
-  await runPepsiSANSOnPDBFiles(MQjob, foundJob)
-  await MQjob.log('end pepsisans')
+  await runPipelineStep(MQjob, foundJob, 'pepsisans', 'pepsisans', () =>
+    runPepsiSANSOnPDBFiles(MQjob, foundJob)
+  )
   await progress.update(80)
 
   // GA-SANS analysis
-  await MQjob.log('start ga-sans')
-  await runGASANS(MQjob, foundJob)
-  await MQjob.log('end ga-sans')
+  await runPipelineStep(MQjob, foundJob, 'ga-sans', 'gasans', () =>
+    runGASANS(MQjob, foundJob)
+  )
   await progress.update(90)
 
   // Prepare results
-  await MQjob.log('start results')
-  await prepareBilboMDSANSResults(foundJob)
-  await MQjob.log('end results')
+  await runPipelineStep(MQjob, foundJob, 'results', 'results', () =>
+    prepareBilboMDSANSResults(foundJob)
+  )
   await progress.update(99)
 
   // Cleanup & send email

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bilbomd",
   "private": true,
-  "packageManager": "pnpm@11.0.8",
+  "packageManager": "pnpm@11.4.0",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",


### PR DESCRIPTION
Closes #841.

## Background

A Classic (PDB/OpenMM) job failed when the `rg_100` MD simulation crashed with `openmm.OpenMMException: Particle coordinate is NaN` — the measured Rg was **23 Å** but `rg_max` was set to **100 Å** (a 4.35× stretch), generating restraint forces large enough to diverge the integrator. Two problems surfaced:

1. The job stayed stuck as **Running** with the MD step reading "5/6 completed, 1 failed" — never marked as failed.
2. Nothing warned the user that an `rg_max` that far above the measured Rg is dangerous.

## Bug 1 — Job stuck as "Running" (worker)

`handleError` in `job-utils.ts` already sets `job.status = 'Error'` and `steps.<step>.status = 'Error'`, but no pipeline ever called it — step failures propagated straight to BullMQ, leaving MongoDB untouched.

- Added a shared **`runPipelineStep(MQjob, DBjob, label, step, fn)`** helper that preserves the existing `start`/`end` logging and, on failure, calls `handleError` (which re-throws so BullMQ still fails the job).
- Converted every step in all OpenMM-capable pipelines: `bilbomd-pdb`, `bilbomd-auto`, `bilbomd-alphafold`, `bilbomd-openfold`, `bilbomd-sans`. Prep steps without an `IBilboMDSteps` key pass `undefined` (job still marked Error).

## Bug 2 — rg_max safety warning (UI)

- New pure helper **`getRgMaxWarning`** flags when `rg_max > 2× measured rg` (AutoRg normally suggests ~1.5×).
- `NewJobForm.tsx` renders a non-blocking `<Alert severity="warning">` below the Rg Max field showing the ratio, the AutoRg-suggested value, and a recommended cap. Submission is not blocked.

## Tests

- `runPipelineStep`: success path + failure path (job/step set to Error, no `end` log after failure).
- `getRgMaxWarning`: boundary at exactly 2×, string/NaN/zero/negative handling.
- Updated the alphafold pipeline test mock for the new `job-utils` export.
- Full monorepo: **build 7/7, lint 5/5, test 8/8** all pass.

## Changesets

- `@bilbomd/worker` (patch) — fail jobs on step error.
- `@bilbomd/ui` (patch) — Classic form rg_max warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)