### PR TITLE
fix(worker): recover stuck NERSC jobs missing nersc sub-document

### DIFF
--- a/.changeset/worker-recover-stuck-nersc-jobs.md
+++ b/.changeset/worker-recover-stuck-nersc-jobs.md
@@ -1,0 +1,8 @@
+---
+'@bilbomd/worker': patch
+---
+
+Recover NERSC jobs stuck at "Submitted" that were submitted before the nersc
+persistence fix. The monitor now reconstructs the missing `nersc` sub-document
+from the successful submission step (parsing the NERSC JobID from the step
+message) so these jobs resume status tracking (#858).

--- a/apps/worker/src/workers/bilboMdNerscJobMonitor.ts
+++ b/apps/worker/src/workers/bilboMdNerscJobMonitor.ts
@@ -35,6 +35,45 @@ const fetchIncompleteJobs = async (): Promise<IJob[]> => {
   }).exec()
 }
 
+// Recover jobs that were submitted to Slurm before the fix that persists the
+// nersc sub-document was deployed. Such jobs have a successful
+// nersc_submit_slurm_batch step (with the NERSC JobID in the message) but no
+// nersc field in MongoDB, so the normal monitor query never finds them.
+const recoverStuckNerscJobs = async (): Promise<void> => {
+  const stuckJobs = await DBJob.find({
+    status: { $ne: JobStatus.Completed },
+    cleanup_in_progress: false,
+    nersc: { $exists: false },
+    'steps.nersc_submit_slurm_batch.status': 'Success'
+  }).exec()
+
+  if (stuckJobs.length === 0) return
+  logger.info(`Recovering ${stuckJobs.length} stuck NERSC job(s) missing nersc sub-document...`)
+
+  for (const job of stuckJobs) {
+    const message = (job.steps as Record<string, { status: string; message: string } | undefined>)
+      ?.nersc_submit_slurm_batch?.message ?? ''
+    const match = message.match(/NERSC JobID (\S+)/)
+    if (!match) {
+      logger.warn(
+        `Job ${job.uuid}: cannot parse NERSC JobID from step message "${message}" — skipping`
+      )
+      continue
+    }
+    const jobid = match[1]
+    const nersc: INerscInfo = {
+      jobid,
+      state: NerscStatus.PENDING,
+      qos: '',
+      time_submitted: new Date(),
+      time_started: undefined,
+      time_completed: undefined
+    }
+    await job.updateOne({ $set: { nersc } })
+    logger.info(`Job ${job.uuid}: recovered with NERSC JobID ${jobid}`)
+  }
+}
+
 const queryNERSCForJobState = async (job: IJob): Promise<INerscInfo | null> => {
   try {
     const jobid = job.nersc?.jobid
@@ -192,6 +231,11 @@ const syncJobStatusFromNerscState = async (
 
 const monitorAndCleanupJobs = async (): Promise<void> => {
   try {
+    // Recover any jobs stuck without a nersc sub-document (submitted before the
+    // fix was deployed). Idempotent — once recovered they satisfy the normal
+    // fetchIncompleteJobs query and are no longer returned here.
+    await recoverStuckNerscJobs()
+
     logger.info('Starting job monitoring and cleanup...')
 
     // Step 1: Fetch all jobs where nersc.state is not null from MongoDB


### PR DESCRIPTION
## Summary

Companion fix for #855 / #856.

Jobs submitted to NERSC **before** the nersc persistence fix (#856) was deployed have a successful `nersc_submit_slurm_batch` step (with the NERSC JobID in the step message) but no `nersc` field in MongoDB. The monitor's `'nersc.state': { $ne: null }` filter excludes them permanently, leaving them stuck at "Submitted" indefinitely.

## Change

Adds `recoverStuckNerscJobs()`, called at the start of each `monitorAndCleanupJobs` cycle. It:

1. Queries for jobs where `nersc` is absent but `steps.nersc_submit_slurm_batch.status === 'Success'`
2. Parses the NERSC JobID out of the step message (e.g. `"NERSC JobID 12345678"`)
3. Writes a `nersc: { jobid, state: 'PENDING', ... }` sub-document via `updateOne`

Once recovered, each job satisfies the normal `fetchIncompleteJobs` query and is tracked/updated by the monitor as usual.

**Idempotent** — once a job has `nersc.state` set it is no longer returned by the recovery query, so running it every cycle is safe at negligible cost. It will be a no-op once all pre-fix jobs are resolved.

## Test plan

- [ ] Deploy to NERSC and confirm previously-stuck "Submitted" jobs are recovered (NERSC JobID and Status appear in the Jobs table) within one monitor cycle.
- [ ] Confirm newly submitted jobs (after #856) are unaffected and continue to work normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)