### PR TITLE
fix(backend): skip Swagger JSON write on read-only prod filesystem

### DIFF
--- a/.changeset/backend-swagger-readonly-fs.md
+++ b/.changeset/backend-swagger-readonly-fs.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/backend': patch
+---
+
+Skip the non-fatal Swagger JSON archival write in production. The hardened container runs with a read-only root filesystem, so the write always failed with EACCES and logged a warning on every startup. The in-memory OpenAPI spec served at runtime is unaffected; the snapshot is now only written outside production.

--- a/apps/backend/src/openapi/swagger.ts
+++ b/apps/backend/src/openapi/swagger.ts
@@ -158,10 +158,14 @@ export default swaggerSpec
 
 // This json file is written purely as an archival record of the API.
 // It is not used by the application at runtime, so failure is non-fatal.
-try {
-  const outputPath = path.resolve('dist/openapi/v1/swagger_v1.json')
-  fs.writeFileSync(outputPath, JSON.stringify(swaggerSpec, null, 2))
-  logger.info(`Swagger file written to ${outputPath}`)
-} catch (err) {
-  logger.warn('Failed to write Swagger JSON (non-fatal):', err)
+// Skip in production: the hardened container runs with a read-only root
+// filesystem, so the write would always fail with EACCES and add log noise.
+if (process.env.NODE_ENV !== 'production') {
+  try {
+    const outputPath = path.resolve('dist/openapi/v1/swagger_v1.json')
+    fs.writeFileSync(outputPath, JSON.stringify(swaggerSpec, null, 2))
+    logger.info(`Swagger file written to ${outputPath}`)
+  } catch (err) {
+    logger.warn('Failed to write Swagger JSON (non-fatal):', err)
+  }
 }


### PR DESCRIPTION
## Summary

The backend logs a recurring non-fatal warning on every startup in production:

```
Failed to write Swagger JSON (non-fatal): EACCES: permission denied, open '/app/dist/openapi/v1/swagger_v1.json'
```

### Root cause

`apps/backend/src/openapi/swagger.ts` writes an archival copy of the OpenAPI spec to disk as an import side-effect. In production, the container runs with a **read-only root filesystem** (`read_only: true` in `docker-compose-epyc.prod.yml` / `.dev.yml`, with `tmpfs` mounts only for paths that need to be writable). `/app/dist` is not writable, so the write always fails with `EACCES`. It's caught and non-fatal, but logs a warning every time.

### Fix

Gate the write behind `NODE_ENV !== 'production'`. The snapshot is purely an archival artifact useful in dev/local; nothing reads `swagger_v1.json` at runtime, and the in-memory spec served by Swagger UI / the OpenAPI route is unaffected (`export default swaggerSpec` runs before the write).

## Verification

- `pnpm -F @bilbomd/backend lint` — clean
- `pnpm -F @bilbomd/backend build` — succeeds
- `pnpm -F @bilbomd/backend test` — 463 passed (38 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)