### PR TITLE
fix(ui): clean up unguarded console.* calls (#851)

### DIFF
--- a/.changeset/ui-remove-console-calls.md
+++ b/.changeset/ui-remove-console-calls.md
@@ -1,0 +1,9 @@
+---
+'@bilbomd/ui': patch
+---
+
+Clean up unguarded `console.*` calls in the UI (#851). Removed stray debugging
+`console.log` statements and dead commented-out console lines, and routed genuine
+diagnostics through a new `utils/logger` abstraction whose `log`/`debug`/`info`
+are no-ops in production builds while `warn`/`error` still surface. Added a
+`no-console` ESLint rule (with a test-file exception) to prevent regressions.

--- a/apps/ui/eslint.config.mjs
+++ b/apps/ui/eslint.config.mjs
@@ -47,6 +47,11 @@ export default defineConfig([
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
 
+      // No stray console.* in production code — route diagnostics through
+      // the `utils/logger` abstraction instead (which gates log/debug/info
+      // to dev). logger.ts itself opts out via a file-level eslint-disable.
+      'no-console': 'error',
+
       // TS hygiene
       '@typescript-eslint/no-unused-vars': [
         'warn',
@@ -59,6 +64,17 @@ export default defineConfig([
         'warn',
         { checksVoidReturn: false }
       ]
+    }
+  },
+
+  // Tests legitimately spy on / reassign console — allow it there.
+  {
+    files: [
+      'src/**/__tests__/**/*.{ts,tsx}',
+      'src/**/*.{test,spec}.{ts,tsx}'
+    ],
+    rules: {
+      'no-console': 'off'
     }
   }
 ])

--- a/apps/ui/src/app/api/apiSlice.ts
+++ b/apps/ui/src/app/api/apiSlice.ts
@@ -7,6 +7,7 @@ import {
 } from '@reduxjs/toolkit/query/react'
 import { setCredentials } from '../../slices/authSlice'
 import type { RootState } from '../store'
+import { logger } from 'utils/logger'
 
 const baseURL =
   process.env.NODE_ENV === 'test' ? 'http://localhost:3003/api/v1' : '/api/v1'
@@ -54,7 +55,7 @@ const baseQueryWithReauth: BaseQueryFn<
       // Return the result of the original query
       return result
     } else if (refreshResult?.error?.status === 403) {
-      console.error(
+      logger.error(
         'Refresh token expired or invalid:',
         refreshResult.error.data
       )

--- a/apps/ui/src/components/ConstInpForm/ConstInpStepper.tsx
+++ b/apps/ui/src/components/ConstInpForm/ConstInpStepper.tsx
@@ -152,9 +152,6 @@ const ConstInpStepper = () => {
                 // You can access form values using the `values` parameter
                 // You can reset the form using the `resetForm` function
 
-                // Example:
-                console.log(values) // Access form values
-
                 // Reset the form after submission
                 resetForm()
               }}

--- a/apps/ui/src/components/ConstInpForm/FormModel/validationSchemas.ts
+++ b/apps/ui/src/components/ConstInpForm/FormModel/validationSchemas.ts
@@ -38,7 +38,6 @@ const validationSchemas = [
             const typedFile = file as File
             if (file) {
               const spaceCheck = await noSpaces(typedFile)
-              // console.log(spaceCheck)
               return spaceCheck
             }
             return false
@@ -80,7 +79,6 @@ const validationSchemas = [
                   'Please choose number between chain start and end residue',
                   (value, ctx) => {
                     // Tricky stuff to find where parent values stored.
-                    // console.log(ctx)
                     if (!ctx.from) {
                       // Handle the case where ctx.from is undefined
                       // For example, you can return false or throw an error.
@@ -91,19 +89,6 @@ const validationSchemas = [
                       (x) => x.id === ctx.parent.chainid
                     )
                     if (!chain) return false
-                    // const chainStart = ctx.from[2]!.value.chains.find(
-                    //   (x) => x.id === ctx.parent.chainid
-                    // ).first_res
-
-                    // const chainEnd = ctx.from[2]!.value.chains.find(
-                    //   (x) => x.id === ctx.parent.chainid
-                    // ).last_res
-                    // console.log('chainStart', chainStart)
-                    // console.log('chainEnd', chainEnd)
-                    // console.log(ctx)
-                    // if (value >= chainStart && value <= chainEnd) {
-                    //   return true
-                    // }
                     if (value >= chain.first_res && value <= chain.last_res) {
                       return true
                     }
@@ -147,9 +132,6 @@ const validationSchemas = [
                     }
                     const rigidBodies = ctx.from[2]!.value.rigid_bodies
                     const numRigidBodies = ctx.from[2]!.value.rigid_bodies.length
-                    // console.log('rigidBodies', rigidBodies)
-                    // console.log('numRigidBodies', numRigidBodies)
-                    // console.log(ctx)
                     for (let idx = 0; idx < numRigidBodies; idx++) {
                       // loop through domains in rigid body
                       const domains = rigidBodies[idx]!.domains
@@ -158,7 +140,6 @@ const validationSchemas = [
                         //skip validating against itself
                         // && same rigid body
                         if (ctx.from[1]!.value.id === rigidBodies[idx]!.id) {
-                          // console.log('skip')
                           continue
                         }
                         //https://stackoverflow.com/questions/36035074/how-can-i-find-an-overlap-between-two-given-ranges
@@ -175,7 +156,6 @@ const validationSchemas = [
                         }
                       }
                     }
-                    // console.log('no overlap')
                     return true
                   }
                 ),
@@ -264,7 +244,6 @@ const validationSchemas = [
                         }
                       }
                     }
-                    // console.log('no overlap')
                     return true
                   }
                 )

--- a/apps/ui/src/components/ConstInpForm/Forms/UploadForm.tsx
+++ b/apps/ui/src/components/ConstInpForm/Forms/UploadForm.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, useEffect, useCallback } from 'react'
 import { CARBOHYDRATE_RESIDUES } from '@bilbomd/bilbomd-types'
+import { logger } from 'utils/logger'
 import { Field, useFormikContext } from 'formik'
 import {
   Typography,
@@ -243,7 +244,7 @@ const UploadForm = ({ setStepIsValid }: UploadFormProps) => {
           void setFieldValue('pdb_file.file', file)
         }
         reader.onerror = (error) => {
-          console.error('File reading error:', error)
+          logger.error('File reading error:', error)
         }
         reader.readAsText(file)
       }

--- a/apps/ui/src/components/Home.tsx
+++ b/apps/ui/src/components/Home.tsx
@@ -12,6 +12,7 @@ import { selectCurrentToken } from 'slices/authSlice'
 import { useRefreshMutation } from 'slices/authApiSlice'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import usePersist from 'hooks/usePersist'
+import { logger } from 'utils/logger'
 import useTitle from 'hooks/useTitle'
 import ClassicPDBOpenMMPipelineSchematic from 'features/jobs/ClassicPDBOpenMMPipelineSchematic'
 import ClassicCRDPipelineSchematic from 'features/jobs/ClassicCRDPipelineSchematic'
@@ -40,7 +41,7 @@ const Home = ({ title = 'BilboMD' }) => {
         await refresh(undefined)
         setTrueSuccess(true)
       } catch (error) {
-        console.error('verifyRefreshToken error:', error)
+        logger.error('verifyRefreshToken error:', error)
       }
     }
     if (!token && persist) void verifyRefreshToken()

--- a/apps/ui/src/features/admin/QueueDetailsPage.tsx
+++ b/apps/ui/src/features/admin/QueueDetailsPage.tsx
@@ -31,6 +31,7 @@ import { FrontendBullMQJob } from '../../types/bullmq'
 import { QueueJobActionsMenu } from './QueueJobActionsMenu'
 import BoxDataGridWrapper from '../../themes/components/BoxDataGridWrapper'
 import { formatDateSafe } from 'utils/dates'
+import { logger } from 'utils/logger'
 
 interface BilboMDJobData {
   type: string
@@ -89,7 +90,7 @@ const QueueDetailsPage = () => {
       setDeleteTargetJobId(null)
       setDeleteTargetTitle(null)
     } catch (error) {
-      console.error('Failed to delete job:', error)
+      logger.error('Failed to delete job:', error)
       // optionally show error UI
     }
   }
@@ -135,8 +136,6 @@ const QueueDetailsPage = () => {
   if (!matchedQueue) {
     return <Alert severity='warning'>Queue not found.</Alert>
   }
-
-  console.log('Jobs:', jobs)
 
   const typedJobs: FrontendBullMQJob<BilboMDJobData>[] = (jobs?.jobs ??
     []) as unknown as FrontendBullMQJob<BilboMDJobData>[]

--- a/apps/ui/src/features/af2pae/DownloadAF2PAEfile.tsx
+++ b/apps/ui/src/features/af2pae/DownloadAF2PAEfile.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { logger } from 'utils/logger'
 import { Button } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import { Box } from '@mui/system'
@@ -36,7 +37,7 @@ const Download = ({ uuid }: DownloadProps) => {
         window.URL.revokeObjectURL(url)
       }
     } catch (error) {
-      console.error('Download const.inp error:', error)
+      logger.error('Download const.inp error:', error)
     } finally {
       const elapsed = Date.now() - start
       const delay = Math.max(0, 1000 - elapsed)

--- a/apps/ui/src/features/af2pae/PAEJiffy.tsx
+++ b/apps/ui/src/features/af2pae/PAEJiffy.tsx
@@ -1,3 +1,4 @@
+import { logger } from 'utils/logger'
 import {
   Typography,
   Paper,
@@ -127,7 +128,7 @@ const Alphafold2PAEJiffy = () => {
       setSubmittedValues(values)
       setFormInitialValues(values)
     } catch (error) {
-      console.error('Error submitting form:', error)
+      logger.error('Error submitting form:', error)
     }
   }
 
@@ -248,7 +249,7 @@ const Alphafold2PAEJiffy = () => {
           : (paeBuf as ArrayBuffer)
       return reshapeFloat32(buf, viz.length, viz.downsample ?? 1)
     } catch (e) {
-      console.error('Failed to parse pae.bin', e)
+      logger.error('Failed to parse pae.bin', e)
       return null
     }
   }, [vizOk, binOk, viz, paeBuf])

--- a/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
+++ b/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
@@ -41,6 +41,7 @@ import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
 import AFOpenMMPipelineSchematic from './AFOpenMMPipelineSchematic'
 import AFCharmmPipelineSchematic from './AFCharmmPipelineSchematic'
+import { logger } from 'utils/logger'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -536,7 +537,7 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
         ? addNewPublicJob(form).unwrap()
         : addNewAlphaFoldJob(form).unwrap())
     } catch (error) {
-      console.error('rejected', error)
+      logger.error('rejected', error)
       setSubmitError(
         (error as { data?: { message?: string } }).data?.message ||
           'An error occurred during submission.'

--- a/apps/ui/src/features/analysis/BilboMdFeedback.tsx
+++ b/apps/ui/src/features/analysis/BilboMdFeedback.tsx
@@ -22,8 +22,6 @@ const BilboMdFeedback = ({ feedback, publicId }: FeedbackProps) => {
 
   const actualFeedback = feedback || fetchedFeedback
 
-  // console.log('actualFeedback:', actualFeedback)
-
   if (isLoading) {
     return <CircularProgress />
   }
@@ -39,7 +37,6 @@ const BilboMdFeedback = ({ feedback, publicId }: FeedbackProps) => {
     actualFeedback.best_model_dat_file || actualFeedback.best_model || ''
 
   const getChipProps = (value: number) => {
-    // console.log('value:', value)
     if (value < 1.2) {
       return { sx: { backgroundColor: 'green' } }
     } else if (value >= 1.2 && value <= 2.0) {

--- a/apps/ui/src/features/auth/MagickLink.tsx
+++ b/apps/ui/src/features/auth/MagickLink.tsx
@@ -12,6 +12,7 @@ import Grid from '@mui/material/Grid'
 import Divider from '@mui/material/Divider'
 import { Link } from 'react-router'
 import useTitle from 'hooks/useTitle'
+import { logger } from 'utils/logger'
 import { axiosInstance } from 'app/api/axios'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query'
@@ -84,13 +85,9 @@ const MagickLink = () => {
           // The request was made and the server responded with a status code
           // that falls out of the range of 2xx
           // error message from backend available in data.message
-          //console.log(err.response)
           setError(err.response.data.message)
           setSuccess(null)
           setStatus(err)
-          // console.log(err.response.data.message)
-          // console.log(err.response.status)
-          // console.log(err.response.headers)
         }
       })
     if (response?.data) {
@@ -102,7 +99,6 @@ const MagickLink = () => {
   }
 
   const resendVerificationCode = async (email: string) => {
-    // console.log('resend code for:', email)
     await axiosInstance
       .post(
         VERIFICATION_CODE_URL,
@@ -112,12 +108,11 @@ const MagickLink = () => {
           withCredentials: true
         }
       )
-      .then((res) => {
-        console.log('done', res.status, res.data.message)
+      .then(() => {
         setVerified(true)
       })
       .catch((err) => {
-        console.log(err)
+        logger.error(err)
       })
   }
 

--- a/apps/ui/src/features/auth/OrcidConfirmation.tsx
+++ b/apps/ui/src/features/auth/OrcidConfirmation.tsx
@@ -12,6 +12,7 @@ import {
   useFinalizeOrcidMutation
 } from '../../slices/authApiSlice'
 import { userDisplayName } from 'utils/userDisplayName'
+import { logger } from 'utils/logger'
 
 interface ProfileRowProps {
   label: string
@@ -57,7 +58,7 @@ export default function OrcidConfirmation() {
       await finalizeOrcid({}).unwrap()
       window.location.href = '/welcome'
     } catch (err) {
-      console.error(err)
+      logger.error(err)
       window.location.href = '/auth/orcid-error?reason=finalize'
     }
   }

--- a/apps/ui/src/features/auth/PersistLogin.tsx
+++ b/apps/ui/src/features/auth/PersistLogin.tsx
@@ -5,6 +5,7 @@ import usePersist from '../../hooks/usePersist'
 import { useSelector } from 'react-redux'
 import { selectCurrentToken } from '../../slices/authSlice'
 import { Alert, Button, CircularProgress } from '@mui/material'
+import { logger } from 'utils/logger'
 import Grid from '@mui/material/Grid'
 
 const PersistLogin = () => {
@@ -22,15 +23,13 @@ const PersistLogin = () => {
         await refresh(undefined).unwrap()
         setTrueSuccess(true)
       } catch (err) {
-        console.error('Refresh failed:', err)
+        logger.error('Refresh failed:', err)
       }
     }
     if (persist && !token) {
       void verifyRefreshToken()
     }
   }, [persist, refresh, token])
-
-  // console.log('PersistLogin:', { token, persist })
 
   let content
 
@@ -91,12 +90,9 @@ const PersistLogin = () => {
     )
   } else if (isSuccess && trueSuccess) {
     //persist: yes, token: yes
-    // console.log('success')
     content = <Outlet />
   } else if (token && isUninitialized) {
     //persist: yes, token: yes
-    // console.log('token and uninitialized')
-    // console.log('isUninitialized:', isUninitialized)
     content = <Outlet />
   }
 

--- a/apps/ui/src/features/auth/Prefetch.tsx
+++ b/apps/ui/src/features/auth/Prefetch.tsx
@@ -8,7 +8,6 @@ import { Outlet } from 'react-router'
 
 const Prefetch = () => {
   useEffect(() => {
-    // console.log('subscribing')
     const store = setupStore()
     store.dispatch(
       configApiSlice.util.prefetch('getConfigs', 'configData', { force: true })

--- a/apps/ui/src/features/auth/Signup.tsx
+++ b/apps/ui/src/features/auth/Signup.tsx
@@ -18,6 +18,7 @@ import {
 import Grid from '@mui/material/Grid'
 import useTitle from 'hooks/useTitle'
 import { axiosInstance, isAxiosError } from 'app/api/axios'
+import { logger } from 'utils/logger'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
 import { Debug } from 'components/Debug'
 
@@ -51,7 +52,6 @@ const Signup = () => {
         headers: { 'Content-Type': 'application/json' },
         withCredentials: true
       })
-      // console.log('response: ', response)
       if (response.status === 201) {
         // successfully created a new user
         setError('')
@@ -63,7 +63,7 @@ const Signup = () => {
     } catch (error) {
       if (isAxiosError(error)) {
         // Access to config, request, and response
-        console.error('Axios Error: ', error)
+        logger.error('Axios Error: ', error)
         if (!error.response) {
           setError('No Server Response')
         } else if (error.response.status === 409) {
@@ -71,7 +71,7 @@ const Signup = () => {
         }
         setSubmitting(false)
       } else {
-        console.error(error)
+        logger.error(error)
       }
     }
   }

--- a/apps/ui/src/features/auth/VerifyEmail.tsx
+++ b/apps/ui/src/features/auth/VerifyEmail.tsx
@@ -6,13 +6,11 @@ import { useParams, Link } from 'react-router'
 import Button from '@mui/material/Button'
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 import useTitle from 'hooks/useTitle'
+import { logger } from 'utils/logger'
 
 const VerifyEmail = () => {
   useTitle('BilboMD: Verify Email')
   const { code } = useParams()
-  // const data = JSON.stringify({ code })
-  // console.log(data)
-
   const isMountedRef = useRef(false) // Create a ref to track the initial mount
   const [verificationStatus, setVerificationStatus] = useState<
     'loading' | 'success' | 'failure'
@@ -29,16 +27,13 @@ const VerifyEmail = () => {
             withCredentials: true
           }
         )
-        // console.log('res1:', response.data.message)
         if (response.data.message === 'Verified') {
-          // console.log('seems we should be verified')
           setVerificationStatus('success')
         } else {
-          // console.log('res2:', response.data.message)
           setVerificationStatus('failure')
         }
       } catch (error) {
-        console.error('auth error: ', error)
+        logger.error('auth error: ', error)
         setVerificationStatus('failure')
       }
     }

--- a/apps/ui/src/features/auth/Welcome.tsx
+++ b/apps/ui/src/features/auth/Welcome.tsx
@@ -27,7 +27,6 @@ type WelcomeProps = {
 }
 
 const Welcome: React.FC<WelcomeProps> = ({ mode }: WelcomeProps) => {
-  console.log(`Welcome mode: ${mode}`)
   const { username } = useAuth()
   const isAnonymous = mode === 'anonymous'
   useTitle(

--- a/apps/ui/src/features/autojob/NewAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/NewAutoJobForm.tsx
@@ -31,6 +31,7 @@ import PipelineSchematic from './PipelineSchematic'
 import { BilboMDAutoJobFormValues } from '../../types/autoJobForm'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
+import { logger } from 'utils/logger'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -127,7 +128,7 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
         ? addNewPublicJob(form).unwrap()
         : addNewJob(form).unwrap())
     } catch (error) {
-      console.error('rejected', error)
+      logger.error('rejected', error)
       setSubmitError(
         (error as { data?: { message?: string } }).data?.message ||
           'An error occurred during submission.'

--- a/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
@@ -35,6 +35,7 @@ import { useTheme } from '@mui/material/styles'
 import PipelineSchematic from './PipelineSchematic'
 import { BilboMDAutoJobFormValues } from '../../types/autoJobForm'
 import type { BilboMDAutoDTO } from '@bilbomd/bilbomd-types'
+import { logger } from 'utils/logger'
 
 const ResubmitAutoJobForm = () => {
   useTitle('BilboMD: Resubmit Auto Job')
@@ -164,7 +165,7 @@ const ResubmitAutoJobForm = () => {
       // Navigate to the new job page
       void navigate(`/dashboard/jobs/${newJob.id}`)
     } catch (error) {
-      console.error('rejected', error)
+      logger.error('rejected', error)
     }
   }
 

--- a/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
+++ b/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
@@ -62,8 +62,6 @@ const FoXSEnsembleCharts = ({
   maxYAxis,
   foxsData
 }: Props) => {
-  // console.log('combinedData:', combinedData)
-  // console.log('foxsData:', foxsData)
   // Initialize visibility state for each line
   const [visibility, setVisibility] = useState([
     false,
@@ -73,7 +71,6 @@ const FoXSEnsembleCharts = ({
   const handleCheckboxChange = (index: number) => {
     const newVisibility = visibility.slice()
     newVisibility[index] = !newVisibility[index]
-    // console.log('Updated visibility:', newVisibility)
     setVisibility(newVisibility)
   }
   return (

--- a/apps/ui/src/features/jobs/BilboMDNerscStep.tsx
+++ b/apps/ui/src/features/jobs/BilboMDNerscStep.tsx
@@ -20,8 +20,6 @@ const BilboMDNerscStep = ({
 }: BilboMDStepProps) => {
 
   const { friendlyName, tooltipMessage } = getStepDetails(stepName)
-  // console.log(stepName, stepStatus, stepMessage)
-  // console.log(friendlyName, tooltipMessage)
   return (
     <Grid
       key={stepName}

--- a/apps/ui/src/features/jobs/DeleteJob.tsx
+++ b/apps/ui/src/features/jobs/DeleteJob.tsx
@@ -18,7 +18,7 @@ interface DeleteJobProps {
 const DeleteJob = ({ id, title, hide, onClose }: DeleteJobProps) => {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [deleting, setDeleting] = useState(false)
-  const [deleteJob, { isSuccess, isError, error }] = useDeleteJobMutation()
+  const [deleteJob, { isSuccess }] = useDeleteJobMutation()
   const onClickDelete = async () => {
     setDeleting(true)
     await deleteJob({ id })
@@ -37,13 +37,9 @@ const DeleteJob = ({ id, title, hide, onClose }: DeleteJobProps) => {
 
   useEffect(() => {
     if (isSuccess) {
-      console.log('DeleteJob isSuccess:', isSuccess, 'error:', error)
       if (onClose) onClose()
     }
-    if (isError) {
-      console.log('DeleteJob isError:', isError, 'error:', error)
-    }
-  }, [isSuccess, isError, error, onClose])
+  }, [isSuccess, onClose])
 
   return (
     <>

--- a/apps/ui/src/features/jobs/FileSelect.tsx
+++ b/apps/ui/src/features/jobs/FileSelect.tsx
@@ -8,6 +8,7 @@ import {
   Alert
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import { logger } from 'utils/logger'
 
 interface FileSelectProps extends FormControlProps {
   value: File
@@ -54,7 +55,7 @@ const FileSelect = (props: FileSelectProps) => {
       }
 
       reader.onerror = () => {
-        console.error('Error reading file:', reader.error)
+        logger.error('Error reading file:', reader.error)
       }
 
       reader.readAsDataURL(file)

--- a/apps/ui/src/features/jobs/FoXSAnalysis.tsx
+++ b/apps/ui/src/features/jobs/FoXSAnalysis.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { logger } from 'utils/logger'
 import FoXSChart from 'features/scoperjob/FoXSChart'
 import { Alert, AlertTitle } from '@mui/material'
 import Grid from '@mui/material/Grid'
@@ -80,7 +81,7 @@ const prepData = (
 
 const combineFoxsData = (foxsDataArray: FoxsData[]): CombinedFoxsData[] => {
   if (!Array.isArray(foxsDataArray) || foxsDataArray.length < 2) {
-    console.warn(
+    logger.warn(
       'FoXSAnalysis: Not enough data to process ensemble comparison.'
     )
     return []
@@ -88,7 +89,7 @@ const combineFoxsData = (foxsDataArray: FoxsData[]): CombinedFoxsData[] => {
 
   const base = foxsDataArray[0]
   if (!base || !Array.isArray(base.data) || base.data.length === 0) {
-    console.warn('FoXSAnalysis: Base FoXS dataset is empty or invalid.')
+    logger.warn('FoXSAnalysis: Base FoXS dataset is empty or invalid.')
     return []
   }
 

--- a/apps/ui/src/features/jobs/JobError.tsx
+++ b/apps/ui/src/features/jobs/JobError.tsx
@@ -1,6 +1,7 @@
 import { axiosInstance, AxiosResponse } from 'app/api/axios'
 import type { BilboMDJobDTO } from '@bilbomd/bilbomd-types'
 import { useSelector } from 'react-redux'
+import { logger } from 'utils/logger'
 import { selectCurrentToken } from 'slices/authSlice'
 import { useEffect, useState, useCallback } from 'react'
 import { Box } from '@mui/system'
@@ -29,7 +30,7 @@ const JobError = ({ job }: JobProps) => {
         )
         setLogContent(response.data.logContent)
       } catch (error) {
-        console.error('Error fetching log file:', error)
+        logger.error('Error fetching log file:', error)
       }
     },
     [token]

--- a/apps/ui/src/features/jobs/Jobs.tsx
+++ b/apps/ui/src/features/jobs/Jobs.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useState } from 'react'
 import { useSearchParams } from 'react-router'
+import { logger } from 'utils/logger'
 import {
   DataGrid,
   GridColDef,
@@ -95,7 +96,7 @@ const getRunTimeInHours = (
 
   // Validate that the time difference makes sense
   if (diffMs < 0) {
-    console.warn('Invalid NERSC runtime: end time before start time', {
+    logger.warn('Invalid NERSC runtime: end time before start time', {
       jobid: nersc.jobid,
       time_started: nersc.time_started,
       time_completed: nersc.time_completed,
@@ -135,7 +136,7 @@ const getHoursInQueue = (nersc: INerscInfo | undefined, jobStatus?: string) => {
     end = new Date()
   } else if (jobStatus === 'Running' || nersc.state === 'RUNNING') {
     // Job is running but no real start time recorded - this shouldn't happen
-    console.warn('Job is running but no valid NERSC start time recorded', {
+    logger.warn('Job is running but no valid NERSC start time recorded', {
       jobid: nersc.jobid,
       status: jobStatus,
       nersc_state: nersc.state,
@@ -155,7 +156,7 @@ const getHoursInQueue = (nersc: INerscInfo | undefined, jobStatus?: string) => {
   // Debug logging for negative times (should be rare now)
   if (diffMs < 0) {
     const now = new Date()
-    console.warn('Invalid NERSC queue time: negative duration detected', {
+    logger.warn('Invalid NERSC queue time: negative duration detected', {
       jobid: nersc.jobid,
       jobStatus,
       nersc_state: nersc.state,
@@ -321,7 +322,7 @@ const Jobs = () => {
       await deleteJob({ id: deleteTargetJobId }).unwrap()
       enqueueSnackbar('Job deletion queued.', { variant: 'success' })
     } catch (err) {
-      console.error('Failed to delete job:', err)
+      logger.error('Failed to delete job:', err)
       enqueueSnackbar('Failed to delete job. Please try again.', {
         variant: 'error'
       })
@@ -424,7 +425,7 @@ const Jobs = () => {
         link.parentNode?.removeChild(link)
       }
     } catch (err) {
-      console.error('Download failed:', err)
+      logger.error('Download failed:', err)
       enqueueSnackbar('Failed to download results. Please try again.', {
         variant: 'error'
       })

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useState } from 'react'
+import { logger } from 'utils/logger'
 import {
   Box,
   Button,
@@ -161,7 +162,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
         ? addNewPublicJob(form).unwrap()
         : addNewJob(form).unwrap())
     } catch (error) {
-      console.error('rejected', error)
+      logger.error('rejected', error)
       setSubmitError(
         (error as { data?: { message?: string } }).data?.message ||
           'An error occurred during submission.'

--- a/apps/ui/src/features/jobs/ResubmitJobForm.tsx
+++ b/apps/ui/src/features/jobs/ResubmitJobForm.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useState } from 'react'
+import { logger } from 'utils/logger'
 import {
   Box,
   Button,
@@ -125,8 +126,6 @@ const ResubmitJobForm = () => {
   const selectedMode: 'pdb' | 'crd_psf' =
     job?.mongo.jobType === 'crd' ? 'crd_psf' : 'pdb'
 
-  // console.log('job', job)
-
   let jobMongo: BilboMDCRDDTO | BilboMDPDBDTO
   if (job.mongo.jobType === 'crd') {
     jobMongo = job.mongo as BilboMDCRDDTO
@@ -223,7 +222,7 @@ const ResubmitJobForm = () => {
       // Navigate to the new job page
       void navigate(`/dashboard/jobs/${newJob.id}`)
     } catch (error) {
-      console.error('rejected', error)
+      logger.error('rejected', error)
     }
   }
 
@@ -643,7 +642,7 @@ const ResubmitJobForm = () => {
                                   void setFieldValue('rg_min', rg_min)
                                   void setFieldValue('rg_max', rg_max)
                                 } catch (error) {
-                                  console.error('Error:', error)
+                                  logger.error('Error:', error)
                                   void setFieldValue('rg_min', '')
                                   void setFieldValue('rg_max', '')
                                 }

--- a/apps/ui/src/features/jobs/SingleJobPage.tsx
+++ b/apps/ui/src/features/jobs/SingleJobPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, lazy, Suspense } from 'react'
 import { useParams, useLocation, useNavigate, Link } from 'react-router'
+import { logger } from 'utils/logger'
 import useTitle from 'hooks/useTitle'
 import {
   Button,
@@ -81,13 +82,12 @@ const SingleJobPage = () => {
   }
 
   const handleDeleteJob = async () => {
-    // console.log('Deleting job with ID:', id)
     if (!id) return
     try {
       await deleteJob({ id })
       void navigate('/dashboard/jobs')
     } catch (err) {
-      console.error('Failed to delete the job:', err)
+      logger.error('Failed to delete the job:', err)
     }
   }
 
@@ -138,11 +138,6 @@ const SingleJobPage = () => {
     pollingInterval: 15000,
     skipPollingIfUnfocused: true
   })
-
-  // Debug logging
-  // console.log('moviesData:', moviesData)
-  // console.log('moviesError:', moviesError)
-  // console.log('moviesLoading:', moviesLoading)
 
   const getProgressValue = () => {
     if (!job) return 0
@@ -218,7 +213,7 @@ const SingleJobPage = () => {
         )
       }
     } catch (error) {
-      console.error('Download results error:', error)
+      logger.error('Download results error:', error)
       setDownloadError(
         'Download failed. The results archive may be unavailable. Please try again or contact support.'
       )
@@ -229,8 +224,6 @@ const SingleJobPage = () => {
     (job?.mongo.status as JobStatusEnum) || 'Pending',
     theme
   )
-
-  // console.log('job', job)
 
   const jobTypeRouteSegment = job
     ? jobTypeToRoute[job.mongo.jobType] || 'classic'

--- a/apps/ui/src/features/molstar/Viewer.tsx
+++ b/apps/ui/src/features/molstar/Viewer.tsx
@@ -25,6 +25,7 @@ import { PluginBehaviors } from 'molstar/lib/mol-plugin/behavior'
 import { renderReact18 } from 'molstar/lib/mol-plugin-ui/react18'
 import { PluginUIContext } from 'molstar/lib/mol-plugin-ui/context'
 
+import { logger } from 'utils/logger'
 import { ViewportComponent } from './Viewport'
 import EnsembleTogglePanel from './EnsembleTogglePanel'
 import {
@@ -162,7 +163,7 @@ const MolstarViewer = ({
         case 'multi':
           return ''
         default:
-          console.warn(`Unknown job type '${jobType}', defaulting to 'classic'`)
+          logger.warn(`Unknown job type '${jobType}', defaulting to 'classic'`)
           return 'classic'
       }
     }
@@ -220,7 +221,7 @@ const MolstarViewer = ({
       })
       return response.data
     } catch (error) {
-      console.error('Error fetching PDB data:', error)
+      logger.error('Error fetching PDB data:', error)
       return null
     }
   }
@@ -476,7 +477,7 @@ const MolstarViewer = ({
 
       setIsDomainColor(nextMode)
     } catch (error) {
-      console.error('Failed to apply domain color preset:', error)
+      logger.error('Failed to apply domain color preset:', error)
     }
   }
 

--- a/apps/ui/src/features/multimd/MultiMDJobDBDetails.tsx
+++ b/apps/ui/src/features/multimd/MultiMDJobDBDetails.tsx
@@ -26,8 +26,6 @@ type MongoDBProperty = {
 }
 
 const MultiMDJobDBDetails: React.FC<JobDBDetailsProps> = ({ job }) => {
-  // console.log('MultiMDJobDBDetails: job:', job)
-
   const properties = [
     { label: 'Pipeline', value: 'BilboMD Multi' },
 

--- a/apps/ui/src/features/multimd/NewMultiMDJobForm.tsx
+++ b/apps/ui/src/features/multimd/NewMultiMDJobForm.tsx
@@ -32,6 +32,7 @@ import { Formik, Form, Field } from 'formik'
 import { Debug } from 'components/Debug'
 import useAuth from 'hooks/useAuth'
 import { formatDateSafe } from 'utils/dates'
+import { logger } from 'utils/logger'
 
 interface SubmitValues {
   title: string
@@ -101,14 +102,14 @@ const NewMultiMDJobForm: React.FC = () => {
     try {
       const newJob = await addNewJob(form).unwrap()
       setStatus(null)
-      console.log('Job created successfully:', newJob)
+      logger.debug('Job created successfully:', newJob)
     } catch (error: unknown) {
       if (isApiError(error)) {
         // If the error is from the API, extract the message
         setStatus(error.data?.message || 'An unexpected error occurred.')
       } else {
         // Generic fallback for unexpected errors
-        console.error('Unexpected error:', error)
+        logger.error('Unexpected error:', error)
         setStatus('An unexpected error occurred.')
       }
     }

--- a/apps/ui/src/features/nersc/NerscStatus.tsx
+++ b/apps/ui/src/features/nersc/NerscStatus.tsx
@@ -19,7 +19,6 @@ const NerscStatusList = () => {
     // error: outagesError,
     // isLoading: outagesIsLoading
   } = useGetNerscOutagesQuery()
-  // console.log('outages:', outages)
   const {
     data: config,
     error: configError,

--- a/apps/ui/src/features/nersc/NerscStatusChecker.tsx
+++ b/apps/ui/src/features/nersc/NerscStatusChecker.tsx
@@ -38,7 +38,6 @@ const NerscStatusChecker: React.FC<NerscStatusCheckerProps> = ({
   const systemStatus = nerscStatIsSuccess
     ? nerscStat.find((system) => system.name === systemName)
     : null
-  // console.log('systemStatus:', systemStatus)
   // Determine if the system is unavailable
   const isUnavailable = systemStatus?.status === 'unavailable'
 

--- a/apps/ui/src/features/nersc/NerscStatusChip.tsx
+++ b/apps/ui/src/features/nersc/NerscStatusChip.tsx
@@ -14,7 +14,6 @@ interface NerscStatusChipProps {
 
 const NerscStatusChip: React.FC<NerscStatusChipProps> = ({ system }) => {
   const color = system.status === 'active' ? 'success' : 'warning'
-  // console.log(system.notes[0])
   let toolTipMessage = 'OK'
   if (system.status) {
     toolTipMessage = system.status

--- a/apps/ui/src/features/nersc/ProjectHours.tsx
+++ b/apps/ui/src/features/nersc/ProjectHours.tsx
@@ -19,11 +19,9 @@ const ProjectHours = ({ projectCode }: { projectCode: string }) => {
   let content: ContentType
   if (isLoading) content = <CircularProgress />
   if (error) {
-    console.log('err:', error)
     content = <Alert>Error loading NERSC Status.{error.toString()}</Alert>
   }
   if (!project) return <div>No data available</div>
-  // console.log('project:', project)
   if (isSuccess) {
     // Calculate percentages for CPU and GPU usage
     // const cpuUsagePercent =

--- a/apps/ui/src/features/nersc/SystemStatuses.tsx
+++ b/apps/ui/src/features/nersc/SystemStatuses.tsx
@@ -20,7 +20,6 @@ const NerscSystemStatuses = () => {
   if (isLoading) content = <CircularProgress />
 
   if (error) {
-    console.log('err:', error)
     content = (
       <Alert>
         <AlertTitle>Error loading NERSC Status.</AlertTitle>
@@ -37,7 +36,6 @@ const NerscSystemStatuses = () => {
     'container_runtimes'
   ]
   if (isSuccess) {
-    console.log('nerscStatuses:', nerscStatuses)
     content = (
       <Box>
         <Grid sx={{ mx: 1, display: 'flex', alignItems: 'center' }}>

--- a/apps/ui/src/features/openfoldjob/NewOpenFoldJobForm.tsx
+++ b/apps/ui/src/features/openfoldjob/NewOpenFoldJobForm.tsx
@@ -42,6 +42,7 @@ import { useTheme } from '@mui/material/styles'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
 import OF3OpenMMPipelineSchematic from './OF3OpenMMPipelineSchematic'
+import { logger } from 'utils/logger'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -512,7 +513,7 @@ const NewOpenFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
         ? addNewPublicJob(form).unwrap()
         : addNewOpenFoldJob(form).unwrap())
     } catch (error) {
-      console.error('rejected', error)
+      logger.error('rejected', error)
       setSubmitError(
         (error as { data?: { message?: string } }).data?.message ||
           'An error occurred during submission.'

--- a/apps/ui/src/features/public/PublicDownloadResultsSection.tsx
+++ b/apps/ui/src/features/public/PublicDownloadResultsSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { logger } from 'utils/logger'
 import { Alert, Button, Grid, Typography } from '@mui/material'
 import HeaderBox from 'components/HeaderBox'
 import Item from 'themes/components/Item'
@@ -41,7 +42,7 @@ const PublicDownloadResultsSection = ({ job }: { job: PublicJobStatus }) => {
         )
       }
     } catch (error) {
-      console.error('Download results error:', error)
+      logger.error('Download results error:', error)
       setDownloadError(
         'Download failed. The results archive may be unavailable. Please try again or contact support.'
       )

--- a/apps/ui/src/features/public/PublicJobPage.tsx
+++ b/apps/ui/src/features/public/PublicJobPage.tsx
@@ -1,5 +1,6 @@
 import { useParams, Link } from 'react-router'
 import { useState, useEffect, lazy, Suspense } from 'react'
+import { logger } from 'utils/logger'
 import {
   Alert,
   AlertTitle,
@@ -69,10 +70,10 @@ const handleDownload = async (publicId: string) => {
       link.click()
       link.parentNode?.removeChild(link)
     } else {
-      console.error('No data to download')
+      logger.error('No data to download')
     }
   } catch (error) {
-    console.error('Download results error:', error)
+    logger.error('Download results error:', error)
   }
 }
 
@@ -82,13 +83,11 @@ const PublicJobPage = () => {
   const { publicId } = useParams<{ publicId: string }>()
   const [shouldPoll, setShouldPoll] = useState(true)
   const [currentTime, setCurrentTime] = useState<Date>(new Date())
-  // console.log('PublicJobPage publicId:', publicId)
 
   const { data, isLoading, isError } = useGetPublicJobByIdQuery(publicId!, {
     skip: !publicId,
     pollingInterval: shouldPoll ? 10000 : 0
   })
-  // console.log('PublicJobPage data:', data)
 
   useEffect(() => {
     if (data?.status) {

--- a/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
+++ b/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
@@ -39,6 +39,7 @@ import {
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
 import SANSPipelineSchematic from './SANSPipelineSchematic'
+import { logger } from 'utils/logger'
 
 type NewJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -155,7 +156,7 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
         ? addNewPublicSANSJob(form).unwrap()
         : addNewSANSJob(form).unwrap())
     } catch (error) {
-      console.error('rejected', error)
+      logger.error('rejected', error)
     }
   }
 

--- a/apps/ui/src/features/scoperjob/BilboMDScoperTable.tsx
+++ b/apps/ui/src/features/scoperjob/BilboMDScoperTable.tsx
@@ -16,7 +16,6 @@ interface BilboMDScoperTableProps {
 }
 
 const BilboMDScoperTable = ({ results }: BilboMDScoperTableProps) => {
-  console.log('BilboMDScoperTable: results:', results)
   const rows = [
     {
       key: 'KGS Number of Conformations to Generate',

--- a/apps/ui/src/features/scoperjob/NewScoperJobForm.tsx
+++ b/apps/ui/src/features/scoperjob/NewScoperJobForm.tsx
@@ -27,6 +27,7 @@ import HeaderBox from 'components/HeaderBox'
 import useTitle from 'hooks/useTitle'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
+import { logger } from 'utils/logger'
 
 type NewScoperJobFormProps = {
   mode?: 'authenticated' | 'anonymous'
@@ -105,7 +106,7 @@ const NewScoperJobForm = ({
           : await addNewScoperJob(form).unwrap()
       setStatus(newJob)
     } catch (error) {
-      console.error('rejected', error)
+      logger.error('rejected', error)
       setSubmitError(
         (error as { data?: { message?: string } }).data?.message ||
           'An error occurred during submission.'

--- a/apps/ui/src/features/users/ApiTokenManagement.tsx
+++ b/apps/ui/src/features/users/ApiTokenManagement.tsx
@@ -23,6 +23,7 @@ import { DataGrid, GridColDef } from '@mui/x-data-grid'
 import { formatDistanceToNowStrict } from 'date-fns'
 import { parseDateSafe, formatDateSafe } from 'utils/dates'
 import { useSnackbar } from 'notistack'
+import { logger } from 'utils/logger'
 
 const APITokenManager = () => {
   const { username } = useAuth()
@@ -127,7 +128,7 @@ const APITokenManager = () => {
       enqueueSnackbar(`${label} Token created.`, { variant: 'default' })
       void refetch()
     } catch (err) {
-      console.error('Failed to create token:', err)
+      logger.error('Failed to create token:', err)
       enqueueSnackbar('Failed to create token.', { variant: 'error' })
     }
   }
@@ -138,7 +139,7 @@ const APITokenManager = () => {
       enqueueSnackbar('Token deleted.', { variant: 'default' })
       void refetch()
     } catch (err) {
-      console.error('Failed to delete token:', err)
+      logger.error('Failed to delete token:', err)
       enqueueSnackbar('Failed to delete token.', { variant: 'error' })
     }
   }

--- a/apps/ui/src/features/users/EditUserForm.tsx
+++ b/apps/ui/src/features/users/EditUserForm.tsx
@@ -116,13 +116,11 @@ const EditUserForm = ({ user }: EditUserFormProps) => {
 
   useEffect(() => {
     if (updateResult.isSuccess || deleteResult.isSuccess) {
-      console.log('about to navigate back to /users')
       void navigate('../users')
     }
   }, [updateResult.isSuccess, deleteResult.isSuccess, navigate])
 
   const myOnSubmit = async (values: EditUserFormValues) => {
-    // console.log(values)
     await updateUser({
       id: user.id,
       roles: values.roles,

--- a/apps/ui/src/features/users/SafetyZone.tsx
+++ b/apps/ui/src/features/users/SafetyZone.tsx
@@ -2,7 +2,6 @@ import { Typography, Alert, Button } from '@mui/material'
 
 const SafetyZone = () => {
   const handleContactSupport = () => {
-    console.log('Contacting support for account deletion')
     window.location.href = 'mailto:bilbomd@lbl.gov'
   }
 

--- a/apps/ui/src/features/users/UserAccount.tsx
+++ b/apps/ui/src/features/users/UserAccount.tsx
@@ -105,7 +105,6 @@ const UserAccount: React.FC = () => {
 
   const handleUpdateEmail = async (values: { newEmail: string }) => {
     try {
-      // console.log('Updating email to:', values.newEmail)
       await updateEmail({
         username,
         currentEmail: email,
@@ -129,8 +128,6 @@ const UserAccount: React.FC = () => {
   }
 
   const handleVerifyOtp = async (values: { otp: string }) => {
-    // console.log('Verifying OTP:', values.otp)
-
     try {
       await verifyOtp({
         username,
@@ -185,7 +182,6 @@ const UserAccount: React.FC = () => {
     }
 
     try {
-      // console.log('Deleting account:', username)
       await deleteUserByUserName(username).unwrap()
       showMessageDialog('Account deleted successfully')
       setTimeout(handleAutomaticLogout, 3000)

--- a/apps/ui/src/features/users/UsersList.tsx
+++ b/apps/ui/src/features/users/UsersList.tsx
@@ -30,7 +30,6 @@ const UsersList = () => {
   }
 
   if (isError) {
-    // console.error('Error fetching users:', error)
     content = (
       <Alert severity='error' variant='outlined'>
         An error occurred while fetching users.
@@ -39,7 +38,6 @@ const UsersList = () => {
   }
 
   if (isSuccess && users.length > 0) {
-    // console.log('Users:', users)
     const columns: GridColDef[] = [
       { field: 'username', headerName: 'Username' },
       { field: 'email', headerName: 'Email', width: 180 },
@@ -86,7 +84,6 @@ const UsersList = () => {
   }
 
   if (isSuccess && users.length === 0) {
-    // console.warn('Unexpected data format for users:', users)
     content = (
       <Typography color='error'>
         No users available or data format is invalid.

--- a/apps/ui/src/schemas/Alphafold2PAEValidationSchema.ts
+++ b/apps/ui/src/schemas/Alphafold2PAEValidationSchema.ts
@@ -20,7 +20,6 @@ export const af2paeJiffySchema = object().shape({
       async (file) => {
         if (file) {
           const spaceCheck = await noSpaces(file as File)
-          // console.log(spaceCheck)
           return spaceCheck
         }
         return false
@@ -63,10 +62,8 @@ export const af2paeJiffySchema = object().shape({
     })
     .test('file-size-check', 'Max file size is 140MB', (file) => {
       if (file && (file as File).size <= 140000000) {
-        // console.log(file.size)
         return true
       }
-      // console.log(file.size)
       return false
     })
     .test('file-type-check', 'Only accepts a JSON file', (file) => {
@@ -74,7 +71,6 @@ export const af2paeJiffySchema = object().shape({
         file &&
         (file as File).name.split('.').pop()?.toUpperCase() === 'JSON'
       ) {
-        // console.log(file.name.split('.').pop())
         return true
       }
       return false
@@ -85,7 +81,6 @@ export const af2paeJiffySchema = object().shape({
       async (file) => {
         if (file) {
           const spaceCheck = await noSpaces(file as File)
-          // console.log(spaceCheck)
           return spaceCheck
         }
         return false

--- a/apps/ui/src/schemas/PDBFileSchema.ts
+++ b/apps/ui/src/schemas/PDBFileSchema.ts
@@ -8,15 +8,12 @@ const pdbFileSchema = mixed()
   })
   .test('file-size-check', 'Max file size is 2MB', (file) => {
     if (file && (file as File).size <= 2000000) {
-      // console.log(file.size)
       return true
     }
-    // console.log(file.size)
     return false
   })
   .test('file-type-check', 'Only accepts a *.pdb file.', (file) => {
     if (file && (file as File).name.split('.').pop()?.toUpperCase() === 'PDB') {
-      // console.log(file.name.split('.').pop())
       return true
     }
     return false
@@ -27,7 +24,6 @@ const pdbFileSchema = mixed()
     async (file) => {
       if (file) {
         const spaceCheck = await noSpaces(file as File)
-        // console.log(spaceCheck)
         return spaceCheck
       }
       return false

--- a/apps/ui/src/schemas/ScoperValidationSchema.ts
+++ b/apps/ui/src/schemas/ScoperValidationSchema.ts
@@ -107,7 +107,6 @@ export const bilbomdScoperJobSchema = object().shape({
       async (file) => {
         if (file) {
           const spaceCheck = await noSpaces(file as File)
-          // console.log(spaceCheck)
           return spaceCheck
         }
         return false

--- a/apps/ui/src/schemas/ValidationFunctions.ts
+++ b/apps/ui/src/schemas/ValidationFunctions.ts
@@ -53,9 +53,7 @@ const fromCharmmGui = (file: File): Promise<boolean> => {
     reader.onloadend = () => {
       const lines = (reader.result as string).split(/[\r\n]+/g)
       for (let line = 0; line < 5; line++) {
-        // console.log(charmmGui.test(lines[line]), 'line', line, lines[line])
         if (charmmGui.test(lines[line]!)) {
-          // console.log(lines[line])
           resolve(true)
         }
       }
@@ -98,7 +96,6 @@ const isCRD = (file: File): Promise<boolean> => {
 
 const isPsfData = (file: File): Promise<boolean> => {
   return new Promise((resolve) => {
-    // console.log(`validate if ${file.name} isPsfData`)
     const reader = new FileReader()
     reader.readAsText(file)
     reader.onloadend = () => {
@@ -107,13 +104,11 @@ const isPsfData = (file: File): Promise<boolean> => {
         /^\s*\d+\s+[A-Z]{4}\s+\d+\s+[A-Z]{3,}\s+[a-zA-Z0-9_']+\s+[a-zA-Z0-9_']+\s+-?\d+\.\d+(?:[eE][+-]?\d+)?\s+\d+\.\d+(?:[eE][+-]?\d+)?\s+\d+/
 
       if (!lines[0]?.includes('PSF')) {
-        // console.log('first line does not contain PSF')
         resolve(false)
         return
       }
 
       if (!lines.some((line) => line.trim().endsWith('!NTITLE'))) {
-        // console.log('NTITLE missing')
         resolve(false)
         return
       }
@@ -122,20 +117,17 @@ const isPsfData = (file: File): Promise<boolean> => {
         /\d+\s+!NATOM/.test(line)
       )
       if (natomLineIndex === -1) {
-        // console.log('!NATOM line not found')
         resolve(false)
         return
       }
 
       const natomResult = lines[natomLineIndex]!.match(/(\d+)\s+!NATOM/)
       if (!natomResult) {
-        // console.log('Failed to capture number of atoms')
         resolve(false)
         return
       }
 
       const natom = parseInt(natomResult[1]!, 10)
-      // console.log('natom expected = ', natom)
       if (isNaN(natom)) {
         resolve(false)
         return
@@ -146,16 +138,13 @@ const isPsfData = (file: File): Promise<boolean> => {
         natomLineIndex + 1,
         natomLineIndex + 1 + natom
       )
-      // console.log('num atom lines = ', atomLines.length)
       if (atomLines.length !== natom) {
-        // console.log('Incorrect number of atom lines')
         resolve(false)
         return
       }
 
       for (const line of atomLines) {
         if (!atomRegex.test(line)) {
-          // console.log('Failed atom regex:', line)
           resolve(false)
           return
         }
@@ -165,7 +154,6 @@ const isPsfData = (file: File): Promise<boolean> => {
     }
 
     reader.onerror = () => {
-      // console.log('Error reading the file')
       resolve(false)
     }
   })
@@ -175,7 +163,6 @@ const noSpaces = (file: File): Promise<boolean> => {
   const spaces = /\s/
   return new Promise((resolve) => {
     if (spaces.test(file.name)) {
-      // console.log('false', file.name)
       resolve(false)
     }
     resolve(true)
@@ -204,7 +191,6 @@ const noSpaces = (file: File): Promise<boolean> => {
 const isSaxsData = (
   file: File
 ): Promise<{ valid: boolean; message?: string }> => {
-  // console.log(`validate if ${file.name} isSaxsData`)
   const sciNotation = /-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?/g
 
   return new Promise((resolve) => {
@@ -460,13 +446,11 @@ const isValidConstInpFile = (
       }
 
       // Check 'define' lines for 'segid' followed by the correct format
-      // console.log('isValidConstInpFile mode: ', mode)
       if (mode === 'pdb') {
         const segidRegex = /segid\s+((PRO|DNA|RNA|CAR|CAL)[A-Z])\b/
         const validSegid = lines
           .filter((line) => line.startsWith('define'))
           .every((line) => segidRegex.test(line))
-        // console.log(file.name, ' valid segid is ', validSegid)
         if (!validSegid) {
           resolve('segid must be: PRO[A-Z], DNA[A-Z], RNA[A-Z], etc.')
           return
@@ -476,7 +460,6 @@ const isValidConstInpFile = (
         const validSegid = lines
           .filter((line) => line.startsWith('define'))
           .every((line) => segidRegex.test(line))
-        // console.log(file.name, ' valid segid is ', validSegid)
         if (!validSegid) {
           resolve('segid must contain 4 uppercase letters [A-Z]')
           return

--- a/apps/ui/src/schemas/fieldTests/fieldTests.ts
+++ b/apps/ui/src/schemas/fieldTests/fieldTests.ts
@@ -160,8 +160,7 @@ export const jsonFileCheck = () =>
         try {
           JSON.parse(content)
           return true
-        } catch (error) {
-          console.log('Invalid JSON content:', error)
+        } catch {
           return false
         }
       }

--- a/apps/ui/src/slices/authApiSlice.ts
+++ b/apps/ui/src/slices/authApiSlice.ts
@@ -1,5 +1,6 @@
 import { apiSlice } from 'app/api/apiSlice'
 import { logOut, setCredentials } from 'slices/authSlice'
+import { logger } from 'utils/logger'
 
 interface LoginCredentials {
   email?: string
@@ -37,15 +38,14 @@ export const authApiSlice = apiSlice.injectEndpoints({
       }),
       async onQueryStarted(_arg, { dispatch, queryFulfilled }) {
         try {
-          const { data } = await queryFulfilled
+          await queryFulfilled
           dispatch(logOut())
           // Dave Gray suggests this timeout to give components time to unmount before resetting state
           setTimeout(() => {
             dispatch(apiSlice.util.resetApiState())
           }, 1000)
-          console.log('Logout succeeded with response:', data)
         } catch (error) {
-          console.log(error)
+          logger.error(error)
         }
       }
     }),
@@ -57,11 +57,10 @@ export const authApiSlice = apiSlice.injectEndpoints({
       async onQueryStarted(_arg, { dispatch, queryFulfilled }) {
         try {
           const { data } = await queryFulfilled
-          //console.log(data)
           const { accessToken } = data
           dispatch(setCredentials({ accessToken }))
         } catch (error) {
-          console.log(error)
+          logger.error(error)
         }
       }
     }),

--- a/apps/ui/src/slices/jobsApiSlice.ts
+++ b/apps/ui/src/slices/jobsApiSlice.ts
@@ -8,6 +8,7 @@ import { apiSlice } from '../app/api/apiSlice'
 import type { BilboMDJobDTO, JobAssetsDTO } from '@bilbomd/bilbomd-types'
 import { FileCheckResult } from '../types/jobCheckResults'
 import { RootState } from '../app/store'
+import { logger } from 'utils/logger'
 
 interface FoxsData {
   [key: string]: unknown
@@ -132,7 +133,7 @@ export const jobsApiSlice = apiSlice.injectEndpoints({
         try {
           await queryFulfilled
         } catch (error) {
-          console.error('Error occurred during job deletion:', error)
+          logger.error('Error occurred during job deletion:', error)
           patchResult.undo()
         }
       },

--- a/apps/ui/src/themes/ThemeContext.ts
+++ b/apps/ui/src/themes/ThemeContext.ts
@@ -10,9 +10,7 @@ type ThemeContextType = {
 // Create the context
 export const ThemeContext = createContext<ThemeContextType>({
   mode: 'light',
-  toggleColorMode: () => {
-    console.log('toggleColorMode not initialized')
-  },
+  toggleColorMode: () => {},
   theme: createTheme()
 })
 

--- a/apps/ui/src/themes/overrides/BackGround.ts
+++ b/apps/ui/src/themes/overrides/BackGround.ts
@@ -2,7 +2,6 @@ import { blueGrey } from '@mui/material/colors'
 import { Theme } from '@mui/material/styles'
 
 export default function BackGround(theme: Theme) {
-  // console.log('theme', theme)
   return {
     MuiCssBaseline: {
       styleOverrides: {

--- a/apps/ui/src/themes/overrides/ListItemIcon.ts
+++ b/apps/ui/src/themes/overrides/ListItemIcon.ts
@@ -2,7 +2,6 @@ import { blueGrey } from '@mui/material/colors'
 import { Theme } from '@mui/material/styles'
 
 export default function ListItemIcon(theme: Theme) {
-  // console.log('ListItemIcon', theme.palette.mode)
   return {
     MuiListItemIcon: {
       styleOverrides: {

--- a/apps/ui/src/utils/logger.ts
+++ b/apps/ui/src/utils/logger.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-console */
+// Lightweight logger for the UI.
+//
+// `log`/`debug`/`info` are no-ops in production builds so stray diagnostics
+// don't ship to the browser console. `warn`/`error` always pass through to the
+// console (dynamically, so test spies on `console.error`/`console.warn` still
+// observe them) and provide a single seam for routing to a reporting service
+// later.
+const isDev = import.meta.env.DEV
+
+export const logger = {
+  log: (...args: unknown[]) => {
+    if (isDev) console.log(...args)
+  },
+  debug: (...args: unknown[]) => {
+    if (isDev) console.debug(...args)
+  },
+  info: (...args: unknown[]) => {
+    if (isDev) console.info(...args)
+  },
+  warn: (...args: unknown[]) => {
+    console.warn(...args)
+  },
+  error: (...args: unknown[]) => {
+    console.error(...args)
+  }
+}


### PR DESCRIPTION
Closes #851.

## Summary

The UI shipped ~143 unguarded `console.*` calls to the production browser console (61 active + 82 commented-out) across ~58 files. This PR cleans them up and locks in the result with an ESLint rule. **UI-only** — backend/worker already use proper loggers; `apps/scoper` (9 calls) is left as a follow-up per the issue.

## Changes

- **New `apps/ui/src/utils/logger.ts`** — a small logger abstraction. `log`/`debug`/`info` are no-ops in production builds (gated on `import.meta.env.DEV`); `warn`/`error` always pass through to `console` (dynamically, so test spies on `console.error`/`console.warn` still observe them).
- **Replaced active calls** — `console.error`/`console.warn` → `logger.error`/`logger.warn`; debugging `console.log` deleted (or converted to `logger.debug`/`logger.error` where deletion would leave an empty block). Imports use the bare alias `import { logger } from 'utils/logger'`.
- **Deleted ~82 commented-out `console.*` lines** as dead code.
- **Added `no-console: 'error'`** to the `src/**` ESLint config, with a test-file override (`__tests__`/`*.test`/`*.spec`) and a file-level disable in `logger.ts`.
- Minor incidental cleanups: removed a now-empty `if (isError)` debug branch + unused `isError`/`error` in `DeleteJob.tsx`; dropped unused `res`/`data` bindings in `MagickLink.tsx` / `authApiSlice.ts`; turned the `ThemeContext` default stub into a clean no-op.

## Verification

- `pnpm -F @bilbomd/ui lint` → 0 errors, 0 warnings
- `pnpm -F @bilbomd/ui build` → success
- `pnpm -F @bilbomd/ui test` → 130 files, 1101 tests pass
- `grep -rn "console\." apps/ui/src` (excl. tests) → only `utils/logger.ts` matches

## Out of scope

`apps/scoper` (9 calls) — separate follow-up branch, as noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)