### PR TITLE
fix(backend): support HTTP / no-proxy deployments (configurable Secure cookies + public URL docs)

### DIFF
--- a/.changeset/allowed-origins-explicit-port.md
+++ b/.changeset/allowed-origins-explicit-port.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/backend': patch
+---
+
+Avoid deriving an invalid CORS origin when `BILBOMD_URL` already includes an explicit port. Previously the allowed-origins list always appended `:BILBOMD_UI_PORT`, producing junk entries like `http://localhost:3001:3001` for no-proxy installs that set `BILBOMD_URL=http://localhost:3001`. The port is now only appended when `BILBOMD_URL` has no port of its own.

--- a/.changeset/configurable-cookie-secure.md
+++ b/.changeset/configurable-cookie-secure.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/backend': patch
+---
+
+Add a `COOKIE_SECURE` environment variable to control the `Secure` attribute on auth and session cookies. Browsers silently drop `Secure` cookies over plain HTTP, which broke login, token refresh, and ORCID for installs accessed via `http://` (e.g. `http://localhost:3001` with no TLS-terminating proxy). The flag defaults to the previous behavior (`Secure` when `BILBOMD_ENV=production`); set `COOKIE_SECURE=false` to allow cookies over HTTP. This also unifies the secure-cookie logic across the refresh-token, session, and ORCID cookies, which previously read inconsistent env vars (`BILBOMD_ENV` vs `NODE_ENV`).

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -17,7 +17,7 @@ import { connectDB } from './config/dbConn.js'
 import { initOrcidClient } from './controllers/auth/orcidClientConfig.js'
 import { CronJob } from 'cron'
 import { deleteOldJobs } from './middleware/jobCleaner.js'
-import { config, getEnvVar } from './config/config.js'
+import { config, getEnvVar, isCookieSecure } from './config/config.js'
 import sfapiRoutes from './routes/sfapi.js'
 import registerRoutes from './routes/register.js'
 import verifyRoutes from './routes/verify.js'
@@ -101,7 +101,7 @@ app.use(
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production', // true if HTTPS
+      secure: isCookieSecure(), // HTTPS-only unless COOKIE_SECURE=false
       maxAge: 1000 * 60 * 15 // 15 minutes
     }
   })

--- a/apps/backend/src/config/allowedOrigins.ts
+++ b/apps/backend/src/config/allowedOrigins.ts
@@ -35,7 +35,17 @@ const bilbomdUrl = process.env.BILBOMD_URL
 const bilbomdUiPort = process.env.BILBOMD_UI_PORT
 if (bilbomdUrl) {
   allowedOrigins.push(bilbomdUrl)
-  if (bilbomdUiPort) {
+  // Only append the UI port when BILBOMD_URL has no explicit port of its own.
+  // If it already does (e.g. http://localhost:3001 for a no-proxy install),
+  // appending would produce an invalid origin like http://localhost:3001:3001.
+  const hasExplicitPort = (() => {
+    try {
+      return new URL(bilbomdUrl).port !== ''
+    } catch {
+      return false
+    }
+  })()
+  if (bilbomdUiPort && !hasExplicitPort) {
     allowedOrigins.push(`${bilbomdUrl}:${bilbomdUiPort}`)
   }
 }

--- a/apps/backend/src/config/config.ts
+++ b/apps/backend/src/config/config.ts
@@ -16,6 +16,22 @@ const getEnvVarWithDefault = (name: string, defaultValue: string): string => {
   return process.env[name] || defaultValue
 }
 
+/**
+ * Whether auth/session cookies should carry the `Secure` attribute (HTTPS-only).
+ *
+ * Browsers silently drop `Secure` cookies over plain HTTP, which breaks login,
+ * token refresh, and the ORCID OAuth flow for installs accessed via http://
+ * (e.g. http://localhost:3001 with no TLS-terminating proxy in front).
+ *
+ * Defaults to the previous behavior (`Secure` when BILBOMD_ENV=production). Set
+ * COOKIE_SECURE=false to allow cookies over HTTP on such deployments, or
+ * COOKIE_SECURE=true to force `Secure` regardless of BILBOMD_ENV.
+ */
+export const isCookieSecure = (): boolean =>
+  process.env.COOKIE_SECURE !== undefined
+    ? toBoolean(process.env.COOKIE_SECURE)
+    : process.env.BILBOMD_ENV === 'production'
+
 export const config = {
   sendEmailNotifications: toBoolean(process.env.SEND_EMAIL_NOTIFICATIONS),
   bullmqAttempts: process.env.BULLMQ_ATTEMPTS

--- a/apps/backend/src/controllers/auth/__tests__/authController.test.ts
+++ b/apps/backend/src/controllers/auth/__tests__/authController.test.ts
@@ -3,7 +3,8 @@ import type { Request, Response } from 'express'
 
 vi.mock('../../../config/config.js', () => ({
   config: { logLevel: 'info', sendEmailNotifications: false },
-  getEnvVar: vi.fn().mockReturnValue('test-secret')
+  getEnvVar: vi.fn().mockReturnValue('test-secret'),
+  isCookieSecure: vi.fn(() => false)
 }))
 
 vi.mock('@bilbomd/mongodb-schema', () => ({

--- a/apps/backend/src/controllers/auth/__tests__/authTokens.test.ts
+++ b/apps/backend/src/controllers/auth/__tests__/authTokens.test.ts
@@ -5,7 +5,8 @@ import type { IUser } from '@bilbomd/mongodb-schema'
 
 vi.mock('../../../config/config.js', () => ({
   config: { logLevel: 'info', sendEmailNotifications: false },
-  getEnvVar: vi.fn().mockReturnValue('test-secret')
+  getEnvVar: vi.fn().mockReturnValue('test-secret'),
+  isCookieSecure: vi.fn(() => false)
 }))
 
 import { issueTokensAndSetCookie } from '../authTokens.js'

--- a/apps/backend/src/controllers/auth/__tests__/handleOrcidLogin.test.ts
+++ b/apps/backend/src/controllers/auth/__tests__/handleOrcidLogin.test.ts
@@ -3,7 +3,8 @@ import type { Request, Response } from 'express'
 
 vi.mock('../../../config/config.js', () => ({
   config: { logLevel: 'info', sendEmailNotifications: false },
-  getEnvVar: vi.fn().mockReturnValue('test-secret')
+  getEnvVar: vi.fn().mockReturnValue('test-secret'),
+  isCookieSecure: vi.fn(() => true)
 }))
 
 const { buildAuthorizationUrlMock, randomStateMock, randomNonceMock } =

--- a/apps/backend/src/controllers/auth/authController.ts
+++ b/apps/backend/src/controllers/auth/authController.ts
@@ -3,7 +3,7 @@ import jwt from 'jsonwebtoken'
 import { User, IUser } from '@bilbomd/mongodb-schema'
 import { Request, Response } from 'express'
 import { issueTokensAndSetCookie } from './authTokens.js'
-import { getEnvVar } from '../../config/config.js'
+import { getEnvVar, isCookieSecure } from '../../config/config.js'
 
 const refreshTokenSecret = getEnvVar('REFRESH_TOKEN_SECRET')
 
@@ -116,11 +116,10 @@ const logout = (req: Request, res: Response) => {
     return
   }
 
-  const isProduction = process.env.BILBOMD_ENV === 'production'
   res.clearCookie('jwt', {
     httpOnly: true,
     sameSite: 'lax',
-    secure: isProduction
+    secure: isCookieSecure()
   })
   res.json({ message: 'Cookie cleared' })
 }

--- a/apps/backend/src/controllers/auth/authTokens.ts
+++ b/apps/backend/src/controllers/auth/authTokens.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken'
 import { Response } from 'express'
 import { IUser } from '@bilbomd/mongodb-schema'
-import { getEnvVar } from '../../config/config.js'
+import { getEnvVar, isCookieSecure } from '../../config/config.js'
 import { userDisplayName } from './displayName.js'
 
 const accessTokenSecret = getEnvVar('ACCESS_TOKEN_SECRET')
@@ -34,11 +34,10 @@ export async function issueTokensAndSetCookie(
     { expiresIn: '7d' }
   )
 
-  const isProduction = process.env.BILBOMD_ENV === 'production'
   res.cookie('jwt', refreshToken, {
     httpOnly: true,
     sameSite: 'lax',
-    secure: isProduction,
+    secure: isCookieSecure(),
     maxAge: 7 * 24 * 60 * 60 * 1000
   })
 

--- a/apps/backend/src/controllers/auth/handleOrcidLogin.ts
+++ b/apps/backend/src/controllers/auth/handleOrcidLogin.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import { clientConfig, discovered } from './orcidClientConfig.js'
 import { buildAuthorizationUrl, randomState, randomNonce } from 'openid-client'
 import { logger } from '../../middleware/loggers.js'
+import { isCookieSecure } from '../../config/config.js'
 
 export async function handleOrcidLogin(req: Request, res: Response) {
   const state = randomState()
@@ -12,7 +13,7 @@ export async function handleOrcidLogin(req: Request, res: Response) {
   // half-finished OAuth flow can sit around.
   const cookieOptions = {
     httpOnly: true,
-    secure: true,
+    secure: isCookieSecure(),
     sameSite: 'lax' as const,
     maxAge: 5 * 60 * 1000
   }

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -21,6 +21,15 @@ BILBOMD_FQDN=localhost
 # This is the port that Apache/NGINX will be connecting to.
 BILBOMD_UI_PORT=3001
 
+# Auth/session cookies use the Secure attribute (HTTPS-only) by default when
+# BILBOMD_ENV=production. Browsers SILENTLY DROP Secure cookies over plain HTTP,
+# which breaks login, token refresh, and ORCID for installs accessed via http://
+# (e.g. http://localhost:3001 with no TLS-terminating proxy). If you run over
+# plain HTTP, set COOKIE_SECURE=false. Leave unset (or true) when serving over
+# HTTPS. Cookies sent without Secure travel unencrypted — only relax this on a
+# trusted/local network.
+# COOKIE_SECURE=false
+
 # Secrets for signing the JWT Tokens
 # run this command four times in a terminal with nodejs in the path:
 # node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -12,8 +12,8 @@ BILBOMD_DEPLOY_SITE=local
 BILBOMD_DEV_BIND_ADDR=127.0.0.1
 BILBOMD_BACKEND_PORT=3501
 # BILBOMD_URL is the EXACT public base URL users type into their browser, and is
-# used verbatim to build the links in verification / magic-link / OTP emails and
-# the ORCID redirect. Include the port if it is non-standard:
+# used verbatim to build the links in verification / magic-link / OTP emails.
+# Include the port if it is non-standard:
 #   - Behind a TLS reverse proxy:  https://your.domain        (443 implied)
 #   - Direct / no proxy:           http://localhost:3001      (port REQUIRED)
 # Do NOT rely on BILBOMD_UI_PORT to supply the port here — that is the host port
@@ -33,7 +33,7 @@ BILBOMD_UI_PORT=3001
 
 # Auth/session cookies use the Secure attribute (HTTPS-only) by default when
 # BILBOMD_ENV=production. Browsers SILENTLY DROP Secure cookies over plain HTTP,
-# which breaks login, token refresh, and ORCID for installs accessed via http://
+# which breaks login and token refresh for installs accessed via http://
 # (e.g. http://localhost:3001 with no TLS-terminating proxy). If you run over
 # plain HTTP, set COOKIE_SECURE=false. Leave unset (or true) when serving over
 # HTTPS. Cookies sent without Secure travel unencrypted — only relax this on a

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -11,9 +11,19 @@ LOG_LEVEL=debug
 BILBOMD_DEPLOY_SITE=local
 BILBOMD_DEV_BIND_ADDR=127.0.0.1
 BILBOMD_BACKEND_PORT=3501
-BILBOMD_URL=http://localhost
+# BILBOMD_URL is the EXACT public base URL users type into their browser, and is
+# used verbatim to build the links in verification / magic-link / OTP emails and
+# the ORCID redirect. Include the port if it is non-standard:
+#   - Behind a TLS reverse proxy:  https://your.domain        (443 implied)
+#   - Direct / no proxy:           http://localhost:3001      (port REQUIRED)
+# Do NOT rely on BILBOMD_UI_PORT to supply the port here — that is the host port
+# the UI is published on, which differs from the public port when a proxy is in
+# front (e.g. proxy on 443 -> container 3001). The two cannot be derived from
+# each other, so the full public URL must be stated explicitly.
+BILBOMD_URL=http://localhost:3001
 BILBOMD_FQDN=localhost
-# CORS: the UI origin (BILBOMD_URL:BILBOMD_UI_PORT) is allowed automatically.
+# CORS: the BILBOMD_URL origin is allowed automatically. If BILBOMD_URL has no
+# explicit port, the BILBOMD_URL:BILBOMD_UI_PORT combination is allowed too.
 # Add extra origins only if needed (comma-separated):
 # CORS_ALLOWED_ORIGINS=http://other-host:3001
 


### PR DESCRIPTION
## Summary

Fixes several issues third-party operators hit when deploying BilboMD **without** a TLS-terminating reverse proxy in front (i.e. accessed directly over plain HTTP, e.g. `http://localhost:3001`). Our beamline/NERSC deployments sit behind nginx on HTTPS, so these never surfaced internally.

### 1. Configurable `Secure` cookie attribute (`COOKIE_SECURE`)
Browsers **silently drop** `Secure` cookies over plain HTTP, which broke login, token refresh, and the session cookie for HTTP installs. Auth would appear to succeed, then fail ~2 min later when the short-lived access token expired and `/auth/refresh` found no cookie.

- New `isCookieSecure()` helper in `config.ts`, driven by `COOKIE_SECURE`.
- Defaults to the **previous behavior** (`Secure` when `BILBOMD_ENV=production`), so HTTPS deployments are unaffected.
- Set `COOKIE_SECURE=false` to allow cookies over HTTP on a trusted/local network.
- Unifies the secure-cookie logic across the refresh-token, session, and ORCID cookies, which previously read inconsistent env vars (`BILBOMD_ENV` vs `NODE_ENV`) or were hardcoded.

### 2. `BILBOMD_URL` must be the full public URL (incl. port)
Verification / magic-link / OTP email links are built verbatim from `BILBOMD_URL`. No-proxy installs left it as `http://localhost` (no port), so links pointed at port 80 where nothing listens.

- `.env.example` now documents that `BILBOMD_URL` is the exact public base URL — include the port for direct installs (`http://localhost:3001`), omit it behind a TLS proxy (`https://your.domain`). The example default is now `http://localhost:3001`.
- Note added explaining why the port can't be auto-derived from `BILBOMD_UI_PORT` (host port ≠ public port when proxied).

### 3. CORS origin guard
`allowedOrigins.ts` no longer appends `:BILBOMD_UI_PORT` when `BILBOMD_URL` already contains an explicit port, which previously produced an invalid origin like `http://localhost:3001:3001`.

## Operator guidance (HTTP / no-proxy install)
```bash
BILBOMD_URL=http://localhost:3001
COOKIE_SECURE=false
```

## Testing
- `pnpm -F @bilbomd/backend lint` — clean
- `pnpm -F @bilbomd/backend build` — succeeds
- `pnpm -F @bilbomd/backend test` — 463/463 pass

Changesets included (both `@bilbomd/backend` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)