### PR TITLE
fix(ui): preserve X-Forwarded-Proto so Secure session cookies work (#911)

### DIFF
--- a/.changeset/fix-forwarded-proto-secure-cookies.md
+++ b/.changeset/fix-forwarded-proto-secure-cookies.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Fix the UI nginx clobbering `X-Forwarded-Proto` so `Secure` session cookies work behind a TLS-terminating proxy. The inner nginx listens on :80 and previously forwarded `X-Forwarded-Proto: $scheme` (always `http`), so the backend saw `req.secure === false` and express-session silently dropped the `Secure` `bilbomd-session` cookie — breaking the cookie-based auth used for MD movie/poster streaming on HTTPS deployments (beamline via Cloudflare and NERSC/SPIN via the nginx ingress). nginx now preserves the real upstream protocol (falling back to `$scheme` for direct/local HTTP), so `Secure` cookies can be used without the `COOKIE_SECURE=false` workaround. See issue #911.

--- a/apps/ui/nginx/nginx.conf
+++ b/apps/ui/nginx/nginx.conf
@@ -21,6 +21,20 @@ http {
     set_real_ip_from 128.55.137.128/25;
     set_real_ip_from 128.55.206.0/24;
 
+    # Preserve the original client protocol across proxy hops. The public edge
+    # (Cloudflare for the beamline, the k8s nginx ingress on SPIN/NERSC) sets
+    # X-Forwarded-Proto to the real scheme (https); this inner nginx listens on
+    # :80, so falling back to $scheme would clobber it to http. When the backend
+    # then sees X-Forwarded-Proto: http it treats req.secure as false, and
+    # express-session SILENTLY refuses to send the Secure session cookie —
+    # breaking the cookie-based auth used for MD movie streaming. Trust the
+    # upstream value when present, fall back to $scheme for direct/local HTTP.
+    # See issue #911.
+    map $http_x_forwarded_proto $client_proto {
+        default $http_x_forwarded_proto;
+        ""      $scheme;
+    }
+
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/apps/ui/nginx/nginx.default.conf
+++ b/apps/ui/nginx/nginx.default.conf
@@ -12,7 +12,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
         # proxy_set_header Connection "";
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $client_proto;
         proxy_set_header X-Real-IP $remote_addr;
         add_header X-Debug-Orcid-Callback-Routed "true";
     }
@@ -23,7 +23,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $client_proto;
         
         # Enable caching for videos
         proxy_cache_valid 200 1h;
@@ -46,7 +46,7 @@ server {
         proxy_set_header CF-Ray $http_cf_ray;  # Optional: Forward ray ID for debugging
         proxy_http_version 1.1;
         # proxy_set_header Connection "";
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $client_proto;
     }
 
     # index.html must never be cached — it references hashed assets whose
@@ -80,7 +80,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
         # proxy_set_header Connection "";
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $client_proto;
 
         # Ensure that the path is correctly forwarded to Express
         proxy_redirect off;
@@ -102,7 +102,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_http_version 1.1;
         # proxy_set_header Connection "";
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $client_proto;
     }
 
     # Serve version.json


### PR DESCRIPTION
Follow-up to #912. Addresses the **actual root cause** behind issue #911.

## Background

MD movie playback failed immediately with `Video access attempt without valid session`. Native `<video>`/`<img>` requests can't carry the JWT, so they authenticate via the `bilbomd-session` cookie. We confirmed in the running beamline deployment that the `bilbomd-session` cookie was **never stored in the browser** (only `jwt` was), so the earlier `rolling`/`maxAge` change (#912) couldn't help — there was no cookie to keep alive.

## Root cause

The tell was that `jwt` was present but `bilbomd-session` was not, even though both use `secure: isCookieSecure()`:

- `jwt` is set via `res.cookie()`, which writes the `Secure` attribute unconditionally; the browser stores it over the HTTPS edge. ✅
- `bilbomd-session` is set via **express-session**, which behaves differently: if `cookie.secure === true` and it believes the connection is insecure (`req.secure === false`), it **silently declines to send `Set-Cookie`**. ❌

`req.secure` was `false` because the inner UI nginx listens on `:80` and forwarded `proxy_set_header X-Forwarded-Proto $scheme` (always `http`), clobbering the real `https` set by the public edge. So with `Secure` cookies enabled (PR #889 flipped the beamline to `Secure` via `BILBOMD_ENV=production`), express-session dropped the session cookie. Setting `COOKIE_SECURE=false` in the beamline env confirmed the diagnosis and restored movies.

## Fix

`apps/ui/nginx/nginx.conf` adds a `map` that trusts the upstream `X-Forwarded-Proto` when present and falls back to `$scheme` for direct/local HTTP; `apps/ui/nginx/nginx.default.conf` uses `$client_proto` instead of `$scheme` in all proxied `location` blocks (`/api`, video, orcid callback, sfapi, bullmq). The backend then sees the true `https`, `req.secure` is correct, and `Secure` cookies are emitted normally.

## Deployment impact

The single `bilbomd-ui` image bakes both nginx files, so this applies everywhere:

- **Beamline (docker compose, Cloudflare):** root cause fixed. After deploy, `COOKIE_SECURE=false` can be removed so cookies stay `Secure`.
- **NERSC / SPIN (Helm, nginx ingress):** `values-prod.yaml` has `NODE_ENV=production` + `BILBOMD_ENV=production` and no `COOKIE_SECURE`, so `Secure` cookies are (and were, pre-#889) enabled there too. The SPIN nginx ingress sets `X-Forwarded-Proto: https`, but the inner ui nginx was overwriting it back to `http` — so this **same latent bug affects NERSC** and is fixed by the same change. Worth verifying movie playback on NERSC after deploy.
- **Local (docker-compose.local, HTTP):** no upstream header → `map` falls back to `$scheme` (http); local uses `BILBOMD_ENV=development` so cookies aren't `Secure` anyway. No change in behavior.

### Note on `COOKIE_SECURE=false`
Once this is deployed, the `COOKIE_SECURE=false` override set on the beamline can be removed to restore `Secure` cookies. Leaving it set is harmless but slightly less secure.

## Validation

- `nginx -t` passes with both configs (`map` placement + directives validated in an `nginx:alpine` container).
- `pnpm -F @bilbomd/ui lint` — clean.
- Config-only change; no application code touched.

Changeset included (`@bilbomd/ui: patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)