### PR TITLE
fix(ui): harden usePersist against corrupted localStorage

### DIFF
--- a/.changeset/usepersist-corrupt-localstorage.md
+++ b/.changeset/usepersist-corrupt-localstorage.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Fix usePersist hook crashing on corrupted localStorage data. The hook now safely falls back to `false` when the stored `persist` value is not valid JSON, instead of throwing a SyntaxError during render.

--- a/apps/ui/src/hooks/__tests__/usePersist.test.tsx
+++ b/apps/ui/src/hooks/__tests__/usePersist.test.tsx
@@ -27,6 +27,17 @@ describe('usePersist', () => {
     expect(result.current[0]).toBe(false)
   })
 
+  it('should initialize with false if localStorage contains corrupted data', () => {
+    // Arrange: Set up localStorage with a non-JSON value
+    localStorage.setItem('persist', 'not-valid-json')
+
+    // Act: Render the hook (must not throw)
+    const { result } = renderHook(() => usePersist())
+
+    // Assert: Falls back to false instead of crashing
+    expect(result.current[0]).toBe(false)
+  })
+
   it('should update localStorage when the state changes', () => {
     // Act: Render the hook and update the state
     const { result } = renderHook(() => usePersist())

--- a/apps/ui/src/hooks/usePersist.ts
+++ b/apps/ui/src/hooks/usePersist.ts
@@ -1,9 +1,16 @@
 import { useState, useEffect } from 'react'
 
+const readPersist = (): boolean => {
+  try {
+    return JSON.parse(localStorage.getItem('persist') as string) === true
+  } catch {
+    // Corrupted or non-JSON value in localStorage — fall back to false
+    return false
+  }
+}
+
 const usePersist = (): [boolean, React.Dispatch<React.SetStateAction<boolean>>] => {
-  const [persist, setPersist] = useState<boolean>(
-    JSON.parse(localStorage.getItem('persist') as string) || false
-  )
+  const [persist, setPersist] = useState<boolean>(readPersist)
 
   useEffect(() => {
     localStorage.setItem('persist', JSON.stringify(persist))


### PR DESCRIPTION
## Summary

The `usePersist` hook called `JSON.parse(localStorage.getItem('persist'))` directly during state initialization. If the stored `persist` value was corrupted or non-JSON (e.g. `persist=foo`), `JSON.parse` threw a `SyntaxError` during render, crashing the component tree.

This wraps the read in a `try/catch` (via a small `readPersist()` helper) that falls back to `false` on bad data. The `=== true` check preserves the original boolean behavior for all valid values (`true` → `true`, `false` → `false`, missing/`null` → `false`).

## Changes

- `apps/ui/src/hooks/usePersist.ts` — safe read with fallback
- `apps/ui/src/hooks/__tests__/usePersist.test.tsx` — regression test for corrupted localStorage
- Added `@bilbomd/ui` patch changeset

## Verification

- ✅ `pnpm -F @bilbomd/ui lint` — clean
- ✅ `pnpm -F @bilbomd/ui build` — succeeds
- ✅ `pnpm -F @bilbomd/ui test` — all 1101 tests pass (including the new one)

## Context

Found during a re-evaluation of an older code audit. This was item #4 of four. Items #1 (untyped RTK Query) and #3 (PAE object URL leaks) are now effectively resolved; #2 (UI console cleanup) is tracked separately in #851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)