### PR TITLE
chore(infra): rename kube contexts from bilbomd-{env} to nersc-spin-{env}

### DIFF
--- a/infra/HELM_NOTES.md
+++ b/infra/HELM_NOTES.md
@@ -164,13 +164,13 @@ helm install bilbomd-nersc-prod ./helm -f ./helm/values-prod.yaml
 I have combined the kube config yaml files from both the development and production servers into a single yaml file. In order to switch kubectl commands between the development and production servers you must first select the "context" to use.
 
 ```bash
-kubectl config use-context bilbomd-prod
+kubectl config use-context nersc-spin-prod
 ```
 
 or
 
 ```bash
-kubectl config use-context bilbomd-dev
+kubectl config use-context nersc-spin-dev
 ```
 
 And check that the desired context is the active one:
@@ -178,8 +178,8 @@ And check that the desired context is the active one:
 ```sh
 ❯ kubectl config get-contexts
 CURRENT   NAME           CLUSTER       AUTHINFO      NAMESPACE
-          bilbomd-dev    development   development   bilbomd
-*         bilbomd-prod   production    production    bilbomd
+          nersc-spin-dev    development   development   bilbomd
+*         nersc-spin-prod   production    production    bilbomd
 ```
 
 ### Development

--- a/infra/deploy-to-nersc.sh
+++ b/infra/deploy-to-nersc.sh
@@ -60,16 +60,16 @@ validate_env() {
     usage >&2
     exit 1
   fi
-  if ! kubectl config get-contexts -o name 2>/dev/null | grep -qx "bilbomd-$env"; then
-    echo -e "${RED}❌ kube-context 'bilbomd-$env' not found.${NC}" >&2
+  if ! kubectl config get-contexts -o name 2>/dev/null | grep -qx "nersc-spin-$env"; then
+    echo -e "${RED}❌ kube-context 'nersc-spin-$env' not found.${NC}" >&2
     exit 1
   fi
 }
 
 use_context() {
   local env="$1"
-  echo -e "🔧 Switching to context: ${BLUE}bilbomd-$env${NC}"
-  kubectl config use-context "bilbomd-$env" >/dev/null
+  echo -e "🔧 Switching to context: ${BLUE}nersc-spin-$env${NC}"
+  kubectl config use-context "nersc-spin-$env" >/dev/null
   echo "🧭 Current context: $(kubectl config current-context)"
   echo "📛 Current namespace: $NS"
   echo "--------------------------------"

--- a/infra/update_sfapi.sh
+++ b/infra/update_sfapi.sh
@@ -14,7 +14,7 @@ else
 fi
 
 # Define contexts
-CONTEXTS=("bilbomd-dev" "bilbomd-prod")
+CONTEXTS=("nersc-spin-dev" "nersc-spin-prod")
 
 for CONTEXT in "${CONTEXTS[@]}"; do
     echo "🔁 Switching to context: $CONTEXT"
@@ -30,10 +30,10 @@ for CONTEXT in "${CONTEXTS[@]}"; do
 
     VALUES_FILE=""
     NAME=""
-    if [[ "$CONTEXT" == "bilbomd-dev" ]]; then
+    if [[ "$CONTEXT" == "nersc-spin-dev" ]]; then
         NAME="bilbomd-nersc-dev"
         VALUES_FILE="values-dev.yaml"
-    elif [[ "$CONTEXT" == "bilbomd-prod" ]]; then
+    elif [[ "$CONTEXT" == "nersc-spin-prod" ]]; then
         NAME="bilbomd-nersc-prod"
         VALUES_FILE="values-prod.yaml"
     else


### PR DESCRIPTION
## Summary

- Rename kubectl context names from `bilbomd-dev`/`bilbomd-prod` to `nersc-spin-dev`/`nersc-spin-prod` across all infra scripts
- Updated `HELM_NOTES.md` documentation examples
- Updated context validation and switching in `deploy-to-nersc.sh`
- Updated context iteration in `update_sfapi.sh`

## Test plan

- [ ] Verify `kubectl config get-contexts` shows contexts named `nersc-spin-dev` and `nersc-spin-prod`
- [ ] Run `deploy-to-nersc.sh` against dev to confirm context switching works with new names
- [ ] Run `update_sfapi.sh` to confirm it switches and applies secrets correctly in both contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)