### PR TITLE
fix(worker): persist nersc sub-document after Slurm submission

### DIFF
--- a/.changeset/worker-persist-nersc-jobid.md
+++ b/.changeset/worker-persist-nersc-jobid.md
@@ -1,0 +1,7 @@
+---
+'@bilbomd/worker': patch
+---
+
+Fix NERSC JobID and Status not appearing in the Jobs table. The worker now
+persists the `nersc` sub-document to MongoDB immediately after Slurm submission,
+so the NERSC job monitor can track and display job status (#855).

--- a/apps/worker/src/services/functions/__tests__/bilbomd-step-functions-nersc.test.ts
+++ b/apps/worker/src/services/functions/__tests__/bilbomd-step-functions-nersc.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Job as BullMQJob } from 'bullmq'
+import type { IJob } from '@bilbomd/mongodb-schema'
+
+vi.mock('../../../helpers/loggers.js', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('../mongo-utils.js', () => ({
+  updateStepStatus: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../nersc-api-functions.js', () => ({
+  executeNerscScript: vi.fn().mockResolvedValue(undefined),
+  submitJobToNersc: vi.fn().mockResolvedValue('submit-task-id'),
+  monitorTaskAtNERSC: vi.fn()
+}))
+
+vi.mock('../prepare-results.js', () => ({
+  prepareResults: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../job-utils.js', () => ({
+  cleanupJob: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../../../config/config.js', () => ({
+  config: {}
+}))
+
+const makeDBJob = (): IJob =>
+  ({
+    _id: 'job-id',
+    uuid: 'test-uuid',
+    steps: {},
+    updateOne: vi.fn().mockResolvedValue(undefined)
+  }) as unknown as IJob
+
+const makeMQJob = (): BullMQJob =>
+  ({
+    log: vi.fn().mockResolvedValue(undefined)
+  }) as unknown as BullMQJob
+
+describe('submitBilboMDSlurm', () => {
+  let submitBilboMDSlurm: typeof import('../bilbomd-step-functions-nersc.js').submitBilboMDSlurm
+  let monitorTaskAtNERSC: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const nerscApi = await import('../nersc-api-functions.js')
+    monitorTaskAtNERSC = vi.mocked(nerscApi.monitorTaskAtNERSC)
+    const mod = await import('../bilbomd-step-functions-nersc.js')
+    submitBilboMDSlurm = mod.submitBilboMDSlurm
+  })
+
+  it('persists the nersc sub-document to MongoDB after submission', async () => {
+    monitorTaskAtNERSC.mockResolvedValue({
+      result: JSON.stringify({ jobid: '12345678' })
+    })
+
+    const DBjob = makeDBJob()
+    const MQjob = makeMQJob()
+
+    const result = await submitBilboMDSlurm(MQjob, DBjob)
+
+    expect(result).toBe('12345678')
+    expect(DBjob.nersc).toEqual(
+      expect.objectContaining({ jobid: '12345678', state: 'PENDING' })
+    )
+    expect(DBjob.updateOne).toHaveBeenCalledWith({
+      $set: {
+        nersc: expect.objectContaining({ jobid: '12345678', state: 'PENDING' })
+      }
+    })
+  })
+
+  it('throws and does not persist nersc when no job ID is returned', async () => {
+    monitorTaskAtNERSC.mockResolvedValue({
+      result: JSON.stringify({ jobid: '' })
+    })
+
+    const DBjob = makeDBJob()
+    const MQjob = makeMQJob()
+
+    await expect(submitBilboMDSlurm(MQjob, DBjob)).rejects.toThrow(
+      /Failed to submit Slurm batch file/
+    )
+    expect(DBjob.updateOne).not.toHaveBeenCalled()
+  })
+})

--- a/apps/worker/src/services/functions/bilbomd-step-functions-nersc.ts
+++ b/apps/worker/src/services/functions/bilbomd-step-functions-nersc.ts
@@ -211,6 +211,12 @@ const submitBilboMDSlurm = async (
       time_completed: undefined
     }
 
+    // Persist the nersc sub-document so the NERSC job monitor (which filters on
+    // `nersc.state != null`) can pick up the job and track its Slurm status.
+    // Use updateOne instead of save() to avoid ParallelSaveError, consistent
+    // with the step-status updates in mongo-utils.ts.
+    await DBjob.updateOne({ $set: { nersc: DBjob.nersc } })
+
     await updateJobStatus(
       DBjob,
       stepName,


### PR DESCRIPTION
## Summary

Fixes #855 — NERSC JobID and Status never appeared in the Jobs table.

After submitting a job to the NERSC Slurm queue, `submitBilboMDSlurm` set `DBjob.nersc` **in memory but never wrote it to MongoDB**. The follow-up `updateJobStatus` call only persists the `steps.*` field via `updateOne`, so the `nersc` sub-document (`jobid`, `state`, `qos`, `time_submitted`) was lost.

Consequences:
- The Jobs table showed the job stuck at **Submitted** with blank **NERSC JobID** / **NERSC Status** columns.
- The NERSC job monitor (`bilboMdNerscJobMonitor.ts`), which filters incomplete jobs on `'nersc.state': { $ne: null }`, never picked the job up — so status was never tracked either.

## Change

In `apps/worker/src/services/functions/bilbomd-step-functions-nersc.ts`, persist the `nersc` sub-document with an atomic `updateOne` immediately after it is assigned:

```ts
await DBjob.updateOne({ $set: { nersc: DBjob.nersc } })
```

`updateOne` is used (rather than `save()`) to stay consistent with the `ParallelSaveError`-avoidance pattern documented in `mongo-utils.ts`.

## Tests

Added `__tests__/bilbomd-step-functions-nersc.test.ts` covering `submitBilboMDSlurm`:
- Persists the `nersc` sub-document (`jobid`, `state: 'PENDING'`) via `updateOne` and returns the NERSC job ID.
- Throws and does **not** persist `nersc` when no job ID is returned from NERSC.

## Verification

- [x] `pnpm -F @bilbomd/worker lint`
- [x] `pnpm -F @bilbomd/worker build`
- [x] `pnpm -F @bilbomd/worker test` (136 passed)
- [ ] End-to-end on a NERSC deployment: submit a job, confirm `nersc.{jobid,state}` is written to MongoDB right after the `nersc_submit_slurm_batch` step, and confirm the Jobs table shows the NERSC JobID and a status that progresses PENDING → RUNNING → COMPLETED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)