### PR TITLE
chore(infra): single-string image refs in Helm values for Renovate tracking

### DIFF
--- a/infra/helm/templates/backend-deployment.yaml
+++ b/infra/helm/templates/backend-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - secretRef:
             name: sfapi-priv-key
             optional: false
-        image: "{{ .Values.backend.image.registry }}/{{ .Values.backend.image.owner }}/{{ with .Values.backend.image.user }}{{ . }}/{{ end }}{{ with .Values.backend.image.repository }}{{ . }}{{ end }}:{{ .Values.backend.image.tag }}"
+        image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
         imagePullPolicy: "{{ .Values.backend.image.pullPolicy }}"
         name: container-0
         ports:

--- a/infra/helm/templates/ui-deployment.yaml
+++ b/infra/helm/templates/ui-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - configMapRef:
             name: {{ .Values.namespace }}-ui-config
             optional: false
-        image: "{{ .Values.ui.image.registry }}/{{ .Values.ui.image.owner }}/{{ with .Values.ui.image.user }}{{ . }}/{{ end }}{{ with .Values.ui.image.repository }}{{ . }}{{ end }}{{ with .Values.ui.image.build }}{{ . }}{{ end }}:{{ .Values.ui.image.tag }}"
+        image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
         imagePullPolicy: "{{ .Values.ui.image.pullPolicy }}"
         name: container-0
         ports:

--- a/infra/helm/templates/worker-deployment.yaml
+++ b/infra/helm/templates/worker-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - secretRef:
             name: {{ .Values.namespace }}-secrets
             optional: false
-        image: "{{ .Values.worker.image.registry }}/{{ .Values.worker.image.owner }}/{{ with .Values.worker.image.user }}{{ . }}/{{ end }}{{ with .Values.worker.image.repository }}{{ . }}{{ end }}:{{ .Values.worker.image.tag }}"
+        image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
         imagePullPolicy: "{{ .Values.worker.image.pullPolicy }}"
         lifecycle:
           postStart:

--- a/infra/helm/values-dev.yaml
+++ b/infra/helm/values-dev.yaml
@@ -49,11 +49,7 @@ redis:
 ui:
   name: ui
   image:
-    registry: ghcr.io
-    owner: bl1231
-    user: null
-    repository: bilbomd-ui
-    build: null
+    repository: ghcr.io/bl1231/bilbomd-ui
     tag: 2.20.4
     pullPolicy: Always
     secret: ghcr
@@ -61,11 +57,7 @@ ui:
 backend:
   name: backend
   image:
-    registry: ghcr.io
-    owner: bl1231
-    user: null
-    repository: bilbomd-backend
-    build: null
+    repository: ghcr.io/bl1231/bilbomd-backend
     tag: 2.9.5
     pullPolicy: Always
     secret: ghcr
@@ -73,11 +65,7 @@ backend:
 worker:
   name: worker
   image:
-    registry: ghcr.io
-    owner: bl1231
-    user: null
-    repository: bilbomd-worker
-    build: null
+    repository: ghcr.io/bl1231/bilbomd-worker
     tag: 2.14.8
     pullPolicy: Always
     secret: ghcr

--- a/infra/helm/values-prod.yaml
+++ b/infra/helm/values-prod.yaml
@@ -49,11 +49,7 @@ redis:
 ui:
   name: ui
   image:
-    registry: ghcr.io
-    owner: bl1231
-    user: null
-    repository: bilbomd-ui
-    build: null
+    repository: ghcr.io/bl1231/bilbomd-ui
     tag: 2.20.4
     pullPolicy: Always
     secret: ghcr
@@ -61,11 +57,7 @@ ui:
 backend:
   name: backend
   image:
-    registry: ghcr.io
-    owner: bl1231
-    user: null
-    repository: bilbomd-backend
-    build: null
+    repository: ghcr.io/bl1231/bilbomd-backend
     tag: 2.9.5
     pullPolicy: Always
     secret: ghcr
@@ -73,11 +65,7 @@ backend:
 worker:
   name: worker
   image:
-    registry: ghcr.io
-    owner: bl1231
-    user: null
-    repository: bilbomd-worker
-    build: null
+    repository: ghcr.io/bl1231/bilbomd-worker
     tag: 2.14.8
     pullPolicy: Always
     secret: ghcr

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,19 @@
   "ignorePaths": [
     "apps/scoper/bilbomd-scoper-base.dockerfile"
   ],
+  "helm-values": {
+    "managerFilePatterns": [
+      "/infra/helm/values.*\\.yaml$/"
+    ]
+  },
   "packageRules": [
+    {
+      "description": "Group container image updates across compose and helm into one PR",
+      "matchManagers": ["docker-compose", "helm-values"],
+      "matchDatasources": ["docker"],
+      "groupName": "container images",
+      "groupSlug": "container-images"
+    },
     {
       "description": "Group all minor and patch npm updates into one PR",
       "matchManagers": ["npm"],


### PR DESCRIPTION
## Summary

Converts the Helm chart's image definitions from the split `registry` / `owner` / `user` / `repository` / `build` fields to a single fully-qualified `repository` string + `tag`, matching the docker-compose convention. This enables Renovate's built-in **`helm-values`** manager to monitor and bump the `ui`, `backend`, and `worker` images — previously it couldn't, because it can't stitch the split fields back into a full image reference.

## Changes

- **Templates** (`backend`/`ui`/`worker` deployments): image expression simplified to `"{{ .Values.<svc>.image.repository }}:{{ .Values.<svc>.image.tag }}"`. (mongo/redis already used this form.)
- **`values-dev.yaml` / `values-prod.yaml`**: each app image block now uses `repository: ghcr.io/bl1231/bilbomd-<svc>` + `tag`. Dropped the always-`null` `user`/`build` fields; kept `pullPolicy` and `secret`.
- **`renovate.json`**:
  - Extended `helm-values` manager to scan `infra/helm/values*.yaml` (its default only matches bare `values.yaml`, not the `-dev`/`-prod` files where images live).
  - Added a packageRule grouping `docker-compose` + `helm-values` docker bumps into one "container images" PR, so the duplicated versions don't open two PRs per release.

## Verification

- `helm template` for both dev and prod renders **byte-identical** image strings to before the change.
- `helm lint` passes (the pre-existing `mongo-backup-cronjob` metadata.name warning is unrelated).
- `renovate.json` validated as well-formed JSON.

Renovate will now track all five images (ui, backend, worker, mongo, redis) natively — no regex/customManager or inline annotations required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)