### PR TITLE
fix(backend): repair queries broken by mongoose sanitizeFilter

### DIFF
--- a/.changeset/fix-sanitizefilter-operator-queries.md
+++ b/.changeset/fix-sanitizefilter-operator-queries.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/backend': patch
+---
+
+Fix HTTP 500 on user registration (and other broken queries) caused by mongoose `sanitizeFilter`. With `sanitizeFilter` enabled globally, any `{ $op: ... }` filter value is wrapped in `$eq` to block operator injection, which then fails to cast against the field's type. This broke the registration previous-email lookup (`$in`), the `deleteOldJobs` cron (`$lt`), and the anonymous job-quota checks (`$in`). Developer-built operator filters are now either rewritten to scalar matches or wrapped in `mongoose.trusted()`. Added regression tests that exercise real mongoose casting under `sanitizeFilter`.

--- a/apps/backend/src/__tests__/sanitizeFilter.test.ts
+++ b/apps/backend/src/__tests__/sanitizeFilter.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import mongoose, { Model } from 'mongoose'
+import { User, Job, JobStatus } from '@bilbomd/mongodb-schema'
+
+// Reproduce mongoose's query-time `sanitizeFilter` + schema casting WITHOUT a
+// DB connection. This is the exact path that turned user registration into a
+// 500: with `sanitizeFilter` enabled globally (app.ts), mongoose wraps any
+// `{ $op: ... }` filter value in `{ $eq: ... }` to neutralize operator
+// injection, which then fails to cast against the field's type. The escape
+// hatch for developer-built (non-user) operators is `mongoose.trusted()`.
+//
+// Returns the CastError if the filter is rejected, else null.
+const filterCastError = <T>(
+  model: Model<T>,
+  filter: Record<string, unknown>
+): Error | null => {
+  const query = model.find(filter as never, null, {
+    sanitizeFilter: true
+  })
+  ;(query as unknown as { _castConditions: () => void })._castConditions()
+  return (query as unknown as { error: () => Error | null }).error() ?? null
+}
+
+describe('sanitizeFilter operator-query regressions', () => {
+  describe('registerController previous-email lookup (User.previousEmails: [String])', () => {
+    it('casts cleanly when matching the array field against a scalar (the fix)', () => {
+      expect(
+        filterCastError(User, { previousEmails: 'scott@example.com' })
+      ).toBeNull()
+    })
+
+    it('casts cleanly when an operator is explicitly mongoose.trusted()', () => {
+      expect(
+        filterCastError(User, {
+          previousEmails: mongoose.trusted({ $in: ['scott@example.com'] })
+        })
+      ).toBeNull()
+    })
+
+    it('REGRESSION: a bare { $in: [...] } is mangled by sanitizeFilter and fails to cast', () => {
+      expect(
+        filterCastError(User, {
+          previousEmails: { $in: ['scott@example.com'] }
+        })
+      ).toBeInstanceOf(mongoose.Error.CastError)
+    })
+  })
+
+  describe('anonymous job-quota status filter (Job.status: String enum)', () => {
+    const activeStatuses = [
+      JobStatus.Submitted,
+      JobStatus.Pending,
+      JobStatus.Running
+    ]
+
+    it('casts cleanly with mongoose.trusted({ $in })', () => {
+      expect(
+        filterCastError(Job, {
+          status: mongoose.trusted({ $in: activeStatuses })
+        })
+      ).toBeNull()
+    })
+
+    it('REGRESSION: a bare { $in: [...] } fails to cast under sanitizeFilter', () => {
+      expect(
+        filterCastError(Job, { status: { $in: activeStatuses } })
+      ).toBeInstanceOf(mongoose.Error.CastError)
+    })
+  })
+
+  describe('jobCleaner age filter (Job.createdAt: Date)', () => {
+    const threshold = new Date('2026-01-01T00:00:00Z')
+
+    it('casts cleanly with mongoose.trusted({ $lt })', () => {
+      expect(
+        filterCastError(Job, {
+          createdAt: mongoose.trusted({ $lt: threshold })
+        })
+      ).toBeNull()
+    })
+
+    it('REGRESSION: a bare { $lt: date } fails to cast under sanitizeFilter', () => {
+      expect(
+        filterCastError(Job, { createdAt: { $lt: threshold } })
+      ).toBeInstanceOf(mongoose.Error.CastError)
+    })
+  })
+})

--- a/apps/backend/src/controllers/__tests__/registerController.test.ts
+++ b/apps/backend/src/controllers/__tests__/registerController.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Request, Response } from 'express'
+import { Model } from 'mongoose'
+
+vi.mock('../../config/config.js', () => ({
+  config: { sendEmailNotifications: false },
+  getEnvVar: vi.fn().mockReturnValue('https://bilbomd.example.com')
+}))
+
+vi.mock('@bilbomd/mongodb-schema', () => ({
+  User: { findOne: vi.fn(), create: vi.fn() }
+}))
+
+vi.mock('../../config/nodemailerConfig.js', () => ({
+  sendVerificationEmail: vi.fn()
+}))
+
+vi.mock('../../middleware/loggers.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn() }
+}))
+
+import { User } from '@bilbomd/mongodb-schema'
+import { handleNewUser } from '../registerController.js'
+
+const makeReq = (body: unknown): Request => ({ body }) as Request
+const makeRes = (): Response => {
+  const res = {} as Response
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  return res
+}
+
+// Build the chainable findOne mock the controller uses:
+// User.findOne(filter).collation(...).lean().exec()
+const captured: Record<string, unknown>[] = []
+const findOneChain = (result: unknown) => ({
+  collation: () => ({ lean: () => ({ exec: () => Promise.resolve(result) }) })
+})
+
+// Cast a captured filter through mongoose's sanitizeFilter + schema casting
+// using the REAL User schema, exactly as query execution would. Returns a
+// CastError if the (sanitized) filter is invalid — which is what previously
+// produced a 500 for the previous-email `$in` lookup.
+const filterCastError = <T>(
+  model: Model<T>,
+  filter: Record<string, unknown>
+): Error | null => {
+  const query = model.find(filter as never, null, {
+    sanitizeFilter: true
+  })
+  ;(query as unknown as { _castConditions: () => void })._castConditions()
+  return (query as unknown as { error: () => Error | null }).error() ?? null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  captured.length = 0
+})
+
+describe('handleNewUser', () => {
+  it('returns 400 when username or email is missing', async () => {
+    const res = makeRes()
+    await handleNewUser(makeReq({ user: 'scott' }), res)
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(User.findOne).not.toHaveBeenCalled()
+  })
+
+  it('creates a new user and never passes a bare operator filter to findOne', async () => {
+    // No existing user matches any of the duplicate checks.
+    vi.mocked(User.findOne).mockImplementation((filter) => {
+      captured.push(filter as unknown as Record<string, unknown>)
+      return findOneChain(null) as never
+    })
+    vi.mocked(User.create).mockResolvedValue({ username: 'scott' } as never)
+
+    const res = makeRes()
+    await handleNewUser(
+      makeReq({ user: 'scott', email: 'scott@example.com' }),
+      res
+    )
+
+    expect(res.status).toHaveBeenCalledWith(201)
+    // All three duplicate checks ran: username, email, previousEmails.
+    expect(captured).toHaveLength(3)
+
+    // The regression guard: every filter the controller hands to findOne must
+    // survive mongoose's sanitizeFilter + cast against the real User schema. A
+    // bare `{ previousEmails: { $in: [...] } }` (the original bug) would throw
+    // a CastError here and fail this test.
+    const { User: RealUser } = await vi.importActual<
+      typeof import('@bilbomd/mongodb-schema')
+    >('@bilbomd/mongodb-schema')
+    for (const filter of captured) {
+      expect(filterCastError(RealUser, filter)).toBeNull()
+    }
+  })
+
+  it('returns 409 on a duplicate username', async () => {
+    vi.mocked(User.findOne).mockImplementationOnce(
+      () => findOneChain({ username: 'scott' }) as never
+    )
+
+    const res = makeRes()
+    await handleNewUser(
+      makeReq({ user: 'scott', email: 'scott@example.com' }),
+      res
+    )
+
+    expect(res.status).toHaveBeenCalledWith(409)
+    expect(User.create).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/controllers/jobs/createJob.ts
+++ b/apps/backend/src/controllers/jobs/createJob.ts
@@ -1,3 +1,4 @@
+import mongoose from 'mongoose'
 import { logger } from '../../middleware/loggers.js'
 import multer from 'multer'
 import fs from 'fs-extra'
@@ -227,7 +228,7 @@ const createPublicJob = async (req: Request, res: Response) => {
         ]
         const quotaQuery = {
           client_ip_hash,
-          status: { $in: activeStatuses },
+          status: mongoose.trusted({ $in: activeStatuses }),
           access_mode: AccessMode.Anonymous
         }
         const counts = await Promise.all([

--- a/apps/backend/src/controllers/jobs/sansJobController.ts
+++ b/apps/backend/src/controllers/jobs/sansJobController.ts
@@ -1,3 +1,4 @@
+import mongoose from 'mongoose'
 import { v4 as uuid } from 'uuid'
 import path from 'path'
 import fs from 'fs-extra'
@@ -169,7 +170,7 @@ const createPublicSANSJob = async (req: Request, res: Response) => {
         ]
         const quotaQuery = {
           client_ip_hash,
-          status: { $in: activeStatuses },
+          status: mongoose.trusted({ $in: activeStatuses }),
           access_mode: AccessMode.Anonymous
         }
         const counts = await Promise.all([

--- a/apps/backend/src/controllers/registerController.ts
+++ b/apps/backend/src/controllers/registerController.ts
@@ -42,8 +42,11 @@ const handleNewUser = async (req: Request, res: Response) => {
     return
   }
 
+  // Matching an array field against a scalar finds docs whose array contains
+  // that value. Avoid `$in` here: with mongoose `sanitizeFilter` enabled (see
+  // app.ts) operator objects get wrapped in `$eq`, which would cast-fail.
   const duplicatePreviousEmail = await User.findOne({
-    previousEmails: { $in: [email] }
+    previousEmails: email
   })
     .collation({ locale: 'en', strength: 2 }) // provide case-insensitive search
     .lean()

--- a/apps/backend/src/middleware/__tests__/jobCleaner.test.ts
+++ b/apps/backend/src/middleware/__tests__/jobCleaner.test.ts
@@ -8,10 +8,11 @@ import { Job, MultiJob } from '@bilbomd/mongodb-schema'
 import { logger } from '../loggers.js'
 
 vi.mock('mongoose', async () => {
-  const actual = await vi.importActual('mongoose')
+  const actual = await vi.importActual<typeof import('mongoose')>('mongoose')
   return {
     ...actual,
     default: {
+      ...actual.default,
       connection: {
         readyState: 1
       }
@@ -291,11 +292,11 @@ describe('deleteOldJobs', () => {
       await deleteOldJobs()
 
       expect(Job.find).toHaveBeenCalledWith({
-        createdAt: { $lt: expectedThreshold }
+        createdAt: mongoose.trusted({ $lt: expectedThreshold })
       })
 
       expect(MultiJob.find).toHaveBeenCalledWith({
-        createdAt: { $lt: expectedThreshold }
+        createdAt: mongoose.trusted({ $lt: expectedThreshold })
       })
 
       vi.useRealTimers()

--- a/apps/backend/src/middleware/jobCleaner.ts
+++ b/apps/backend/src/middleware/jobCleaner.ts
@@ -18,7 +18,7 @@ export const deleteOldJobs = async () => {
     const thresholdDate = new Date(Date.now() - maxAge * 1000)
 
     const oldJobs = await Job.find({
-      createdAt: { $lt: thresholdDate }
+      createdAt: mongoose.trusted({ $lt: thresholdDate })
     })
       .lean()
       .exec()
@@ -47,13 +47,13 @@ export const deleteOldJobs = async () => {
     }
 
     const deleteResult = await Job.deleteMany({
-      createdAt: { $lt: thresholdDate }
+      createdAt: mongoose.trusted({ $lt: thresholdDate })
     }).exec()
     const deletedJobsCount = deleteResult.deletedCount
     logger.warn(`Deleted ${deletedJobsCount} jobs from MongoDB`)
 
     const oldMultiJobs = await MultiJob.find({
-      createdAt: { $lt: thresholdDate }
+      createdAt: mongoose.trusted({ $lt: thresholdDate })
     })
       .lean()
       .exec()
@@ -84,7 +84,7 @@ export const deleteOldJobs = async () => {
     }
 
     const deleteMultiResult = await MultiJob.deleteMany({
-      createdAt: { $lt: thresholdDate }
+      createdAt: mongoose.trusted({ $lt: thresholdDate })
     }).exec()
     const deletedMultiJobsCount = deleteMultiResult.deletedCount
     logger.warn(`Deleted ${deletedMultiJobsCount} multi-jobs from MongoDB`)


### PR DESCRIPTION
## Problem

New user registration was returning **HTTP 500** — the "Create An Account" button silently failed with `POST /api/v1/register 500`.

Root cause: `app.ts` enables `mongoose.set('sanitizeFilter', true)` globally (added in the NoSQL-injection hardening, #730). With that flag on, mongoose wraps **any** `{ $op: ... }` filter value in `$eq` to neutralize operator injection, and then tries to cast that wrapped object against the field's type. For the registration previous-email lookup:

```js
User.findOne({ previousEmails: { $in: [email] } })
// → sanitized to { previousEmails: { $eq: { $in: [email] } } }
// → CastError: Cast to string failed for value "{ $in: [...] }" at path "previousEmails"
```

Because that query sits *outside* the controller's `try/catch`, the rejection bubbles to Express 5's default handler → 500.

The same landmine silently broke two other code paths that build operator filters:
- `deleteOldJobs` cron — `createdAt: { $lt: thresholdDate }`
- anonymous job-quota checks (`createJob`, `sansJobController`) — `status: { $in: activeStatuses }`

(`getJobs.ts`'s `$or` is safe — sanitizeFilter recurses into `$or`/`$and`/`$nor` and the inner values are scalars.)

## Fix

- **registerController** — match the `previousEmails` string-array against a scalar (`{ previousEmails: email }`); querying an array field with a scalar already means "array contains this value", and a scalar is sanitizeFilter-safe.
- **jobCleaner / createJob / sansJobController** — wrap the developer-built (non-user) operator filters in `mongoose.trusted()`, the intended escape hatch, preserving injection protection on actual user input.

## Tests

A plain mock of `findOne` can't catch this — the bug is in mongoose's casting layer, which is why the existing suite missed it. The new tests exercise **real `sanitizeFilter` + schema casting offline** (no DB):

- `sanitizeFilter.test.ts` — for all four sites, asserts the fixed filter shape casts cleanly **and** that the naive operator form throws `CastError`.
- `registerController.test.ts` — captures the actual filters `handleNewUser` builds and asserts each casts cleanly against the real `User` schema under `sanitizeFilter`; reintroducing a bare `$in` fails the test. Also covers the 400/409 paths.
- Updated `jobCleaner.test.ts` whose mongoose mock had stubbed out `mongoose.trusted`.

## Verification

- `pnpm -F @bilbomd/backend lint` ✅
- `pnpm -F @bilbomd/backend build` (tsc) ✅
- `pnpm -F @bilbomd/backend test` ✅ (470 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)