### PR TITLE
test(worker): add coverage for untested modules and job-utils

### DIFF
--- a/.changeset/worker-test-coverage-improvements.md
+++ b/.changeset/worker-test-coverage-improvements.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Add unit test coverage for previously untested worker modules: usage-events (context building, event recording), NERSC API token caching/refresh logic, and the rgyr/dmax and feedback python-script spawn wrappers. Extend config tests to cover env-var parsing, validation, and boolean/default helpers. Extend job-utils tests to cover the CHARMM spawn wrapper (spawnCharmm), the writeInputFile failure path, an additional handleError branch, and the invalid-user and missing-email notification paths. Raises worker coverage from ~65% to ~72% statements (43% to 51% branches).

--- a/apps/worker/src/config/__tests__/config.test.ts
+++ b/apps/worker/src/config/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 
 describe('config.ts', () => {
   it('should successfully load config when all required env vars are present', async () => {
@@ -58,5 +58,97 @@ describe('config.ts', () => {
     expect(typeof config.bilbomd.AlphaFoldEnabled).toBe('boolean')
     expect(typeof config.bilbomd.MultiEnabled).toBe('boolean')
     expect(typeof config.bilbomd.ScoperEnabled).toBe('boolean')
+  })
+})
+
+describe('config.ts env parsing', () => {
+  // These tests mutate process.env and re-import the module to exercise the
+  // (non-exported) helper branches. Restore the environment after each test.
+  const ENV_SNAPSHOT = { ...process.env }
+
+  afterEach(() => {
+    process.env = { ...ENV_SNAPSHOT }
+    vi.resetModules()
+  })
+
+  const reimport = async () => {
+    vi.resetModules()
+    return import('../config.js')
+  }
+
+  describe('toBoolean', () => {
+    it('treats "true", "1", and "yes" (any case) as true', async () => {
+      process.env.SEND_EMAIL_NOTIFICATIONS = 'true'
+      process.env.USE_NERSC = '1'
+      process.env.ENABLE_BILBOMD_SANS = 'YES'
+      process.env.ENABLE_BILBOMD_ALPHAFOLD = 'yes'
+      const { config } = await reimport()
+      expect(config.sendEmailNotifications).toBe(true)
+      expect(config.runOnNERSC).toBe(true)
+      expect(config.bilbomd.SANSEnabled).toBe(true)
+      expect(config.bilbomd.AlphaFoldEnabled).toBe(true)
+    })
+
+    it('treats other values and undefined as false', async () => {
+      process.env.SEND_EMAIL_NOTIFICATIONS = 'no'
+      delete process.env.USE_NERSC
+      const { config } = await reimport()
+      expect(config.sendEmailNotifications).toBe(false)
+      expect(config.runOnNERSC).toBe(false)
+    })
+  })
+
+  describe('getEnvVarWithDefault', () => {
+    it('uses the provided value when the env var is set', async () => {
+      process.env.LOG_LEVEL = 'debug'
+      process.env.OPENMM_PYTHON_BIN = '/custom/python'
+      const { config } = await reimport()
+      expect(config.logLevel).toBe('debug')
+      expect(config.openmmPythonBin).toBe('/custom/python')
+    })
+
+    it('falls back to the default when the env var is unset', async () => {
+      delete process.env.LOG_LEVEL
+      delete process.env.OPENMM_PYTHON_BIN
+      const { config } = await reimport()
+      expect(config.logLevel).toBe('info')
+      expect(config.openmmPythonBin).toBe('/opt/envs/openmm/bin/python')
+    })
+  })
+
+  describe('parsePositiveIntEnv', () => {
+    it('parses a valid positive integer and floors it', async () => {
+      process.env.OPENMM_MD_CONCURRENCY = '4.9'
+      const { config } = await reimport()
+      expect(config.openmmMdConcurrency).toBe(4)
+    })
+
+    it('returns the default when unset or empty', async () => {
+      delete process.env.OPENMM_MD_CONCURRENCY
+      process.env.COLABFOLD_TIMEOUT_MS = ''
+      const { config } = await reimport()
+      expect(config.openmmMdConcurrency).toBe(1)
+      expect(config.colabfoldTimeoutMs).toBe(60 * 60 * 1000)
+    })
+
+    it('throws on a non-numeric value', async () => {
+      process.env.OPENMM_MD_CONCURRENCY = 'abc'
+      await expect(reimport()).rejects.toThrow(/is not a positive number/)
+    })
+
+    it('throws on a non-positive value', async () => {
+      process.env.OPENMM_MD_CONCURRENCY = '-1'
+      await expect(reimport()).rejects.toThrow(/is not a positive number/)
+    })
+  })
+
+  describe('validateRequiredEnvVars', () => {
+    it('throws listing the missing required variables', async () => {
+      delete process.env.BILBOMD_URL
+      delete process.env.CHARMM
+      await expect(reimport()).rejects.toThrow(
+        /Missing required environment variables:.*BILBOMD_URL.*CHARMM/
+      )
+    })
   })
 })

--- a/apps/worker/src/services/functions/__tests__/analysis.test.ts
+++ b/apps/worker/src/services/functions/__tests__/analysis.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import type { IJob } from '@bilbomd/mongodb-schema'
+
+const { spawnMock, createWriteStreamMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  createWriteStreamMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+vi.mock('fs-extra', () => ({
+  default: { createWriteStream: createWriteStreamMock }
+}))
+
+vi.mock('../../../helpers/loggers.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}))
+
+import { spawnRgyrDmaxScript } from '../analysis.js'
+
+// Minimal fake ChildProcess: an EventEmitter with stdout/stderr emitters.
+const makeChild = () => {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child
+}
+
+const job = { uuid: 'job-uuid' } as IJob
+
+describe('analysis - spawnRgyrDmaxScript', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createWriteStreamMock.mockImplementation(() => ({
+      write: vi.fn(),
+      end: (cb?: () => void) => cb && cb()
+    }))
+  })
+
+  it('spawns the python rgyr/dmax script with the expected args', async () => {
+    const child = makeChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = spawnRgyrDmaxScript(job)
+    child.emit('exit', 0)
+    await p
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    const [bin, args, opts] = spawnMock.mock.calls[0]
+    expect(bin).toBe('/opt/envs/base/bin/python')
+    expect(args).toContain('/app/scripts/rgyr_v_dmax_analysis.py')
+    expect(opts).toMatchObject({ cwd: expect.stringContaining('job-uuid') })
+  })
+
+  it('resolves and pipes stdout/stderr when the script exits 0', async () => {
+    const child = makeChild()
+    const logStream = { write: vi.fn(), end: (cb?: () => void) => cb && cb() }
+    const errStream = { write: vi.fn(), end: (cb?: () => void) => cb && cb() }
+    createWriteStreamMock
+      .mockReturnValueOnce(logStream)
+      .mockReturnValueOnce(errStream)
+    spawnMock.mockReturnValue(child)
+
+    const p = spawnRgyrDmaxScript(job)
+    child.stdout.emit('data', Buffer.from('hello stdout'))
+    child.stderr.emit('data', Buffer.from('a warning'))
+    child.emit('exit', 0)
+
+    await expect(p).resolves.toBeUndefined()
+    expect(logStream.write).toHaveBeenCalledWith('hello stdout')
+    expect(errStream.write).toHaveBeenCalledWith('a warning')
+  })
+
+  it('rejects when the script exits with a non-zero code', async () => {
+    const child = makeChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = spawnRgyrDmaxScript(job)
+    child.emit('exit', 1)
+
+    await expect(p).rejects.toThrow(/Rgyr Dmax script failed/)
+  })
+
+  it('rejects when the child process emits an error', async () => {
+    const child = makeChild()
+    spawnMock.mockReturnValue(child)
+
+    const p = spawnRgyrDmaxScript(job)
+    child.emit('error', new Error('spawn ENOENT'))
+
+    await expect(p).rejects.toThrow('spawn ENOENT')
+  })
+})

--- a/apps/worker/src/services/functions/__tests__/feedback.test.ts
+++ b/apps/worker/src/services/functions/__tests__/feedback.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import type { IJob } from '@bilbomd/mongodb-schema'
+
+const { spawnMock, createWriteStreamMock, readFileMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  createWriteStreamMock: vi.fn(),
+  readFileMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+vi.mock('fs-extra', () => ({
+  default: {
+    createWriteStream: createWriteStreamMock,
+    promises: { readFile: readFileMock }
+  }
+}))
+
+vi.mock('../../../helpers/loggers.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}))
+
+import { spawnFeedbackScript } from '../feedback.js'
+
+const makeChild = () => {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child
+}
+
+const makeJob = () =>
+  ({
+    uuid: 'job-uuid',
+    feedback: undefined,
+    save: vi.fn().mockResolvedValue(undefined)
+  }) as unknown as IJob & { save: ReturnType<typeof vi.fn> }
+
+describe('feedback - spawnFeedbackScript', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createWriteStreamMock.mockImplementation(() => ({
+      write: vi.fn(),
+      end: (cb?: () => void) => cb && cb()
+    }))
+  })
+
+  it('spawns the python feedback script with the expected args', async () => {
+    const child = makeChild()
+    spawnMock.mockReturnValue(child)
+    readFileMock.mockResolvedValue('{}')
+    const job = makeJob()
+
+    const p = spawnFeedbackScript(job)
+    child.emit('exit', 0)
+    await p
+
+    const [bin, args, opts] = spawnMock.mock.calls[0]
+    expect(bin).toBe('/opt/envs/base/bin/python')
+    expect(args).toContain('/app/scripts/pipeline_decision_tree.py')
+    expect(opts).toMatchObject({ cwd: expect.stringContaining('results') })
+  })
+
+  it('reads feedback.json, stores it on the job, and saves on exit 0', async () => {
+    const child = makeChild()
+    spawnMock.mockReturnValue(child)
+    readFileMock.mockResolvedValue(JSON.stringify({ score: 42, ok: true }))
+    const job = makeJob()
+
+    const p = spawnFeedbackScript(job)
+    child.emit('exit', 0)
+
+    await expect(p).resolves.toBeUndefined()
+    expect(readFileMock).toHaveBeenCalledWith(
+      expect.stringContaining('feedback.json'),
+      'utf-8'
+    )
+    expect(job.feedback).toEqual({ score: 42, ok: true })
+    expect((job as unknown as { save: ReturnType<typeof vi.fn> }).save).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects when feedback.json cannot be read or parsed', async () => {
+    const child = makeChild()
+    spawnMock.mockReturnValue(child)
+    readFileMock.mockRejectedValue(new Error('ENOENT feedback.json'))
+    const job = makeJob()
+
+    const p = spawnFeedbackScript(job)
+    child.emit('exit', 0)
+
+    await expect(p).rejects.toThrow('ENOENT feedback.json')
+  })
+
+  it('rejects when the script exits with a non-zero code', async () => {
+    const child = makeChild()
+    spawnMock.mockReturnValue(child)
+    const job = makeJob()
+
+    const p = spawnFeedbackScript(job)
+    child.emit('exit', 2)
+
+    await expect(p).rejects.toThrow(/Feedback script failed/)
+  })
+
+  it('rejects when the child process emits an error', async () => {
+    const child = makeChild()
+    spawnMock.mockReturnValue(child)
+    const job = makeJob()
+
+    const p = spawnFeedbackScript(job)
+    child.emit('error', new Error('spawn failed'))
+
+    await expect(p).rejects.toThrow('spawn failed')
+  })
+})

--- a/apps/worker/src/services/functions/__tests__/job-utils.test.ts
+++ b/apps/worker/src/services/functions/__tests__/job-utils.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
 import {
   initializeJob,
   cleanupJob,
@@ -6,7 +7,8 @@ import {
   makeFile,
   generateInputFile,
   handleError,
-  runPipelineStep
+  runPipelineStep,
+  spawnCharmm
 } from '../job-utils.js'
 import { User, type IJob, type IUser } from '@bilbomd/mongodb-schema'
 import { Job as BullMQJob } from 'bullmq'
@@ -16,6 +18,10 @@ import { config } from '../../../config/config.js'
 import fs from 'fs-extra'
 import { updateStepStatus, updateJobStatus } from '../mongo-utils.js'
 import { Types } from 'mongoose'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 
 vi.mock('../../../helpers/loggers.js', () => ({
   logger: {
@@ -56,9 +62,20 @@ vi.mock('@bilbomd/mongodb-schema', async () => {
   }
 })
 
+// Minimal fake CHARMM ChildProcess: an EventEmitter with a stdout emitter.
+const makeCharmmChild = () => {
+  const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter }
+  child.stdout = new EventEmitter()
+  return child
+}
+
 describe('job-utils', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   describe('initializeJob', () => {
@@ -473,6 +490,164 @@ describe('job-utils', () => {
       // 'end md' must NOT be logged after a failure
       expect(mockMQJob.log).toHaveBeenCalledWith('start md')
       expect(mockMQJob.log).not.toHaveBeenCalledWith('end md')
+    })
+  })
+
+  describe('fetchJobUser (via cleanupJob)', () => {
+    it('treats an invalid ObjectId user reference as no user', async () => {
+      const mockMQJob = {} as unknown as BullMQJob
+      const mockDBJob = {
+        _id: new Types.ObjectId(),
+        uuid: 'bad-user-uuid',
+        user: 'not-a-valid-object-id',
+        status: 'Running',
+        time_completed: undefined,
+        progress: 0,
+        save: vi.fn().mockResolvedValue(undefined)
+      } as unknown as IJob
+
+      await cleanupJob(mockMQJob, mockDBJob)
+
+      expect(User.findById).not.toHaveBeenCalled()
+      expect(mockDBJob.progress).toBe(100)
+      expect(mockDBJob.status).toBe('Completed')
+      expect(sendJobCompleteEmail).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleJobEmailNotification (via cleanupJob)', () => {
+    it('skips email when the user has no email address', async () => {
+      const mockUser = {
+        _id: new Types.ObjectId(),
+        username: 'noemail'
+      } as IUser
+      const mockMQJob = { log: vi.fn() } as unknown as BullMQJob
+      const mockDBJob = {
+        _id: new Types.ObjectId(),
+        uuid: 'no-email-uuid',
+        user: mockUser,
+        status: 'Running',
+        time_completed: undefined,
+        save: vi.fn().mockResolvedValue(undefined)
+      } as unknown as IJob
+
+      vi.mocked(config).sendEmailNotifications = true
+
+      await cleanupJob(mockMQJob, mockDBJob)
+
+      expect(sendJobCompleteEmail).not.toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('user email is undefined')
+      )
+    })
+  })
+
+  describe('writeInputFile (via generateInputFile)', () => {
+    it('logs and throws when writing the input file fails', async () => {
+      const mockParams = {
+        charmm_template: 'minimize',
+        charmm_inp_file: 'minimize.inp',
+        out_dir: '/tmp/job-dir'
+      }
+
+      vi.mocked(fs.readFile).mockResolvedValue('template {{charmm_inp_file}}')
+      vi.mocked(fs.promises.writeFile).mockRejectedValue(new Error('EACCES'))
+      vi.mocked(config).charmmTemplateDir = '/templates'
+
+      await expect(generateInputFile(mockParams)).rejects.toThrow('EACCES')
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error in writeInputFile')
+      )
+    })
+  })
+
+  describe('handleError (additional branches)', () => {
+    it('logs but does not rethrow when updating the step status fails', async () => {
+      const mockDBJob = {
+        _id: new Types.ObjectId(),
+        uuid: 'step-fail-uuid',
+        title: 'Step Fail Job',
+        __t: 'BilboMDPDBJob',
+        status: 'Running'
+      } as unknown as IJob
+
+      vi.mocked(updateJobStatus).mockResolvedValue(undefined)
+      vi.mocked(updateStepStatus).mockRejectedValue(new Error('step write failed'))
+
+      await expect(handleError(new Error('boom'), mockDBJob, 'md')).rejects.toThrow(
+        "BilboMD failed in step 'md': boom"
+      )
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to update step status for step md')
+      )
+    })
+  })
+
+  describe('spawnCharmm', () => {
+    const params = {
+      charmm_inp_file: 'minimize.inp',
+      charmm_out_file: 'minimize.out',
+      out_dir: '/tmp/job-dir'
+    }
+
+    it('spawns CHARMM with the configured binary and args, resolving on close 0', async () => {
+      const child = makeCharmmChild()
+      spawnMock.mockReturnValue(child)
+      vi.mocked(config).charmmBin = '/usr/local/bin/charmm'
+
+      const p = spawnCharmm(params)
+      child.emit('close', 0)
+
+      await expect(p).resolves.toBeUndefined()
+      expect(spawnMock).toHaveBeenCalledWith(
+        '/usr/local/bin/charmm',
+        ['-o', 'minimize.out', '-i', 'minimize.inp'],
+        { cwd: '/tmp/job-dir' }
+      )
+    })
+
+    it('rejects with the accumulated stdout when CHARMM exits non-zero', async () => {
+      const child = makeCharmmChild()
+      spawnMock.mockReturnValue(child)
+
+      const p = spawnCharmm(params)
+      child.stdout.emit('data', Buffer.from('CHARMM> abnormal termination'))
+      child.emit('close', 1)
+
+      await expect(p).rejects.toThrow('CHARMM> abnormal termination')
+    })
+
+    it('rejects when the CHARMM process emits an error', async () => {
+      const child = makeCharmmChild()
+      spawnMock.mockReturnValue(child)
+
+      const p = spawnCharmm(params)
+      child.emit('error', new Error('ENOENT'))
+
+      await expect(p).rejects.toThrow(/CHARMM process encountered an error: ENOENT/)
+    })
+
+    it('emits heartbeat progress updates while running when given an MQ job', async () => {
+      vi.useFakeTimers()
+      const child = makeCharmmChild()
+      spawnMock.mockReturnValue(child)
+      const MQjob = {
+        updateProgress: vi.fn(),
+        log: vi.fn()
+      } as unknown as BullMQJob
+
+      const p = spawnCharmm(params, MQjob)
+      await vi.advanceTimersByTimeAsync(10_000)
+      child.emit('close', 0)
+
+      await expect(p).resolves.toBeUndefined()
+      expect(MQjob.updateProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'running' })
+      )
+      expect(MQjob.log).toHaveBeenCalledWith(
+        expect.stringContaining('Heartbeat')
+      )
     })
   })
 })

--- a/apps/worker/src/services/functions/__tests__/nersc-api-token-functions.test.ts
+++ b/apps/worker/src/services/functions/__tests__/nersc-api-token-functions.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { postMock, isAxiosErrorMock, signMock, readFileMock } = vi.hoisted(
+  () => ({
+    postMock: vi.fn(),
+    isAxiosErrorMock: vi.fn(),
+    signMock: vi.fn(),
+    readFileMock: vi.fn()
+  })
+)
+
+vi.mock('axios', () => ({
+  default: { post: postMock, isAxiosError: isAxiosErrorMock }
+}))
+
+vi.mock('jsonwebtoken', () => ({
+  default: { sign: signMock }
+}))
+
+vi.mock('fs', () => ({
+  default: { readFileSync: readFileMock }
+}))
+
+vi.mock('../../../helpers/loggers.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}))
+
+// Re-import the module fresh so the module-level token cache starts empty.
+const loadModule = async () => {
+  vi.resetModules()
+  return import('../nersc-api-token-functions.js')
+}
+
+describe('nersc-api-token-functions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    readFileMock.mockReturnValue('PRIVATE_KEY')
+    signMock.mockReturnValue('CLIENT_ASSERTION')
+    isAxiosErrorMock.mockReturnValue(false)
+  })
+
+  describe('ensureValidToken', () => {
+    it('generates an assertion and fetches a new token on first call', async () => {
+      postMock.mockResolvedValue({
+        data: { access_token: 'TOKEN_1', expires_in: 3600, scope: 'sf-api' }
+      })
+      const { ensureValidToken } = await loadModule()
+
+      const token = await ensureValidToken()
+
+      expect(token).toBe('TOKEN_1')
+      expect(readFileMock).toHaveBeenCalledWith('/secrets/priv_key.pem', 'utf8')
+      expect(signMock).toHaveBeenCalledWith(
+        expect.objectContaining({ aud: 'https://oidc.nersc.gov/c2id/token' }),
+        'PRIVATE_KEY',
+        { algorithm: 'RS256' }
+      )
+      expect(postMock).toHaveBeenCalledTimes(1)
+      expect(postMock).toHaveBeenCalledWith(
+        'https://oidc.nersc.gov/c2id/token',
+        expect.any(URLSearchParams),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        })
+      )
+    })
+
+    it('returns the cached token on subsequent calls without refetching', async () => {
+      postMock.mockResolvedValue({
+        data: { access_token: 'TOKEN_1', expires_in: 3600, scope: 'sf-api' }
+      })
+      const { ensureValidToken } = await loadModule()
+
+      const first = await ensureValidToken()
+      const second = await ensureValidToken()
+
+      expect(first).toBe('TOKEN_1')
+      expect(second).toBe('TOKEN_1')
+      expect(postMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('refetches when forceRefresh is true even if a token is cached', async () => {
+      postMock
+        .mockResolvedValueOnce({
+          data: { access_token: 'TOKEN_1', expires_in: 3600, scope: 'sf-api' }
+        })
+        .mockResolvedValueOnce({
+          data: { access_token: 'TOKEN_2', expires_in: 3600, scope: 'sf-api' }
+        })
+      const { ensureValidToken } = await loadModule()
+
+      await ensureValidToken()
+      const refreshed = await ensureValidToken(true)
+
+      expect(refreshed).toBe('TOKEN_2')
+      expect(postMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('refetches when the cached token has expired', async () => {
+      // expires_in of 5s minus the 10s skew puts expiry in the past, so the
+      // next call must refetch.
+      postMock
+        .mockResolvedValueOnce({
+          data: { access_token: 'TOKEN_1', expires_in: 5, scope: 'sf-api' }
+        })
+        .mockResolvedValueOnce({
+          data: { access_token: 'TOKEN_2', expires_in: 3600, scope: 'sf-api' }
+        })
+      const { ensureValidToken } = await loadModule()
+
+      await ensureValidToken()
+      const second = await ensureValidToken()
+
+      expect(second).toBe('TOKEN_2')
+      expect(postMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws AuthenticationFailed on a 401 response', async () => {
+      postMock.mockRejectedValue({ response: { status: 401 } })
+      isAxiosErrorMock.mockReturnValue(true)
+      const { ensureValidToken } = await loadModule()
+
+      await expect(ensureValidToken()).rejects.toThrow('AuthenticationFailed')
+    })
+
+    it('rethrows non-auth errors', async () => {
+      postMock.mockRejectedValue(new Error('network down'))
+      isAxiosErrorMock.mockReturnValue(false)
+      const { ensureValidToken } = await loadModule()
+
+      await expect(ensureValidToken()).rejects.toThrow('network down')
+    })
+  })
+})

--- a/apps/worker/src/services/functions/__tests__/usage-events.test.ts
+++ b/apps/worker/src/services/functions/__tests__/usage-events.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Types } from 'mongoose'
+
+// Capture instances created via `new UsageEvent(doc)` so we can assert on the
+// document shape and the save() call. Hoisted so the vi.mock factory (which is
+// itself hoisted above imports) can safely reference them.
+const { saveMock, usageEventMock, usageEventInstances } = vi.hoisted(() => ({
+  saveMock: vi.fn(),
+  usageEventMock: vi.fn(),
+  usageEventInstances: [] as Array<Record<string, unknown>>
+}))
+
+vi.mock('@bilbomd/mongodb-schema', async () => {
+  const actual =
+    await vi.importActual<typeof import('@bilbomd/mongodb-schema')>(
+      '@bilbomd/mongodb-schema'
+    )
+  return { ...actual, UsageEvent: usageEventMock }
+})
+
+import { buildContext, recordWorkerUsageEvent } from '../usage-events.js'
+
+describe('usage-events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    usageEventInstances.length = 0
+    // Re-apply implementations after clearAllMocks wipes call history.
+    saveMock.mockResolvedValue(undefined)
+    usageEventMock.mockImplementation(function (doc: Record<string, unknown>) {
+      usageEventInstances.push(doc)
+      return { ...doc, save: saveMock }
+    })
+  })
+
+  describe('buildContext', () => {
+    it('builds an anonymous context with public_id and ip hash', () => {
+      const ctx = buildContext({
+        access_mode: 'anonymous',
+        public_id: 'pub-123',
+        client_ip_hash: 'hash-abc'
+      })
+
+      expect(ctx.access_mode).toBe('anonymous')
+      expect(ctx.user).toBeUndefined()
+      expect(ctx.public_id).toBe('pub-123')
+      expect(ctx.client_ip_hash).toBe('hash-abc')
+    })
+
+    it('does not attach a user when access_mode is anonymous even if user given', () => {
+      const ctx = buildContext({
+        access_mode: 'anonymous',
+        user: {
+          _id: new Types.ObjectId(),
+          username: 'alice',
+          email: 'alice@example.com'
+        }
+      })
+
+      expect(ctx.user).toBeUndefined()
+    })
+
+    it('normalizes a populated user with an ObjectId _id', () => {
+      const id = new Types.ObjectId()
+      const ctx = buildContext({
+        access_mode: 'user',
+        user: { _id: id, username: 'bob', email: 'bob@example.com' }
+      })
+
+      expect(ctx.user).toBeDefined()
+      expect(ctx.user?._id).toBeInstanceOf(Types.ObjectId)
+      expect(ctx.user?._id.toString()).toBe(id.toString())
+      expect(ctx.user?.username).toBe('bob')
+      expect(ctx.user?.email).toBe('bob@example.com')
+    })
+
+    it('normalizes a populated user with a string _id into an ObjectId', () => {
+      const id = new Types.ObjectId().toString()
+      const ctx = buildContext({
+        access_mode: 'user',
+        user: { _id: id, username: 'carol', email: 'carol@example.com' }
+      })
+
+      expect(ctx.user?._id).toBeInstanceOf(Types.ObjectId)
+      expect(ctx.user?._id.toString()).toBe(id)
+    })
+
+    it('normalizes a summary user (id field) into an ObjectId _id', () => {
+      const id = new Types.ObjectId().toString()
+      const ctx = buildContext({
+        access_mode: 'user',
+        user: { id, username: 'dave', email: 'dave@example.com' }
+      })
+
+      expect(ctx.user?._id).toBeInstanceOf(Types.ObjectId)
+      expect(ctx.user?._id.toString()).toBe(id)
+      expect(ctx.user?.username).toBe('dave')
+    })
+
+    it('leaves user undefined when shape is unrecognized', () => {
+      const ctx = buildContext({
+        access_mode: 'user',
+        user: { foo: 'bar' } as unknown as Record<string, unknown>
+      })
+
+      expect(ctx.user).toBeUndefined()
+    })
+
+    it('leaves user undefined for null user', () => {
+      const ctx = buildContext({ access_mode: 'user', user: null })
+      expect(ctx.user).toBeUndefined()
+    })
+
+    it('does not treat a user with non-string fields as a valid shape', () => {
+      const ctx = buildContext({
+        access_mode: 'user',
+        user: {
+          _id: new Types.ObjectId(),
+          username: 123,
+          email: 'x@example.com'
+        } as unknown as Record<string, unknown>
+      })
+
+      expect(ctx.user).toBeUndefined()
+    })
+  })
+
+  describe('recordWorkerUsageEvent', () => {
+    const baseContext = buildContext({ access_mode: 'anonymous' })
+
+    it('persists a usage event with normalized fields', async () => {
+      const jobId = new Types.ObjectId()
+
+      await recordWorkerUsageEvent({
+        uuid: 'uuid-1',
+        jobId,
+        pipeline: 'pdb',
+        eventType: 'job_completed',
+        status: 'Completed',
+        durationMs: 1234,
+        context: baseContext
+      })
+
+      expect(saveMock).toHaveBeenCalledTimes(1)
+      expect(usageEventInstances).toHaveLength(1)
+      const doc = usageEventInstances[0]
+      expect(doc.uuid).toBe('uuid-1')
+      expect(doc.pipeline).toBe('pdb')
+      expect(doc.event_type).toBe('job_completed')
+      expect(doc.status).toBe('Completed')
+      expect(doc.duration_ms).toBe(1234)
+      expect((doc.job_id as Types.ObjectId).toString()).toBe(jobId.toString())
+      expect(doc.timestamp).toBeInstanceOf(Date)
+    })
+
+    it('accepts a string jobId', async () => {
+      const jobId = new Types.ObjectId().toString()
+
+      await recordWorkerUsageEvent({
+        uuid: 'uuid-2',
+        jobId,
+        pipeline: 'auto',
+        eventType: 'job_started',
+        context: baseContext
+      })
+
+      const doc = usageEventInstances[0]
+      expect((doc.job_id as Types.ObjectId).toString()).toBe(jobId)
+    })
+
+    it('swallows persistence errors without throwing', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      saveMock.mockRejectedValueOnce(new Error('db down'))
+
+      await expect(
+        recordWorkerUsageEvent({
+          uuid: 'uuid-3',
+          jobId: new Types.ObjectId(),
+          pipeline: 'multi',
+          eventType: 'job_failed',
+          context: baseContext
+        })
+      ).resolves.toBeUndefined()
+
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Improves `@bilbomd/worker` test coverage by adding tests for previously untested modules and filling gaps in `job-utils`. No production code changes — tests and a changeset only.

**Worker coverage: 65.3% → 71.55% statements, 42.75% → 51.4% branches** (179 tests across 23 files, all passing).

## What's covered

| Module | Before | After (stmts) | Notes |
|---|---|---|---|
| `usage-events.ts` | untested | 100% | `buildContext` shape normalization + `recordWorkerUsageEvent` |
| `nersc-api-token-functions.ts` | untested | 100% | token fetch/cache/refresh/expiry, 401 vs generic error |
| `analysis.ts` | untested | 100% | rgyr/dmax spawn wrapper (exit 0, non-zero, error event) |
| `feedback.ts` | untested | 90% | feedback spawn wrapper + feedback.json read/parse/save |
| `config.ts` | 77% | 96% | env-var parsing, validation, boolean/default helpers |
| `job-utils.ts` | 74% | 96% | `spawnCharmm` (incl. heartbeat), `writeInputFile` failure, extra `handleError` branch, invalid-user/no-email paths |

## Testing approach

- `EventEmitter`-based fake `ChildProcess` for the `spawn` wrappers.
- `vi.useFakeTimers()` to exercise the CHARMM heartbeat interval without a real wait.
- Module re-import (`vi.resetModules()`) to isolate the NERSC token cache and re-run `config.ts` env validation per test.

## Checks

- `pnpm -F @bilbomd/worker lint` ✓
- `pnpm -F @bilbomd/worker build` ✓
- `pnpm -F @bilbomd/worker test` ✓ (179 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)