### PR TITLE
feat(infra): automate TLS renewal on NERSC Spin via Let's Encrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,10 @@ backend-dev-tmp
 .claude/settings.local.json
 .nfs*
 
+# tls-acme generated values (contain NERSC uid/gid and email)
+infra/tls-acme/values*.yaml
+infra/tls-acme/prepare-values.yaml
+
 # pae testing outputs
 tools/python/pae_testing/out
 

--- a/infra/HELM_NOTES.md
+++ b/infra/HELM_NOTES.md
@@ -132,7 +132,12 @@ The secrets needed include:
 
 - `bilbomd-secrets` - Contains various ENV setting needed by backend apps.
 - `mongo-secrets` - Contains the root password for the MongoDB database.
-- `ui-tls` - SSL/TLS certificate for the web frontend ui.
+- `ui-tls` - **Deprecated.** Manual InCommon SSL/TLS certificate for the web
+  frontend ui. TLS is now handled automatically by the `tls-acme` CronJob, which
+  renews a Let's Encrypt cert into the `tls-cert` secret every two months — see
+  [`infra/tls-acme/README.md`](./tls-acme/README.md). The `ui-tls`/`ui-tls-dev`
+  secrets are retained only for rollback and can be removed once Let's Encrypt is
+  confirmed stable in production.
 - `ghcr` - A GitHub Personal Access Token needed to pull docker images from `ghcr.io`.
 - `registry-nersc` - This secret is provided automatically by SPIN, and is required to pull images from `registry.nersc.gov`.
 - `sfapi-priv-key` - This contains the private key from our 30-day Superfacility API red client.
@@ -143,7 +148,7 @@ If you have local copies of the secrets as yaml files they can be "applied" to t
 kubectl apply -f helm-secrets/bilbomd-secrets.yaml
 kubectl apply -f helm-secrets/sfapi-priv-key.yaml
 kubectl apply -f helm-secrets/mongo-secrets.yaml
-kubectl apply -f helm-secrets/ui-tls-secrets.yaml
+kubectl apply -f helm-secrets/ui-tls-secrets.yaml   # legacy — superseded by tls-acme (see infra/tls-acme/)
 kubectl apply -f helm-secrets/ghcr.yaml
 ```
 

--- a/infra/helm/templates/ingress.yaml
+++ b/infra/helm/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   name: ingress
   namespace: bilbomd
 spec:
+  ingressClassName: nginx
   rules:
     - host: "{{ .Values.ingress.host }}"
       http:

--- a/infra/helm/values-dev.yaml
+++ b/infra/helm/values-dev.yaml
@@ -1,7 +1,10 @@
 ingress:
   host: 'ingress.bilbomd.development.svc.spin.nersc.org'
   fqdn: 'bilbomd-nersc-dev.bl1231.als.lbl.gov'
-  secret: 'ui-tls-dev'
+  # Let's Encrypt cert auto-renewed by the tls-acme CronJob (see infra/tls-acme/).
+  # Only flip to 'tls-cert' AFTER the initial cert job has populated the secret,
+  # otherwise the Ingress briefly serves the self-signed placeholder.
+  secret: 'tls-cert'
 
 bilbomd:
   url: 'https://bilbomd-nersc-dev.bl1231.als.lbl.gov'

--- a/infra/helm/values-prod.yaml
+++ b/infra/helm/values-prod.yaml
@@ -1,7 +1,10 @@
 ingress:
   host: 'ingress.bilbomd.production.svc.spin.nersc.org'
   fqdn: 'bilbomd-nersc.bl1231.als.lbl.gov'
-  secret: 'ui-tls'
+  # Let's Encrypt cert auto-renewed by the tls-acme CronJob (see infra/tls-acme/).
+  # Only flip to 'tls-cert' AFTER the initial cert job has populated the secret,
+  # otherwise the Ingress briefly serves the self-signed placeholder.
+  secret: 'tls-cert'
 
 bilbomd:
   url: 'https://bilbomd-nersc.bl1231.als.lbl.gov'

--- a/infra/tls-acme/README.md
+++ b/infra/tls-acme/README.md
@@ -1,0 +1,231 @@
+# TLS / HTTPS on NERSC Spin — bilbomd
+
+NERSC Spin does not run cert-manager. TLS for bilbomd is handled by the
+[NERSC/spin-helm tls-acme](https://github.com/NERSC/spin-helm/tree/main/tls-acme)
+chart, which runs a CronJob every two months to obtain/renew a Let's Encrypt
+certificate via the HTTP-01 ACME challenge and writes it into a Kubernetes
+`tls-cert` secret. The bilbomd Helm Ingress then references that secret.
+
+This **replaces** the old manual InCommon certificate process (annual certs from
+https://certificates.lbl.gov/ stored in `infra/helm-secrets/ui-tls-secrets*.yaml`).
+It is a **one-time setup per environment** (dev and prod). Once the CronJob is
+deployed, certificate renewal is fully automatic.
+
+## Architecture
+
+```
+Internet ──HTTPS──► Spin nginx ingress ──► ui:80
+                         │
+                    tls-cert secret
+                         │
+                    tls-acme CronJob (renews every 2 months via Let's Encrypt)
+```
+
+### Ingress ownership (important)
+
+There is exactly **one** Ingress named `ingress`, and it is owned by the **bilbomd
+app Helm chart** (`infra/helm/templates/ingress.yaml`). It routes `/` to `ui:80`
+and references the `tls-cert` secret (via `ingress.secret` in
+`infra/helm/values-<env>.yaml`).
+
+The tls-acme chart is therefore installed with **`ingress.enabled=false`** — it
+must *not* create its own Ingress, or Helm fails with
+`Ingress "ingress" exists and cannot be imported`.
+
+The renewal CronJob still needs the Ingress *name* (via `ingress.name`, which is
+independent of `ingress.enabled`). On each run, the ACME script
+(`get_cert_update_ssl.sh`) backs up the live `ingress`, temporarily repoints all
+hosts to the dummy challenge webserver on port 8080, completes the HTTP-01
+challenge, writes the new cert into `tls-cert`, then restores the original Ingress.
+So the app chart owns the Ingress and the CronJob borrows it during renewal — no
+second Ingress is ever created.
+
+## Prerequisites
+
+1. **NERSC uid/gid** — run `id` on a NERSC login node and confirm the values in
+   `prepare-values-<env>.yaml` (`nersc_user_id`, `nersc_user_group`).
+2. **DNS CNAME records** (already in place for bilbomd; verify with `dig`):
+   - `bilbomd-nersc-dev.bl1231.als.lbl.gov` → `ingress.bilbomd.development.svc.spin.nersc.org`
+   - `bilbomd-nersc.bl1231.als.lbl.gov` → `ingress.bilbomd.production.svc.spin.nersc.org`
+3. **kubectl contexts** configured (`nersc-spin-dev` and `nersc-spin-prod`).
+4. **Clone the NERSC spin-helm repo** (needed for `prepare-values.py`):
+   ```bash
+   git clone https://github.com/NERSC/spin-helm.git /tmp/spin-helm
+   ```
+
+## Step-by-step (per environment)
+
+Replace `<ENV>` with `dev` or `prod` throughout. **Do dev first**, confirm HTTPS,
+then repeat for prod.
+
+### 1. Switch to the correct cluster context
+
+```bash
+kubectl config use-context nersc-spin-<ENV>
+```
+
+### 2. Create the kubeconfig secret
+
+The tls-acme CronJob needs cluster credentials to patch the `tls-cert` secret after
+each renewal. Download the kubeconfig for the environment from the Rancher UI
+(Cluster → Kubeconfig).
+
+> **Critical:** the renewal script derives the internal Spin hostname from
+> `kubectl config current-context` *inside this kubeconfig*:
+> `SPIN_DOMAIN=<ingress-name>.<namespace>.<current-context>.svc.spin.nersc.org`.
+> Spin's OPA admission policy (`ING-002`) requires that segment to be the
+> **cluster name** — `development` or `production` — **not** a local alias like
+> `nersc-spin-dev`. If the context is misnamed, the init job fails with
+> `ingress must have one host with the name ingress.<ns>.development.svc.spin.nersc.org`.
+> So rename the context to match the cluster before creating the secret:
+>
+> ```bash
+> # In the downloaded kubeconfig, rename the context to exactly
+> # <development|production> and make it current:
+> kubectl --kubeconfig=<downloaded> config rename-context \
+>   "$(kubectl --kubeconfig=<downloaded> config current-context)" <development|production>
+> kubectl --kubeconfig=<downloaded> config use-context <development|production>
+> ```
+
+```bash
+kubectl -n bilbomd create secret generic kubeconfig \
+  --from-file=kubeconfig=<path-to-downloaded-kubeconfig>
+```
+
+### 3. Generate tls-acme values.yaml
+
+`prepare-values.py` only needs Python + PyYAML + Jinja2. A minimal conda env is
+provided in `environment.yml` (do **not** reuse a full app env — it pulls in
+unrelated, repo-specific requirements):
+
+```bash
+conda env create -f /path/to/bilbomd/infra/tls-acme/environment.yml
+conda activate bilbomd-tls-acme
+```
+
+Then render the values:
+
+```bash
+cd /tmp/spin-helm/tls-acme
+
+# Use the checked-in bilbomd template as a starting point
+cp /path/to/bilbomd/infra/tls-acme/prepare-values-<ENV>.yaml prepare-values.yaml
+
+# Confirm your NERSC uid/gid and email, then generate values.yaml
+python3 prepare-values.py
+```
+
+### 4. Deploy the tls-acme chart (its own Ingress disabled, cert secret = tls-cert)
+
+The app chart owns the Ingress, so install tls-acme with `ingress.enabled=false`
+(see "Ingress ownership" above). We also pin the cert secret name to `tls-cert`
+explicitly (the chart default, made explicit here for clarity).
+
+```bash
+helm install -n bilbomd -f values.yaml \
+  --set ingress.enabled=false \
+  --set cert.secretName=tls-cert \
+  acmecron .
+```
+
+This creates:
+- A self-signed `tls-cert` secret (placeholder until the first ACME run)
+- A minimal challenge web server deployment + PVC (case2)
+- A CronJob scheduled every 2 months to renew the cert
+
+It does **not** create an Ingress. At this point the bilbomd app Ingress is still
+pointing at the old `ui-tls`/`ui-tls-dev` InCommon secret, so **the live site is
+unaffected**.
+
+### 5. Trigger the initial certificate request
+
+The CronJob runs on its schedule, but trigger it manually right away to get a real
+cert. Look up the CronJob name first (it is `<release>-spin-acme-cron`, e.g.
+`acmecron-spin-acme-cron`):
+
+```bash
+kubectl -n bilbomd get cronjob
+kubectl -n bilbomd create job --from=cronjob/acmecron-spin-acme-cron acmecron-init
+kubectl -n bilbomd logs -f job/acmecron-init
+```
+
+A successful run ends with the `tls-cert` secret holding a valid Let's Encrypt
+certificate. Verify:
+
+```bash
+kubectl -n bilbomd get secret tls-cert -o jsonpath='{.data.tls\.crt}' \
+  | base64 -d | openssl x509 -noout -dates -issuer
+# issuer should be Let's Encrypt (R-series); validity ~90 days
+```
+
+### 6. Cut the app Ingress over to tls-cert (zero downtime)
+
+Only **after** `tls-cert` holds a real cert (step 5), point the bilbomd Ingress at
+it. In `infra/helm/values-<ENV>.yaml` set:
+
+```yaml
+ingress:
+  secret: 'tls-cert'   # was ui-tls-dev (dev) / ui-tls (prod)
+```
+
+Then redeploy the app chart:
+
+```bash
+./infra/deploy-to-nersc.sh deploy <ENV>
+```
+
+nginx now serves the Let's Encrypt cert from `tls-cert`. Because the real cert was
+already in place before the flip, there is no window serving the self-signed
+placeholder.
+
+### 7. Verify HTTPS
+
+```bash
+curl -vI https://bilbomd-nersc-<ENV>.bl1231.als.lbl.gov/
+# Expect: HTTP/2 200, valid Let's Encrypt chain, no SSL warning
+```
+
+Also load the site in a browser and confirm a trusted padlock.
+
+## Ongoing renewal
+
+The CronJob runs automatically every two months. No manual action is needed.
+To check the last renewal:
+
+```bash
+kubectl -n bilbomd get cronjob acmecron-spin-acme-cron
+kubectl -n bilbomd get jobs --sort-by=.metadata.creationTimestamp | tail -5
+kubectl -n bilbomd get secret tls-cert -o jsonpath='{.data.tls\.crt}' \
+  | base64 -d | openssl x509 -noout -dates
+```
+
+## Rollback
+
+If anything goes wrong, revert `ingress.secret` back to `ui-tls`/`ui-tls-dev` in
+`infra/helm/values-<ENV>.yaml` and redeploy. The manual InCommon secret is still
+present in the namespace (see `infra/helm-secrets/ui-tls-secrets*.yaml`) and will be
+served again immediately.
+
+## Updating the tls-acme chart
+
+If the upstream chart or `prepare-values.yaml` template changes:
+
+```bash
+cd /tmp/spin-helm && git pull
+cd tls-acme
+cp /path/to/bilbomd/infra/tls-acme/prepare-values-<ENV>.yaml prepare-values.yaml
+python3 prepare-values.py
+helm upgrade -n bilbomd -f values.yaml \
+  --set ingress.enabled=false --set cert.secretName=tls-cert acmecron .
+```
+
+## Files in this directory
+
+| File | Purpose |
+|------|---------|
+| `prepare-values-dev.yaml` | Template config for the dev tls-acme chart (verify uid/gid/email) |
+| `prepare-values-prod.yaml` | Template config for the prod tls-acme chart |
+| `README.md` | This file |
+
+`values.yaml` (generated by `prepare-values.py`) and any local `prepare-values.yaml`
+copy are gitignored — they contain your personal NERSC uid/gid and email.

--- a/infra/tls-acme/environment.yml
+++ b/infra/tls-acme/environment.yml
@@ -1,0 +1,15 @@
+# Minimal conda environment for running the NERSC spin-helm tls-acme
+# `prepare-values.py` script, which renders values.yaml from a
+# prepare-values-<env>.yaml template. It only needs PyYAML + Jinja2.
+#
+#   conda env create -f environment.yml
+#   conda activate bilbomd-tls-acme
+#
+# See README.md for the full setup workflow.
+name: bilbomd-tls-acme
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - pyyaml
+  - jinja2

--- a/infra/tls-acme/prepare-values-dev.yaml
+++ b/infra/tls-acme/prepare-values-dev.yaml
@@ -1,0 +1,19 @@
+# tls-acme configuration for the bilbomd DEVELOPMENT namespace.
+# Copy to prepare-values.yaml and verify your NERSC uid/gid before running
+# prepare-values.py (from NERSC/spin-helm/tls-acme).
+#
+# The generated values.yaml (and any prepare-values.yaml copy) are gitignored —
+# they contain your personal NERSC uid/gid and email address. Keep them local.
+
+nersc_user_id: 62704       # verify with `id` on a NERSC login node
+nersc_user_group: 104818   # bilbomd project group (matches fsGroup in helm deployments)
+service_port: 8080         # port of the tls-acme challenge web server (case2)
+ingress_name: ingress      # name of the Ingress the bilbomd app chart owns; the
+                           # renewal CronJob borrows it. Install tls-acme with
+                           # --set ingress.enabled=false so it doesn't create
+                           # a second Ingress (see README "Ingress ownership").
+email: sclassen@lbl.gov
+cluster: development       # "development" or "production"
+use_case: case2            # case2: chart deploys its own minimal challenge web server
+user_domains:
+  - bilbomd-nersc-dev.bl1231.als.lbl.gov

--- a/infra/tls-acme/prepare-values-prod.yaml
+++ b/infra/tls-acme/prepare-values-prod.yaml
@@ -1,0 +1,19 @@
+# tls-acme configuration for the bilbomd PRODUCTION namespace.
+# Copy to prepare-values.yaml and verify your NERSC uid/gid before running
+# prepare-values.py (from NERSC/spin-helm/tls-acme).
+#
+# The generated values.yaml (and any prepare-values.yaml copy) are gitignored —
+# they contain your personal NERSC uid/gid and email address. Keep them local.
+
+nersc_user_id: 62704       # verify with `id` on a NERSC login node
+nersc_user_group: 104818   # bilbomd project group (matches fsGroup in helm deployments)
+service_port: 8080         # port of the tls-acme challenge web server (case2)
+ingress_name: ingress      # name of the Ingress the bilbomd app chart owns; the
+                           # renewal CronJob borrows it. Install tls-acme with
+                           # --set ingress.enabled=false so it doesn't create
+                           # a second Ingress (see README "Ingress ownership").
+email: sclassen@lbl.gov
+cluster: production        # "development" or "production"
+use_case: case2            # case2: chart deploys its own minimal challenge web server
+user_domains:
+  - bilbomd-nersc.bl1231.als.lbl.gov


### PR DESCRIPTION
## Summary

Replaces the manual annual InCommon certificate process with automatic Let's Encrypt renewal on NERSC Spin (which does not run cert-manager), using the [NERSC/spin-helm `tls-acme`](https://github.com/NERSC/spin-helm/tree/main/tls-acme) chart. The chart is deployed as a separate `acmecron` release whose CronJob renews the cert every two months via the HTTP-01 ACME challenge and writes it into a `tls-cert` Kubernetes secret; the bilbomd app Ingress references that secret.

This ports the methodology proven in the sibling **t5sbb** project (same Spin clusters).

```
Internet ──HTTPS──► Spin nginx ingress ──► ui:80
                         │
                    tls-cert secret  ◄── tls-acme CronJob (renews every 2 months)
```

## Changes

- **`infra/tls-acme/`** (new): per-env `prepare-values-{dev,prod}.yaml` templates, a minimal `environment.yml` for `prepare-values.py` (PyYAML + Jinja2 only), and a step-by-step `README.md` (kubeconfig secret setup, helm install with `ingress.enabled=false` + `cert.secretName=tls-cert`, initial cert trigger, zero-downtime ingress cutover, verification, rollback, troubleshooting).
- **`infra/helm/templates/ingress.yaml`**: add explicit `ingressClassName: nginx`.
- **`infra/helm/values-{dev,prod}.yaml`**: point `ingress.secret` at `tls-cert`.
- **`.gitignore`**: ignore generated tls-acme values (contain NERSC uid/gid/email).
- **`infra/HELM_NOTES.md`** (+ local `helm-secrets/ssl-certificates/README.md`): mark the manual InCommon process deprecated, pointing to `infra/tls-acme/`.

## Ingress ownership

The bilbomd app chart remains the sole owner of the Ingress named `ingress`. The `tls-acme` chart is installed with `ingress.enabled=false` so it doesn't create a second Ingress; its renewal CronJob borrows the existing one by name during the challenge.

## Testing

Verified end-to-end on **both dev and prod** clusters:
- `acmecron` chart installed (no second Ingress created).
- Initial Let's Encrypt cert issued into `tls-cert` (issuer = Let's Encrypt, ~90-day validity, correct subject per env).
- Ingress cut over to `tls-cert` via `deploy-to-nersc.sh`; HTTPS confirmed serving the new cert.

Two gotchas hit and documented in the README:
1. The `kubeconfig` secret's internal context must be named exactly `development`/`production` (Spin OPA `ING-002`), not a local alias.
2. The initial cert job may need one retry due to ingress-propagation timing.

## Notes

- No changeset — infra-only change with no publishable package, consistent with recent infra PRs (e.g. #893).
- The legacy `ui-tls`/`ui-tls-dev` secrets are retained for rollback and can be removed in a later cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)