### PR TITLE
fix(infra): make helm deploys upgrade single-replica DBs cleanly

### DIFF
--- a/infra/deploy-to-nersc.sh
+++ b/infra/deploy-to-nersc.sh
@@ -26,9 +26,15 @@ echo "--------------------------------"
 echo -e "\033[1;34m📜 Helm History for $RELEASE:\033[0m"
 helm history "$RELEASE"
 
+# Use server-side apply explicitly (Helm 4's "auto" otherwise inherits the
+# previous release's method, which differs between dev and prod). --force-conflicts
+# lets Helm reclaim field ownership (e.g. .spec.replicas after a manual scale-down,
+# or the one-time client-side -> server-side migration).
 helm upgrade --install "$RELEASE" "$CHART_PATH" \
   -f "$CHART_PATH/values.yaml" \
   -f "$CHART_PATH/$VALUES_FILE" \
+  --server-side=true \
+  --force-conflicts \
   --wait
 
 echo -e "\033[1;32m✅ Deployment of $RELEASE completed.\033[0m"

--- a/infra/helm/Chart.yaml
+++ b/infra/helm/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.57
+version: 0.1.58
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: '2.19.0'
+appVersion: '2.20.1'

--- a/infra/helm/templates/mongo-deployment.yaml
+++ b/infra/helm/templates/mongo-deployment.yaml
@@ -15,10 +15,10 @@ spec:
     matchLabels:
       workload.user.cattle.io/workloadselector: apps.deployment-{{ .Values.namespace }}-{{ .Values.mongo.name }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    # Single replica on a ReadWriteOnce PVC: terminate the old pod before
+    # starting the new one so the new pod can mount /data/db without a
+    # Multi-Attach error or mongod.lock conflict during version upgrades.
+    type: Recreate
   template:
     metadata:
       labels:

--- a/infra/helm/templates/redis-deployment.yaml
+++ b/infra/helm/templates/redis-deployment.yaml
@@ -15,10 +15,10 @@ spec:
     matchLabels:
       workload.user.cattle.io/workloadselector: apps.deployment-{{ .Values.namespace }}-{{ .Values.redis.name }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    # Single replica on a ReadWriteOnce PVC: terminate the old pod before
+    # starting the new one so the new pod can mount its volume without a
+    # Multi-Attach error during version upgrades.
+    type: Recreate
   template:
     metadata:
       labels:

--- a/infra/helm/values-dev.yaml
+++ b/infra/helm/values-dev.yaml
@@ -32,7 +32,7 @@ mongo:
   name: mongo
   image:
     repository: mongo
-    tag: 8.2.6
+    tag: 8.3.2
     pullPolicy: IfNotPresent
     secret: registry-nersc
   config:
@@ -42,7 +42,7 @@ redis:
   name: redis
   image:
     repository: redis
-    tag: 8.6.2
+    tag: 8.8.0
     pullPolicy: Always
     secret: registry-nersc
 
@@ -54,7 +54,7 @@ ui:
     user: null
     repository: bilbomd-ui
     build: null
-    tag: 2.19.0
+    tag: 2.20.1
     pullPolicy: Always
     secret: ghcr
 
@@ -66,7 +66,7 @@ backend:
     user: null
     repository: bilbomd-backend
     build: null
-    tag: 2.8.5
+    tag: 2.9.2
     pullPolicy: Always
     secret: ghcr
 
@@ -78,6 +78,6 @@ worker:
     user: null
     repository: bilbomd-worker
     build: null
-    tag: 2.13.2
+    tag: 2.14.4
     pullPolicy: Always
     secret: ghcr

--- a/infra/helm/values-prod.yaml
+++ b/infra/helm/values-prod.yaml
@@ -32,7 +32,7 @@ mongo:
   name: mongo
   image:
     repository: mongo
-    tag: 8.2.6
+    tag: 8.3.2
     pullPolicy: IfNotPresent
     secret: registry-nersc
   config:
@@ -42,7 +42,7 @@ redis:
   name: redis
   image:
     repository: redis
-    tag: 8.6.2
+    tag: 8.8.0
     pullPolicy: Always
     secret: registry-nersc
 
@@ -54,7 +54,7 @@ ui:
     user: null
     repository: bilbomd-ui
     build: null
-    tag: 2.13.1
+    tag: 2.20.1
     pullPolicy: Always
     secret: ghcr
 
@@ -66,7 +66,7 @@ backend:
     user: null
     repository: bilbomd-backend
     build: null
-    tag: 2.7.3
+    tag: 2.9.2
     pullPolicy: Always
     secret: ghcr
 
@@ -78,6 +78,6 @@ worker:
     user: null
     repository: bilbomd-worker
     build: null
-    tag: 2.8.0
+    tag: 2.14.4
     pullPolicy: Always
     secret: ghcr

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -4,4 +4,4 @@ nersc_repo: m4659
 cfs_dir: /global/cfs/cdirs
 pscratch: /pscratch/sd/s/sclassen
 sfapi:
-  token_expires: '2026-06-01 09:14'
+  token_expires: '2026-07-01 13:02'


### PR DESCRIPTION
## Summary

Resolves two Helm deploy failures that surfaced under **Helm 4** (which defaults to server-side apply), and upgrades MongoDB (8.2.6 → **8.3.2**) and Redis (8.6.2 → **8.8.0**) on dev and prod.

### Problems

1. **Dev — `.spec.replicas` ownership conflict.** Deployments had been manually scaled to 0; that tool's field-manager (`agent`) took ownership of `.spec.replicas`. Helm's server-side apply then refused to overwrite it:
   `conflict with "agent" using apps/v1: .spec.replicas`

2. **Prod — single-replica DB rollout deadlock.** `mongo` and `redis` run 1 replica on a **ReadWriteOnce** PVC with `RollingUpdate` (maxSurge=1, maxUnavailable=0). On upgrade, Kubernetes tries to start the new pod before terminating the old one, so the new pod either hits a **Multi-Attach** error (different node) or crashloops on a **`mongod.lock`** conflict (same node sharing `/data/db`). The rollout stalls until the 600s deadline and `--wait` fails.

3. **Dev vs prod apply-method mismatch.** Helm 4's `--server-side=auto` inherits the previous release's method — dev was already server-side, prod was client-side — so `--force-conflicts` was valid on dev but errored on prod (`forceConflicts enabled when serverSideApply disabled`).

### Changes

- **`deploy-to-nersc.sh`**: pin `--server-side=true --force-conflicts` so both environments use the same apply method, and Helm can reclaim field ownership (after manual scale-downs and the one-time client→server-side migration).
- **`mongo-deployment.yaml` / `redis-deployment.yaml`**: `strategy: RollingUpdate` → **`Recreate`**. The old pod terminates fully before the new one starts — correct for a single-replica service on RWO storage.
- **Version bumps** (`Chart.yaml`, `values.yaml`, `values-dev.yaml`, `values-prod.yaml`): mongo `8.3.2`, redis `8.8.0`, and ui/backend/worker to current released tags; chart `0.1.58` / appVersion `2.20.1`; NERSC sfapi token expiry.

### Verification

Both environments deployed from this branch's working tree:

- **dev** — revision 16, `deployed`. All workloads 1/1; mongo `8.3.2`.
- **prod** — revision 42, `deployed`. mongo `8.2.6 → 8.3.2` and redis `8.6.2 → 8.8.0`, both with **0 restarts** (clean Recreate). Mongo log confirms `db version v8.3.2`, WiredTiger opened without errors, reached "Waiting for connections".

### Notes

`infra/` is not a workspace package (`apps/*`, `packages/*` only), so no changeset is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)