### PR TITLE
fix: recover pLDDT from AlphaFold3 PAE JSON when structure B-factors are all zero

### DIFF
--- a/.changeset/auto-recover-plddt-from-pae.md
+++ b/.changeset/auto-recover-plddt-from-pae.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Auto jobs: recover per-residue pLDDT from the AlphaFold3-style PAE JSON (`atom_plddts`) when the uploaded structure's B-factor column is all zeros. Previously, structures that lost their pLDDT during preparation (e.g. protonation) silently produced no fixed_bodies or rigid_bodies, leaving the model un-flexed. pae2const.py now aligns `atom_plddts` to the structure's heavy atoms and logs the recovery, with a clear warning when neither the B-factor column nor the JSON carry pLDDT.

--- a/.changeset/warn-zero-bfactor-column.md
+++ b/.changeset/warn-zero-bfactor-column.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Auto job forms: warn when an uploaded PDB/CIF structure has an all-zero B-factor (pLDDT) column. The non-blocking warning explains that AlphaFold3-style PAE JSON will let BilboMD recover pLDDT automatically, and otherwise no rigid bodies will be defined. Applies to both the new and resubmit auto-job forms.

--- a/apps/ui/src/features/autojob/NewAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/NewAutoJobForm.tsx
@@ -1,12 +1,5 @@
 import { ReactNode, useState } from 'react'
-import {
-  Box,
-  Button,
-  TextField,
-  Typography,
-  Alert,
-  Paper
-} from '@mui/material'
+import { Box, Button, TextField, Typography, Alert, Paper } from '@mui/material'
 import LaunchIcon from '@mui/icons-material/Launch'
 import Grid from '@mui/material/Grid'
 import { Form, Formik, Field } from 'formik'
@@ -328,13 +321,11 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             const metalWarning =
                               metalFound.length > 0 ? (
                                 <Box>
-                                  The following metal-containing
-                                  residues have no force-field
-                                  parameters and will be removed
-                                  before MD:{' '}
-                                  {metalFound.join(', ')}. If these
-                                  residues are important for your
-                                  system, consider using{' '}
+                                  The following metal-containing residues have
+                                  no force-field parameters and will be removed
+                                  before MD: {metalFound.join(', ')}. If these
+                                  residues are important for your system,
+                                  consider using{' '}
                                   <Button
                                     href="https://charmm-gui.org/"
                                     target="_blank"
@@ -355,23 +346,21 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                   >
                                     CHARMM-GUI
                                   </Button>{' '}
-                                  to properly parameterize your
-                                  structure, then submit a Classic job
-                                  with CRD and PSF files using the
-                                  CHARMM engine option.
+                                  to properly parameterize your structure, then
+                                  submit a Classic job with CRD and PSF files
+                                  using the CHARMM engine option.
                                 </Box>
                               ) : null
                             const plddtWarning = plddtAllZero ? (
                               <Box>
-                                All B-factor (pLDDT) values in this
-                                structure are zero. If your PAE JSON is
-                                AlphaFold3-style (contains per-atom
-                                pLDDT), BilboMD will recover pLDDT
-                                automatically; otherwise no rigid
-                                bodies will be defined and your model
-                                will not be flexed. Consider
-                                re-uploading a structure that retains
-                                pLDDT in the B-factor column.
+                                All B-factor (pLDDT) values in this structure
+                                are zero. If your PAE JSON is AlphaFold3-style
+                                (contains per-atom pLDDT), BilboMD will attempt
+                                to recover pLDDT automatically; otherwise no
+                                rigid bodies will be defined and the MD step may
+                                produce meaningless results. Consider
+                                re-uploading a structure that retains pLDDT in
+                                the B-factor column.
                               </Box>
                             ) : null
                             setPdbWarning(

--- a/apps/ui/src/features/autojob/NewAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/NewAutoJobForm.tsx
@@ -18,7 +18,8 @@ import NewAutoJobFormInstructions from './AutoJobFormInstructions'
 import { BilboMDAutoJobSchema } from 'schemas/BilboMDAutoJobSchema'
 import {
   detectGaffCofactors,
-  detectMetalCofactors
+  detectMetalCofactors,
+  isPlddtColumnAllZero
 } from 'schemas/ValidationFunctions'
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
@@ -313,18 +314,20 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                             useExampleData ? 'example-auto.pdb' : undefined
                           }
                           onFileChange={async (file: File) => {
-                            const [gaffFound, metalFound] = await Promise.all([
-                              detectGaffCofactors(file),
-                              detectMetalCofactors(file)
-                            ])
+                            const [gaffFound, metalFound, plddtAllZero] =
+                              await Promise.all([
+                                detectGaffCofactors(file),
+                                detectMetalCofactors(file),
+                                isPlddtColumnAllZero(file)
+                              ])
                             setPdbInfo(
                               gaffFound.length > 0
                                 ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM: ${gaffFound.join(', ')}`
                                 : ''
                             )
-                            setPdbWarning(
+                            const metalWarning =
                               metalFound.length > 0 ? (
-                                <>
+                                <Box>
                                   The following metal-containing
                                   residues have no force-field
                                   parameters and will be removed
@@ -356,7 +359,33 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                                   structure, then submit a Classic job
                                   with CRD and PSF files using the
                                   CHARMM engine option.
-                                </>
+                                </Box>
+                              ) : null
+                            const plddtWarning = plddtAllZero ? (
+                              <Box>
+                                All B-factor (pLDDT) values in this
+                                structure are zero. If your PAE JSON is
+                                AlphaFold3-style (contains per-atom
+                                pLDDT), BilboMD will recover pLDDT
+                                automatically; otherwise no rigid
+                                bodies will be defined and your model
+                                will not be flexed. Consider
+                                re-uploading a structure that retains
+                                pLDDT in the B-factor column.
+                              </Box>
+                            ) : null
+                            setPdbWarning(
+                              metalWarning || plddtWarning ? (
+                                <Box
+                                  sx={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    gap: 1
+                                  }}
+                                >
+                                  {metalWarning}
+                                  {plddtWarning}
+                                </Box>
                               ) : (
                                 ''
                               )

--- a/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
@@ -23,7 +23,8 @@ import AutoJobFormInstructions from './AutoJobFormInstructions'
 import { BilboMDAutoJobSchema } from 'schemas/BilboMDAutoJobSchema'
 import {
   detectGaffCofactors,
-  detectMetalCofactors
+  detectMetalCofactors,
+  isPlddtColumnAllZero
 } from 'schemas/ValidationFunctions'
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
@@ -276,18 +277,20 @@ const ResubmitAutoJobForm = () => {
                         fileType="AlphaFold2 *.pdb"
                         fileExt=".pdb"
                         onFileChange={async (file: File) => {
-                          const [gaffFound, metalFound] = await Promise.all([
-                            detectGaffCofactors(file),
-                            detectMetalCofactors(file)
-                          ])
+                          const [gaffFound, metalFound, plddtAllZero] =
+                            await Promise.all([
+                              detectGaffCofactors(file),
+                              detectMetalCofactors(file),
+                              isPlddtColumnAllZero(file)
+                            ])
                           setPdbInfo(
                             gaffFound.length > 0
                               ? `The following molecules will be automatically parameterized using GAFF2 for OpenMM: ${gaffFound.join(', ')}`
                               : ''
                           )
-                          setPdbWarning(
+                          const metalWarning =
                             metalFound.length > 0 ? (
-                              <>
+                              <Box>
                                 The following metal-containing
                                 residues have no force-field
                                 parameters and will be removed before
@@ -318,7 +321,32 @@ const ResubmitAutoJobForm = () => {
                                 structure, then submit a Classic job
                                 with CRD and PSF files using the
                                 CHARMM engine option.
-                              </>
+                              </Box>
+                            ) : null
+                          const plddtWarning = plddtAllZero ? (
+                            <Box>
+                              All B-factor (pLDDT) values in this
+                              structure are zero. If your PAE JSON is
+                              AlphaFold3-style (contains per-atom
+                              pLDDT), BilboMD will recover pLDDT
+                              automatically; otherwise no rigid bodies
+                              will be defined and your model will not be
+                              flexed. Consider re-uploading a structure
+                              that retains pLDDT in the B-factor column.
+                            </Box>
+                          ) : null
+                          setPdbWarning(
+                            metalWarning || plddtWarning ? (
+                              <Box
+                                sx={{
+                                  display: 'flex',
+                                  flexDirection: 'column',
+                                  gap: 1
+                                }}
+                              >
+                                {metalWarning}
+                                {plddtWarning}
+                              </Box>
                             ) : (
                               ''
                             )

--- a/apps/ui/src/schemas/ValidationFunctions.ts
+++ b/apps/ui/src/schemas/ValidationFunctions.ts
@@ -7,6 +7,7 @@ import {
   cifHasAllowedResiduesOnly as cifHasAllowedResiduesOnlyUtil,
   cifIsSingleModel as cifIsSingleModelUtil
 } from '@bilbomd/bilbomd-types'
+import { parsePLDDTFromPDB, parsePLDDTFromCIF } from '../utils/pdbUtils'
 
 const hasAllowedResiduesOnly = (
   file: File
@@ -594,6 +595,31 @@ const detectGaffCofactors = (file: File): Promise<string[]> =>
 const detectMetalCofactors = (file: File): Promise<string[]> =>
   _detectResiduesFromSet(file, METAL_COFACTORS)
 
+// Detect a structure whose B-factor/pLDDT column is entirely zero. Some
+// preparation tools (e.g. protonation) strip pLDDT, which silently breaks
+// rigid-body detection for auto jobs. Reuses the shared pLDDT parsers.
+const isPlddtColumnAllZero = (file: File): Promise<boolean> => {
+  return new Promise((resolve) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const text = e.target?.result as string | undefined
+      if (!text) {
+        resolve(false)
+        return
+      }
+      const isCif = file.name.toLowerCase().endsWith('.cif')
+      const { data } = isCif
+        ? parsePLDDTFromCIF(text)
+        : parsePLDDTFromPDB(text)
+      // Only warn when we actually parsed residues and every one is zero.
+      resolve(data.length > 0 && data.every((d) => d.plddt === 0))
+    }
+    // On read error, don't block or warn — other validators handle bad files.
+    reader.onerror = () => resolve(false)
+    reader.readAsText(file)
+  })
+}
+
 export {
   fromCharmmGui,
   isCRD,
@@ -611,6 +637,7 @@ export {
   isValidConstInpFile,
   hasAllowedResiduesOnly,
   detectGaffCofactors,
-  detectMetalCofactors
+  detectMetalCofactors,
+  isPlddtColumnAllZero
 }
 export type { SaxsQualityResult }

--- a/apps/ui/src/schemas/__tests__/ValidationFunctions.test.ts
+++ b/apps/ui/src/schemas/__tests__/ValidationFunctions.test.ts
@@ -14,7 +14,8 @@ import {
   cifHasAllowedResiduesOnly,
   noLeadingSpaceOnPDBLines,
   detectGaffCofactors,
-  detectMetalCofactors
+  detectMetalCofactors,
+  isPlddtColumnAllZero
 } from '../ValidationFunctions'
 
 const makeFile = (name: string, content: string, type = 'text/plain') => {
@@ -529,5 +530,82 @@ describe('hasSaxsQualityIssues', () => {
     )
 
     expect(result.totalCount).toBe(1)
+  })
+})
+
+// Build an 80-column PDB ATOM record with the B-factor placed in cols 61-66.
+const pdbAtomLine = (
+  serial: number,
+  resSeq: number,
+  bfactor: number,
+  chain = 'A'
+): string => {
+  const line = Array(80).fill(' ')
+  const put = (start: number, str: string) => {
+    for (let i = 0; i < str.length; i++) line[start + i] = str[i]
+  }
+  put(0, 'ATOM')
+  put(6, String(serial).padStart(5))
+  put(12, ' CA ')
+  put(17, 'ALA')
+  put(21, chain)
+  put(22, String(resSeq).padStart(4))
+  put(30, '   0.000')
+  put(38, '   0.000')
+  put(46, '   0.000')
+  put(54, '  1.00')
+  put(60, bfactor.toFixed(2).padStart(6))
+  put(76, ' C')
+  return line.join('')
+}
+
+const makePdb = (bfactors: number[]): string =>
+  bfactors
+    .map((b, i) => pdbAtomLine(i + 1, i + 1, b))
+    .concat('END')
+    .join('\n')
+
+const makeCif = (bfactors: number[]): string =>
+  [
+    'data_test',
+    'loop_',
+    '_atom_site.group_PDB',
+    '_atom_site.id',
+    '_atom_site.label_comp_id',
+    '_atom_site.auth_asym_id',
+    '_atom_site.auth_seq_id',
+    '_atom_site.B_iso_or_equiv',
+    ...bfactors.map((b, i) => `ATOM ${i + 1} ALA A ${i + 1} ${b.toFixed(2)}`),
+    '#'
+  ].join('\n')
+
+describe('isPlddtColumnAllZero', () => {
+  it('returns true when every PDB B-factor is zero', async () => {
+    const file = makeFile('model.pdb', makePdb([0, 0, 0]))
+    expect(await isPlddtColumnAllZero(file)).toBe(true)
+  })
+
+  it('returns false when PDB B-factors carry pLDDT', async () => {
+    const file = makeFile('model.pdb', makePdb([80, 75, 90]))
+    expect(await isPlddtColumnAllZero(file)).toBe(false)
+  })
+
+  it('returns false when only some PDB B-factors are zero', async () => {
+    const file = makeFile('model.pdb', makePdb([0, 80, 0]))
+    expect(await isPlddtColumnAllZero(file)).toBe(false)
+  })
+
+  it('returns true when every CIF B_iso_or_equiv is zero', async () => {
+    const file = makeFile('model.cif', makeCif([0, 0, 0]))
+    expect(await isPlddtColumnAllZero(file)).toBe(true)
+  })
+
+  it('returns false when CIF B_iso_or_equiv carries pLDDT', async () => {
+    const file = makeFile('model.cif', makeCif([88, 90, 70]))
+    expect(await isPlddtColumnAllZero(file)).toBe(false)
+  })
+
+  it('returns false for an empty or unparseable file (no warning)', async () => {
+    expect(await isPlddtColumnAllZero(makeFile('empty.pdb', ''))).toBe(false)
   })
 })

--- a/tools/python/pae2const.py
+++ b/tools/python/pae2const.py
@@ -62,6 +62,25 @@ class PDBHandler(InputHandler):
     def __init__(self):
         self.pdb_index_to_res = []
         self.pdb_res_plddt = defaultdict(list)
+        # Ordered (chain_id, resseq) for each non-hydrogen atom, in file order.
+        # Used to align AlphaFold3 JSON `atom_plddts` (heavy atoms) to residues
+        # when the structure's B-factor column lacks pLDDT (all zeros).
+        self.pdb_heavy_atom_res = []
+
+    @staticmethod
+    def _is_hydrogen_pdb_atom(line: str) -> bool:
+        """
+        Decide whether a PDB ATOM/HETATM line describes a hydrogen.
+        Prefers the element column (cols 77-78); falls back to the atom name
+        (cols 13-16) when the element is blank.
+        """
+        element = line[76:78].strip().upper() if len(line) >= 78 else ""
+        if element:
+            return element == "H"
+        # Fall back to the atom name. Strip leading digits/altloc spacing.
+        name = line[12:16].strip()
+        name = name.lstrip("0123456789")
+        return name[:1].upper() == "H"
 
     def _prepare_pdb_mappings(self, pdb_file: str) -> int:
         """
@@ -69,7 +88,8 @@ class PDBHandler(InputHandler):
         pdb_res_plddt (per-residue list of B-factors which hold pLDDT).
         Returns the number of residues discovered.
 
-        This populates self.pdb_index_to_res and self.pdb_res_plddt.
+        This populates self.pdb_index_to_res, self.pdb_res_plddt and
+        self.pdb_heavy_atom_res.
         """
         pdb_path = Path(pdb_file)
         if not pdb_path.exists():
@@ -77,6 +97,7 @@ class PDBHandler(InputHandler):
 
         self.pdb_index_to_res.clear()
         self.pdb_res_plddt.clear()
+        self.pdb_heavy_atom_res.clear()
         seen_res = set()  # Track first atom per residue to build index ordering
 
         with open(pdb_path, "r", encoding="utf-8") as fh:
@@ -103,6 +124,10 @@ class PDBHandler(InputHandler):
                 except ValueError:
                     pass
 
+                # Track heavy atoms (in file order) to align with AF3 atom_plddts
+                if not self._is_hydrogen_pdb_atom(line):
+                    self.pdb_heavy_atom_res.append((chain_id, resseq))
+
                 # Use (chain, resseq, icode) to identify first occurrence order
                 key = (chain_id, resseq, icode)
                 if key not in seen_res:
@@ -110,6 +135,49 @@ class PDBHandler(InputHandler):
                     self.pdb_index_to_res.append((chain_id, resseq))
 
         return len(self.pdb_index_to_res)
+
+    def bfactors_all_zero(self) -> bool:
+        """
+        True iff per-residue B-factor (pLDDT) data has been populated and every
+        recorded B-factor is exactly zero. Used to decide whether to recover
+        pLDDT from an AlphaFold3-style PAE JSON.
+        """
+        if not self.pdb_res_plddt:
+            return False
+        return all(
+            b == 0.0 for vals in self.pdb_res_plddt.values() for b in vals
+        )
+
+    def apply_plddt_from_atom_array(self, atom_plddts: List[float]) -> bool:
+        """
+        Repopulate per-residue pLDDT (self.pdb_res_plddt) from a per-heavy-atom
+        pLDDT array (e.g. AlphaFold3 JSON `atom_plddts`), aligning by file order.
+
+        Returns True if the array was applied, False if it could not be aligned
+        (length mismatch with the heavy-atom count) — in which case existing
+        per-residue data is left unchanged.
+        """
+        n_heavy = len(self.pdb_heavy_atom_res)
+        if not atom_plddts or n_heavy == 0:
+            print(
+                "[plddt-fallback] No heavy atoms or empty atom_plddts; cannot recover pLDDT."
+            )
+            return False
+        if len(atom_plddts) != n_heavy:
+            print(
+                f"[plddt-fallback] atom_plddts length ({len(atom_plddts)}) does not match "
+                f"heavy-atom count ({n_heavy}); skipping pLDDT recovery."
+            )
+            return False
+
+        new_res_plddt = defaultdict(list)
+        for (chain_id, resseq), plddt in zip(self.pdb_heavy_atom_res, atom_plddts):
+            try:
+                new_res_plddt[(chain_id, resseq)].append(float(plddt))
+            except (ValueError, TypeError):
+                pass
+        self.pdb_res_plddt = new_res_plddt
+        return True
 
     def get_first_and_last_residue_numbers(self, pdb_file: str) -> Tuple[int, int]:
         """
@@ -239,6 +307,7 @@ class CIFHandler(PDBHandler):
 
         self.pdb_index_to_res.clear()
         self.pdb_res_plddt.clear()
+        self.pdb_heavy_atom_res.clear()
         seen_res = set()
 
         for model in structure:
@@ -257,6 +326,15 @@ class CIFHandler(PDBHandler):
                             self.pdb_res_plddt[(chain_id, resseq)].append(b)
                         except (ValueError, AttributeError):
                             pass
+                        # Track heavy atoms (in file order) to align with AF3
+                        # atom_plddts when B-factors lack pLDDT.
+                        element = (getattr(atom, "element", "") or "").strip().upper()
+                        if not element:
+                            element = atom.get_name().strip().lstrip(
+                                "0123456789"
+                            )[:1].upper()
+                        if element != "H":
+                            self.pdb_heavy_atom_res.append((chain_id, resseq))
 
         return len(self.pdb_index_to_res)
 
@@ -682,6 +760,51 @@ class PAEProcessor:
         Delegates to the input handler.
         """
         return self.input_handler.define_segments(file)
+
+    def maybe_recover_plddt_from_json(self) -> bool:
+        """
+        Recover per-residue pLDDT from the loaded PAE JSON when the structure's
+        B-factor column is all zeros.
+
+        Rigid-body detection gates on per-residue pLDDT read from the structure's
+        B-factor column. Some preparation tools (e.g. protonation) zero that
+        column, which would silently yield no rigid bodies. AlphaFold3-style PAE
+        JSON carries per-heavy-atom pLDDT in `atom_plddts`; align it to the
+        structure's heavy atoms (file order) to restore per-residue pLDDT.
+
+        Only applies to PDB/CIF inputs. Returns True if pLDDT was recovered.
+        """
+        if not isinstance(self.input_handler, PDBHandler):
+            return False
+        if not self.input_handler.bfactors_all_zero():
+            return False
+
+        atom_plddts = (
+            self.pae_data.get("atom_plddts")
+            if isinstance(self.pae_data, dict)
+            else None
+        )
+        if not atom_plddts:
+            print(
+                "[plddt-fallback] Structure B-factor (pLDDT) column is all zeros and the "
+                "PAE JSON has no 'atom_plddts'; no rigid bodies can be defined. "
+                "Re-submit with a structure that retains pLDDT in the B-factor column "
+                "(e.g. the original AlphaFold CIF) or an AlphaFold3-style PAE JSON."
+            )
+            return False
+
+        print(
+            "[plddt-fallback] Structure B-factor (pLDDT) column is all zeros; "
+            "recovering per-residue pLDDT from PAE JSON 'atom_plddts'."
+        )
+        recovered = self.input_handler.apply_plddt_from_atom_array(atom_plddts)
+        if recovered:
+            print(
+                f"[plddt-fallback] Recovered pLDDT for "
+                f"{len(self.input_handler.pdb_res_plddt)} residues from "
+                f"{len(atom_plddts)} heavy-atom values."
+            )
+        return recovered
 
     def define_clusters(self):
         row_start = self.first_residue - 1
@@ -1997,6 +2120,10 @@ if __name__ == "__main__":
 
     # Validate that input structure and PAE matrix align before proceeding
     processor.validate_alignment()
+
+    # If the structure lost its pLDDT (all-zero B-factors), recover it from the
+    # AlphaFold3-style PAE JSON before rigid bodies are defined.
+    processor.maybe_recover_plddt_from_json()
 
     # Define clusters and rigid bodies using processor methods
     processor.define_clusters()

--- a/tools/python/python_tests/test_pae2const.py
+++ b/tools/python/python_tests/test_pae2const.py
@@ -1,0 +1,210 @@
+# tools/python/python_tests/test_pae2const.py
+"""
+Tests for the pLDDT-recovery fallback in pae2const.py.
+
+When a structure's B-factor column is all zeros (e.g. pLDDT stripped during
+protonation), rigid-body detection silently fails. These tests cover recovering
+per-residue pLDDT from an AlphaFold3-style PAE JSON `atom_plddts` array.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+# pae2const.py uses bare sibling imports (`from helpers_viz import ...`), so make
+# the tools/python directory importable and load it as a top-level module — the
+# same import context it runs under as a script.
+_TOOLS_PYTHON = Path(__file__).resolve().parents[1]
+if str(_TOOLS_PYTHON) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_PYTHON))
+
+import pae2const  # noqa: E402
+
+
+# --- PDB synthesis helpers ---------------------------------------------------
+
+# Heavy backbone atoms written per residue, plus one hydrogen.
+_HEAVY_ATOMS = [("N", "N"), ("CA", "C"), ("C", "C"), ("O", "O")]
+_H_ATOM = ("H", "H")
+
+
+def _atom_line(serial, name, resname, chain, resseq, bfac, element):
+    """Build a fixed-column PDB ATOM record."""
+    name_field = name if len(name) >= 4 else f" {name:<3}"
+    return (
+        f"ATOM  {serial:5d} {name_field}{' '}{resname:<3} {chain}{resseq:4d}"
+        f"    {0.0:8.3f}{0.0:8.3f}{0.0:8.3f}{1.0:6.2f}{bfac:6.2f}"
+        f"          {element:>2}\n"
+    )
+
+
+def _write_pdb(path, n_res=20, chain="A", bfac=0.0, with_hydrogens=True):
+    """Write a single-chain PDB with backbone heavy atoms (+ optional H)."""
+    serial = 1
+    with open(path, "w", encoding="utf-8") as fh:
+        for resseq in range(1, n_res + 1):
+            atoms = list(_HEAVY_ATOMS)
+            if with_hydrogens:
+                atoms.append(_H_ATOM)
+            for name, element in atoms:
+                fh.write(
+                    _atom_line(serial, name, "ALA", chain, resseq, bfac, element)
+                )
+                serial += 1
+        fh.write("END\n")
+
+
+def _heavy_atom_plddts(n_res=20, value=80.0):
+    """One pLDDT per heavy atom (4 per residue), matching _write_pdb ordering."""
+    return [value] * (len(_HEAVY_ATOMS) * n_res)
+
+
+# --- Tests -------------------------------------------------------------------
+
+def test_heavy_atom_tracking_skips_hydrogens():
+    with tempfile.TemporaryDirectory() as d:
+        pdb = Path(d) / "m.pdb"
+        _write_pdb(pdb, n_res=20, with_hydrogens=True)
+        h = pae2const.PDBHandler()
+        n = h._prepare_pdb_mappings(str(pdb))
+        assert n == 20  # residues
+        # 4 heavy atoms per residue, hydrogens excluded
+        assert len(h.pdb_heavy_atom_res) == 80
+        assert all(seg == "A" for seg, _ in h.pdb_heavy_atom_res)
+
+
+def test_bfactors_all_zero_detection():
+    with tempfile.TemporaryDirectory() as d:
+        zero = Path(d) / "zero.pdb"
+        nonzero = Path(d) / "nonzero.pdb"
+        _write_pdb(zero, bfac=0.0)
+        _write_pdb(nonzero, bfac=75.0)
+
+        hz = pae2const.PDBHandler()
+        hz._prepare_pdb_mappings(str(zero))
+        assert hz.bfactors_all_zero() is True
+
+        hn = pae2const.PDBHandler()
+        hn._prepare_pdb_mappings(str(nonzero))
+        assert hn.bfactors_all_zero() is False
+
+        # Empty handler (no mappings) must not report all-zero.
+        assert pae2const.PDBHandler().bfactors_all_zero() is False
+
+
+def test_apply_plddt_from_atom_array_repopulates():
+    with tempfile.TemporaryDirectory() as d:
+        pdb = Path(d) / "m.pdb"
+        _write_pdb(pdb, n_res=20, bfac=0.0)
+        h = pae2const.PDBHandler()
+        h._prepare_pdb_mappings(str(pdb))
+        assert h.bfactors_all_zero() is True
+
+        ok = h.apply_plddt_from_atom_array(_heavy_atom_plddts(20, 80.0))
+        assert ok is True
+        assert h.bfactors_all_zero() is False
+        # Per-residue average should now equal the recovered value.
+        avg = h.calculate_bfactor_avg_for_region(str(pdb), 0, 19, 1)
+        assert abs(avg - 80.0) < 1e-6
+
+
+def test_apply_plddt_mismatch_is_rejected():
+    with tempfile.TemporaryDirectory() as d:
+        pdb = Path(d) / "m.pdb"
+        _write_pdb(pdb, n_res=20, bfac=0.0)
+        h = pae2const.PDBHandler()
+        h._prepare_pdb_mappings(str(pdb))
+
+        # Wrong length (heavy count is 80) → rejected, data unchanged.
+        ok = h.apply_plddt_from_atom_array([80.0, 80.0, 80.0])
+        assert ok is False
+        assert h.bfactors_all_zero() is True
+
+
+def test_maybe_recover_plddt_end_to_end_yields_rigid_bodies():
+    """All-zero B-factors + atom_plddts in JSON should produce a rigid body
+    where the un-recovered baseline produces none."""
+    n_res = 20
+    with tempfile.TemporaryDirectory() as d:
+        pdb = Path(d) / "m.pdb"
+        _write_pdb(pdb, n_res=n_res, bfac=0.0)
+
+        # Low-PAE matrix → a single confident cluster spanning the chain.
+        pae = [[1.0 for _ in range(n_res)] for _ in range(n_res)]
+        pae_data = {"pae": pae, "atom_plddts": _heavy_atom_plddts(n_res, 90.0)}
+
+        def build_processor():
+            cfg = pae2const.PAEConfig(plddt_cutoff=50.0)
+            p = pae2const.PAEProcessor(config=cfg)
+            p.input_handler = pae2const.PDBHandler()
+            p.input_file = str(pdb)
+            p.pae_data = pae_data
+            p.first_residue, p.last_residue = (
+                p.get_first_and_last_residue_numbers(str(pdb))
+            )
+            p.chain_segments = p.define_segments(str(pdb))
+            return p
+
+        # Baseline: no recovery → every region fails the pLDDT gate.
+        baseline = build_processor()
+        baseline.define_clusters()
+        baseline.define_rigid_bodies()
+        assert baseline.rigid_bodies == []
+
+        # With recovery: pLDDT restored from atom_plddts → rigid body emerges.
+        recovered = build_processor()
+        assert recovered.maybe_recover_plddt_from_json() is True
+        recovered.define_clusters()
+        recovered.define_rigid_bodies()
+        assert len(recovered.rigid_bodies) >= 1
+
+
+def test_maybe_recover_noop_without_atom_plddts():
+    n_res = 20
+    with tempfile.TemporaryDirectory() as d:
+        pdb = Path(d) / "m.pdb"
+        _write_pdb(pdb, n_res=n_res, bfac=0.0)
+        cfg = pae2const.PAEConfig(plddt_cutoff=50.0)
+        p = pae2const.PAEProcessor(config=cfg)
+        p.input_handler = pae2const.PDBHandler()
+        p.input_file = str(pdb)
+        p.pae_data = {"pae": [[1.0] * n_res for _ in range(n_res)]}  # no atom_plddts
+        p.first_residue, p.last_residue = p.get_first_and_last_residue_numbers(str(pdb))
+        p.chain_segments = p.define_segments(str(pdb))
+        assert p.maybe_recover_plddt_from_json() is False
+
+
+def test_maybe_recover_noop_when_bfactors_present():
+    n_res = 20
+    with tempfile.TemporaryDirectory() as d:
+        pdb = Path(d) / "m.pdb"
+        _write_pdb(pdb, n_res=n_res, bfac=88.0)  # real pLDDT present
+        cfg = pae2const.PAEConfig(plddt_cutoff=50.0)
+        p = pae2const.PAEProcessor(config=cfg)
+        p.input_handler = pae2const.PDBHandler()
+        p.input_file = str(pdb)
+        p.pae_data = {
+            "pae": [[1.0] * n_res for _ in range(n_res)],
+            "atom_plddts": _heavy_atom_plddts(n_res, 10.0),
+        }
+        p.first_residue, p.last_residue = p.get_first_and_last_residue_numbers(str(pdb))
+        p.chain_segments = p.define_segments(str(pdb))
+        # B-factors are non-zero, so recovery must not run / overwrite.
+        assert p.maybe_recover_plddt_from_json() is False
+        avg = p.input_handler.calculate_bfactor_avg_for_region(str(pdb), 0, 0, 1)
+        assert abs(avg - 88.0) < 1e-6
+
+
+if __name__ == "__main__":
+    # Allow running without pytest: `python test_pae2const.py`
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL {fn.__name__}: {exc!r}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

Fixes BilboMD `auto` jobs silently producing **zero** `fixed_bodies`/`rigid_bodies`
(empty `openmm_const.yml`) when the uploaded structure's B-factor column is all zeros.

`tools/python/pae2const.py` reads per-residue pLDDT **only** from the B-factor column;
the gate `bfactor_avg > plddt_cutoff (50)` in `define_rigid_bodies()` never passes when
B-factors are `0.0`, so all rigid bodies are dropped — even for high-confidence models.
The pLDDT isn't actually lost: AlphaFold3-style PAE JSON carries it in `atom_plddts`.

Reproduced with prod job `4ace87c1-b653-4a07-995f-bee84bcf22a2`
(`num_clusters: 16`, `num_rigid_bodies: 0`).

## Changes

**Backend (`@bilbomd/worker`, `tools/python/pae2const.py`)**
- `PDBHandler`/`CIFHandler` track heavy atoms (hydrogens skipped) and expose
  `bfactors_all_zero()` + `apply_plddt_from_atom_array()`.
- `PAEProcessor.maybe_recover_plddt_from_json()` recovers per-residue pLDDT from
  `atom_plddts` via heavy-atom-order alignment when B-factors are all zero; wired into
  `__main__` before clustering. Logs the recovery (and warns when neither the B-factor
  column nor the JSON carry pLDDT). Guards against count mismatch.
- New `tools/python/python_tests/test_pae2const.py` (7 tests).

**Frontend (`@bilbomd/ui`)**
- `isPlddtColumnAllZero()` (reuses `parsePLDDTFromPDB`/`parsePLDDTFromCIF`), wired into the
  `onFileChange` of `NewAutoJobForm` and `ResubmitAutoJobForm` as a non-blocking warning
  that mentions automatic AF3 recovery, composed alongside the existing metal-cofactor
  warning.
- New `ValidationFunctions` test coverage (6 cases).

## Verification

- End-to-end on the failing job inputs: `num_rigid_bodies` **0 → 1**
  (FixedBody1, 4 domains, avg pLDDT ~92, median PAE ~2.2 Å).
- `pnpm -F @bilbomd/ui lint` ✅ · `build` ✅ · full `pnpm test` ✅ (8/8 tasks, UI 1107/1107).
- Python: `test_pae2const.py` 7/7 (run under the `omm-pae` env with igraph/numpy/biopython;
  Python tests aren't part of `pnpm test`/CI).

## Notes

- AF2-style JSON (no `atom_plddts`) is unaffected — recovery triggers only when B-factors
  are all zero **and** `atom_plddts` is present.
- Changesets included: `@bilbomd/ui` (patch), `@bilbomd/worker` (patch).

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)
