### PR TITLE
docs: fix broken pipeline schematic images in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,29 +19,23 @@ BilboMD is a webapp developed at the [SIBYLS beamline](https://sibyls.als.lbl.go
 
 There are several different SAXS modeling pipelines available.
 
+> 📊 Interactive pipeline diagrams for each workflow are rendered in the live app — see the [Deployment](#deployment) instances below (e.g. [Hyperion](https://bilbomd.bl1231.als.lbl.gov)).
+
 ### BilboMD Classic w/PDB inputs
 
 This pipeline offers the classic BilboMD from years past where you can upload a custom `const.inp` file and adjust the `rg_min` and `rg_max` values. It takes a user provided PDB file and experimental SAXS data.
-
-![Classic PDB](apps/ui/public/images/bilbomd-classic-pdb-schematic-openmm-dark.png)
 
 ### BilboMD Classic w/CRD inputs
 
 This pipeline offers the classic BilboMD from years past where you can upload a custom `const.inp` file and adjust the `rg_min` and `rg_max` values. It takes a user provided CRD and PSF file and experimental SAXS data. The CRD and PSF files can be generated using [CHARMM GUI](https://www.charmm-gui.org/).
 
-![Classic CRD](apps/ui/public/images/bilbomd-classic-crd-schematic-dark.png)
-
 ### BilboMD Auto
 
 This pipeline is designed to take Alphafold models and a Per residue Alignment Error (PAE) matrix in combination with your experimental SAXS data.
 
-![Auto](apps/ui/public/images/bilbomd-auto-schematic-openmm-dark.png)
-
 ### BilboMD AF
 
 This pipeline is designed to run Alphafold2 on your provided protein sequence and then run the Auto pipeline above.
-
-![Auto](apps/ui/public/images/bilbomd-af-schematic-openmm-dark.png)
 
 ## Test Coverage
 


### PR DESCRIPTION
## Summary

The pipeline schematics were converted from static PNG files into theme-aware React/SVG components (`apps/ui/src/features/.../*PipelineSchematic*.tsx`). The old PNG files were deleted in #800, but the root `README.md` still linked to four of them, so those images render **broken on GitHub**.

Since the schematics now only exist at runtime inside the UI app (no static `.svg`/`.png` to point at, and GitHub markdown can't render React components or inline `<svg>`), this PR drops the broken image references and instead points readers to the live app, where the interactive diagrams render.

## Changes

- Remove the 4 broken `![...](apps/ui/public/images/bilbomd-*-schematic-*.png)` lines (Classic PDB, Classic CRD, Auto, AF).
- Add a note under `## Pipelines` linking to the existing [Deployment](#deployment) section / Hyperion instance.
- Pipeline descriptions left intact.

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)