### PR TITLE
fix(backend): keep video session alive for MD movie playback (#911)

### DIFF
--- a/.changeset/fix-video-session-lifetime.md
+++ b/.changeset/fix-video-session-lifetime.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/backend': patch
+---
+
+Fix MD movie playback failing with "Video access attempt without valid session". Native `<video>` requests authenticate via the `bilbomd-session` cookie (they can't carry the JWT), but the cookie expired 15 minutes after creation while the 7-day refresh token kept the app working — so movies 401'd after a short idle. The session is now `rolling` (expiry slides forward on each request) with a `maxAge` matching the 7-day refresh-token lifetime. See issue #911.

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -98,10 +98,19 @@ app.use(
     secret: getEnvVar('SESSION_SECRET'),
     resave: false,
     saveUninitialized: false,
+    // `rolling` slides the expiry forward on every request so an active user's
+    // session never lapses mid-use. This matters for MD movie playback: native
+    // <video> requests can't carry the JWT, so they authenticate via this
+    // cookie (see middleware/videoAuth.ts). Without rolling + a long maxAge the
+    // cookie expired 15 min after creation while the 7-day refresh token kept
+    // the app working, so movies 401'd with "Video access attempt without valid
+    // session". maxAge now matches the refresh-token lifetime. See issue #911.
+    rolling: true,
     cookie: {
       httpOnly: true,
       secure: isCookieSecure(), // HTTPS-only unless COOKIE_SECURE=false
-      maxAge: 1000 * 60 * 15 // 15 minutes
+      sameSite: 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days, matches refresh-token lifetime
     }
   })
 )


### PR DESCRIPTION
Fixes #911.

## Problem

Viewing MD movies intermittently failed with a 401 and the backend logged:

```
warn: [bilbomd-backend] Video access attempt without valid session
```

Native `<video src="...">` elements issue their own browser-managed requests (including `Range:` requests for seeking, handled in `streamVideo.ts`) and **cannot** carry an `Authorization: Bearer` header. So streaming authenticates via the `bilbomd-session` cookie instead: `/jobs/*` API calls run `setVideoSession` to stash the username, and the video route uses `verifyVideoSession` to read it.

The cookie's `maxAge` was **15 minutes** with no `rolling`/`resave`, so it expired 15 min after creation and was never extended. Meanwhile the 2-min access token and 7-day refresh token kept the app fully working — masking the dead video session. On a **completed** job (exactly when you watch the finished movies) job polling stops, so after ~15 min nothing refreshed the cookie and every video request 401'd.

## Fix

Backend-only change to the session config in `apps/backend/src/app.ts`:

- `rolling: true` — slides the expiry forward on every `/jobs/*` request, so an active session never lapses mid-use.
- `maxAge: 7 days` — matches the refresh-token lifetime (`authTokens.ts`).
- `sameSite: 'lax'` — explicit, for consistency with the other auth cookies.

The cookie is `httpOnly` + Redis-backed and only gates media for an already-authenticated user, so the longer lifetime is low-risk.

## Alternative considered

A signed-URL token scheme (mint short-lived signed tokens in the media URLs, verify on the video route) would remove the cookie dependency entirely, but is larger and has a UX gotcha: `getMovies` re-polls every 15s and would churn `<video src>`, restarting playback, unless token expiry is bucketed. Documented in #911 as a possible future cleanup; not needed once the lifetime is fixed.

## Verification

- `pnpm -F @bilbomd/backend lint` — clean
- `pnpm -F @bilbomd/backend build` — succeeds
- `pnpm -F @bilbomd/backend test` — 463/463 pass

Changeset included (`@bilbomd/backend: patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)