### PR TITLE
fix: prefetch into real store and close /users authorization gaps

### DIFF
--- a/.changeset/fix-prefetch-real-store.md
+++ b/.changeset/fix-prefetch-real-store.md
@@ -1,0 +1,8 @@
+---
+'@bilbomd/ui': patch
+'@bilbomd/backend': patch
+---
+
+Fix the `Prefetch` component so it dispatches into the real app store via `useAppDispatch` instead of creating a throw-away store with `setupStore()`. Previously every prefetch request went out without an Authorization header (the throw-away store had no auth state) and silently 401'd, so the component did no useful caching. Also skip prefetching the user list for non-Manager/Admin users since they can't view it.
+
+Close backend authorization gaps on the `/users` routes. Administrative endpoints (`GET /users`, `PATCH /users`, `GET /users/:id`, `DELETE /users/:id`) now require the Manager/Admin role via `verifyRoles` — previously any authenticated user could list all users, edit arbitrary users (including escalating their own roles to Admin), or delete users. Self-service endpoints (`DELETE /users/delete-user-by-username/:username`, `POST /users/change-email`, `/verify-otp`, `/resend-otp`) now enforce account ownership via a new `verifyAccountOwnership` middleware, so callers can only act on their own account.

--- a/apps/backend/src/middleware/__tests__/verifyAccountOwnership.test.ts
+++ b/apps/backend/src/middleware/__tests__/verifyAccountOwnership.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Request, Response, NextFunction } from 'express'
+import { verifyAccountOwnership } from '../verifyAccountOwnership.js'
+
+describe('verifyAccountOwnership middleware', () => {
+  let mockRequest: Partial<Request>
+  let mockResponse: Partial<Response>
+  let mockNext: NextFunction
+  let statusSpy: ReturnType<typeof vi.fn>
+  let jsonSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockNext = vi.fn()
+    jsonSpy = vi.fn()
+    statusSpy = vi.fn(() => ({ json: jsonSpy }))
+    mockRequest = { params: {}, body: {} }
+    mockResponse = {
+      status: statusSpy as unknown as Response['status']
+    }
+  })
+
+  const run = (source: 'params' | 'body') =>
+    verifyAccountOwnership(source)(
+      mockRequest as Request,
+      mockResponse as Response,
+      mockNext
+    )
+
+  it('calls next() when the caller owns the account (params)', () => {
+    mockRequest.user = 'alice'
+    mockRequest.params = { username: 'alice' }
+    run('params')
+    expect(mockNext).toHaveBeenCalledOnce()
+    expect(statusSpy).not.toHaveBeenCalled()
+  })
+
+  it('calls next() when the caller owns the account (body)', () => {
+    mockRequest.user = 'alice'
+    mockRequest.body = { username: 'alice' }
+    run('body')
+    expect(mockNext).toHaveBeenCalledOnce()
+    expect(statusSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when acting on another user (params)', () => {
+    mockRequest.user = 'alice'
+    mockRequest.params = { username: 'bob' }
+    run('params')
+    expect(mockNext).not.toHaveBeenCalled()
+    expect(statusSpy).toHaveBeenCalledWith(403)
+  })
+
+  it('returns 403 when acting on another user (body)', () => {
+    mockRequest.user = 'alice'
+    mockRequest.body = { username: 'bob' }
+    run('body')
+    expect(mockNext).not.toHaveBeenCalled()
+    expect(statusSpy).toHaveBeenCalledWith(403)
+  })
+
+  it('returns 401 when no authenticated user is present', () => {
+    mockRequest.params = { username: 'alice' }
+    run('params')
+    expect(mockNext).not.toHaveBeenCalled()
+    expect(statusSpy).toHaveBeenCalledWith(401)
+  })
+
+  it('returns 403 when the target username is missing', () => {
+    mockRequest.user = 'alice'
+    mockRequest.body = {}
+    run('body')
+    expect(mockNext).not.toHaveBeenCalled()
+    expect(statusSpy).toHaveBeenCalledWith(403)
+  })
+
+  it('does not allow a non-owner even with privileged roles (self-only)', () => {
+    mockRequest.user = 'admin'
+    mockRequest.roles = ['Admin']
+    mockRequest.params = { username: 'bob' }
+    run('params')
+    expect(mockNext).not.toHaveBeenCalled()
+    expect(statusSpy).toHaveBeenCalledWith(403)
+  })
+})

--- a/apps/backend/src/middleware/verifyAccountOwnership.ts
+++ b/apps/backend/src/middleware/verifyAccountOwnership.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express'
+
+type UsernameSource = 'params' | 'body'
+
+// Guards self-service account endpoints so a caller can only act on their own
+// account. The target username is read from the route params or request body
+// and compared against req.user (set by verifyJWT). Mirrors the inline
+// ownership check used by the API token controllers.
+const verifyAccountOwnership = (source: UsernameSource): RequestHandler => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      res.status(401).json({ success: false, message: 'Unauthorized' })
+      return
+    }
+
+    const target = source === 'params' ? req.params.username : req.body?.username
+    const targetUsername = Array.isArray(target) ? target[0] : target
+
+    if (!targetUsername || req.user !== targetUsername) {
+      res.status(403).json({ success: false, message: 'Forbidden' })
+      return
+    }
+
+    next()
+  }
+}
+
+export { verifyAccountOwnership }

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -13,16 +13,32 @@ import { createAPIToken } from '../controllers/users/createAPIToken.js'
 import { listAPITokens } from '../controllers/users/listAPITokens.js'
 import { deleteAPIToken } from '../controllers/users/deleteAPIToken.js'
 import { verifyJWT } from '../middleware/verifyJWT.js'
+import { verifyRoles } from '../middleware/verifyRoles.js'
+import { verifyAccountOwnership } from '../middleware/verifyAccountOwnership.js'
 import { logApiRequest } from '../middleware/logApiRequests.js'
 
 const router = express.Router()
 router.use(verifyJWT)
-router.route('/').get(getAllUsers).patch(updateUser)
-router.route('/:id').get(getUser).delete(deleteUserById)
-router.delete('/delete-user-by-username/:username', deleteUserByUsername)
-router.post('/change-email', sendChangeEmailOtp)
-router.post('/verify-otp', verifyOtp)
-router.post('/resend-otp', resendOtp)
+
+// Administrative endpoints that operate on arbitrary users — Managers/Admins only.
+router
+  .route('/')
+  .get(verifyRoles('Admin', 'Manager'), getAllUsers)
+  .patch(verifyRoles('Admin', 'Manager'), updateUser)
+router
+  .route('/:id')
+  .get(verifyRoles('Admin', 'Manager'), getUser)
+  .delete(verifyRoles('Admin', 'Manager'), deleteUserById)
+
+// Self-service endpoints — callers may only act on their own account.
+router.delete(
+  '/delete-user-by-username/:username',
+  verifyAccountOwnership('params'),
+  deleteUserByUsername
+)
+router.post('/change-email', verifyAccountOwnership('body'), sendChangeEmailOtp)
+router.post('/verify-otp', verifyAccountOwnership('body'), verifyOtp)
+router.post('/resend-otp', verifyAccountOwnership('body'), resendOtp)
 router.post('/:username/tokens', logApiRequest, createAPIToken)
 router.get('/:username/tokens', logApiRequest, listAPITokens)
 router.delete('/:username/tokens/:id', logApiRequest, deleteAPIToken)

--- a/apps/backend/test/integration/users.test.ts
+++ b/apps/backend/test/integration/users.test.ts
@@ -45,11 +45,11 @@ interface MyUser {
   email: string
 }
 
-const generateValidToken = (): string => {
+const generateValidToken = (roles: string[] = ['User']): string => {
   const accessTokenPayload: JwtPayload = {
     UserInfo: {
       username: 'testuser1',
-      roles: ['User'],
+      roles,
       email: 'testuser1@example.com'
     }
   }
@@ -126,7 +126,7 @@ describe('GET /api/v1/users', () => {
     expect(res.body.message).toBe('Unauthorized')
   })
   test('should return users', async () => {
-    const token = generateValidToken()
+    const token = generateValidToken(['Admin'])
     // console.log('token--->', token)
     const res = await await request(app)
       .get('/api/v1/users')
@@ -155,7 +155,7 @@ describe('PATCH /api/v1/users', () => {
   let testUser1: IUser
   let token: string
   beforeEach(async () => {
-    token = generateValidToken()
+    token = generateValidToken(['Admin'])
     // Create the test user and store it in the variable
     testUser1 = await User.create({
       username: 'testuser1',
@@ -177,7 +177,7 @@ describe('PATCH /api/v1/users', () => {
     expect(res.body.message).toBe('Unauthorized')
   })
   test('should return error if you dont provide valid user object', async () => {
-    const token = generateValidToken()
+    const token = generateValidToken(['Admin'])
     const res = await await request(app)
       .patch('/api/v1/users')
       .send({})
@@ -232,7 +232,7 @@ describe('DELETE /api/v1/users', () => {
   let testUser1: IUser
   let token: string
   beforeEach(async () => {
-    token = generateValidToken()
+    token = generateValidToken(['Admin'])
     // Create the test user and store it in the variable
     testUser1 = await User.create({
       username: 'testuser1',

--- a/apps/ui/src/features/auth/Prefetch.tsx
+++ b/apps/ui/src/features/auth/Prefetch.tsx
@@ -1,29 +1,40 @@
-import { setupStore } from 'app/store'
 import { jobsApiSlice } from 'slices/jobsApiSlice'
 import { usersApiSlice } from 'slices/usersApiSlice'
 import { configApiSlice } from 'slices/configsApiSlice'
 import { bullmqApiSlice } from 'features/bullmq/bullmqApiSlice'
+import { useAppDispatch } from 'app/hooks'
+import useAuth from 'hooks/useAuth'
 import { useEffect } from 'react'
 import { Outlet } from 'react-router'
 
 const Prefetch = () => {
+  const dispatch = useAppDispatch()
+  const { isManager, isAdmin } = useAuth()
+
   useEffect(() => {
-    const store = setupStore()
-    store.dispatch(
+    // Dispatch into the real app store so the logged-in token is attached;
+    // these warm the cache the RTK Query hooks read later.
+    dispatch(
       configApiSlice.util.prefetch('getConfigs', 'configData', { force: true })
     )
-    store.dispatch(
+    dispatch(
       jobsApiSlice.util.prefetch('getJobs', 'jobsList', { force: true })
     )
-    store.dispatch(
-      usersApiSlice.util.prefetch('getUsers', 'usersList', { force: true })
-    )
-    store.dispatch(
+    // The queue summary (getQueueState) is shown to every authenticated user
+    // on the Jobs page, so prefetch it for everyone.
+    dispatch(
       bullmqApiSlice.util.prefetch('getQueueState', 'queueList', {
         force: true
       })
     )
-  }, [])
+    // The user list is only viewable by Managers/Admins; skip it for plain
+    // Users so we don't fetch data they'll never render.
+    if (isManager || isAdmin) {
+      dispatch(
+        usersApiSlice.util.prefetch('getUsers', 'usersList', { force: true })
+      )
+    }
+  }, [dispatch, isManager, isAdmin])
 
   return <Outlet />
 }

--- a/apps/ui/src/features/auth/__tests__/Prefetch.test.tsx
+++ b/apps/ui/src/features/auth/__tests__/Prefetch.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import Prefetch from '../Prefetch'
+import useAuth from 'hooks/useAuth'
+import { useAppDispatch } from 'app/hooks'
+import type { AppDispatch } from 'app/store'
+import { jobsApiSlice } from 'slices/jobsApiSlice'
+import { usersApiSlice } from 'slices/usersApiSlice'
+import { configApiSlice } from 'slices/configsApiSlice'
+import { bullmqApiSlice } from 'features/bullmq/bullmqApiSlice'
+
+vi.mock('hooks/useAuth', () => ({ default: vi.fn() }))
+vi.mock('app/hooks', () => ({ useAppDispatch: vi.fn() }))
+vi.mock('react-router', () => ({
+  Outlet: () => <div data-testid="outlet" />
+}))
+
+// Tag each prefetch call so we can identify what was dispatched
+vi.mock('slices/configsApiSlice', () => ({
+  configApiSlice: { util: { prefetch: vi.fn(() => ({ type: 'configs' })) } }
+}))
+vi.mock('slices/jobsApiSlice', () => ({
+  jobsApiSlice: { util: { prefetch: vi.fn(() => ({ type: 'jobs' })) } }
+}))
+vi.mock('slices/usersApiSlice', () => ({
+  usersApiSlice: { util: { prefetch: vi.fn(() => ({ type: 'users' })) } }
+}))
+vi.mock('features/bullmq/bullmqApiSlice', () => ({
+  bullmqApiSlice: { util: { prefetch: vi.fn(() => ({ type: 'queue' })) } }
+}))
+
+const mockUseAuth = vi.mocked(useAuth)
+const mockUseAppDispatch = vi.mocked(useAppDispatch)
+
+const authState = (overrides: Partial<ReturnType<typeof useAuth>> = {}) => ({
+  username: 'user',
+  displayName: 'user',
+  roles: ['User'],
+  status: 'User',
+  isManager: false,
+  isAdmin: false,
+  email: 'user@example.com',
+  isAuthenticated: true,
+  ...overrides
+})
+
+describe('Prefetch', () => {
+  let dispatch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dispatch = vi.fn()
+    mockUseAppDispatch.mockReturnValue(dispatch as unknown as AppDispatch)
+  })
+
+  it('prefetches configs, jobs and queue for a plain User but not users', () => {
+    mockUseAuth.mockReturnValue(authState())
+
+    render(<Prefetch />)
+
+    const dispatched = dispatch.mock.calls.map(([action]) => action.type)
+    expect(dispatched).toContain('configs')
+    expect(dispatched).toContain('jobs')
+    expect(dispatched).toContain('queue')
+    expect(dispatched).not.toContain('users')
+    expect(usersApiSlice.util.prefetch).not.toHaveBeenCalled()
+  })
+
+  it('also prefetches users for a Manager', () => {
+    mockUseAuth.mockReturnValue(
+      authState({ roles: ['Manager'], status: 'Manager', isManager: true })
+    )
+
+    render(<Prefetch />)
+
+    expect(dispatch.mock.calls.map(([a]) => a.type)).toContain('users')
+    expect(usersApiSlice.util.prefetch).toHaveBeenCalledWith(
+      'getUsers',
+      'usersList',
+      { force: true }
+    )
+  })
+
+  it('also prefetches users for an Admin', () => {
+    mockUseAuth.mockReturnValue(
+      authState({ roles: ['Admin'], status: 'Admin', isAdmin: true })
+    )
+
+    render(<Prefetch />)
+
+    expect(dispatch.mock.calls.map(([a]) => a.type)).toContain('users')
+  })
+
+  it('dispatches all prefetches into the real app store via useAppDispatch', () => {
+    mockUseAuth.mockReturnValue(authState())
+
+    render(<Prefetch />)
+
+    // Sanity: it uses the shared typed dispatch, not a throw-away store
+    expect(mockUseAppDispatch).toHaveBeenCalled()
+    expect(configApiSlice.util.prefetch).toHaveBeenCalledWith(
+      'getConfigs',
+      'configData',
+      { force: true }
+    )
+    expect(jobsApiSlice.util.prefetch).toHaveBeenCalledWith(
+      'getJobs',
+      'jobsList',
+      { force: true }
+    )
+    expect(bullmqApiSlice.util.prefetch).toHaveBeenCalledWith(
+      'getQueueState',
+      'queueList',
+      { force: true }
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fixes a long-standing dead-code bug in the `Prefetch` component and closes several authorization gaps on the backend `/users` routes that were surfaced while investigating it.

### Frontend: `Prefetch` was doing nothing useful

`Prefetch` called `setupStore()` inside a `useEffect`, creating a **brand-new, throw-away** Redux store with no auth state. Every prefetch dispatched into that store, so:

- `prepareHeaders` read `auth.token === null` → no `Authorization` header
- requests came back **401** (the reauth wrapper only retries on 403)
- the cached results landed in a store nobody reads, then got GC'd

The real data always loaded later via the RTK Query hooks against the actual app store. Net effect: 4 guaranteed-failing background requests per navigation, zero caching benefit.

**Fix:** dispatch via `useAppDispatch` into the real store so the logged-in token is attached. Also skip the `getUsers` prefetch for non-Manager/Admin users (they can't view the user list). `getQueueState` stays ungated — its consumer `BullMQSummary` renders for all authenticated users.

### Backend: `/users` authorization gaps

While tracing the 401s, found that several `/users` endpoints had only `verifyJWT` and **no role or ownership check**:

| Endpoint | Problem | Fix |
|---|---|---|
| `GET /users` | any authed user could list all users | `verifyRoles('Admin','Manager')` |
| `PATCH /users` | **any user could edit any user — including setting their own roles to Admin** | `verifyRoles('Admin','Manager')` |
| `GET /users/:id` | any authed user could read any user | `verifyRoles('Admin','Manager')` |
| `DELETE /users/:id` | any authed user could delete any user | `verifyRoles('Admin','Manager')` |
| `DELETE /users/delete-user-by-username/:username` | **any user could delete anyone's account** | `verifyAccountOwnership('params')` |
| `POST /users/change-email`, `/verify-otp`, `/resend-otp` | trusted caller-supplied username | `verifyAccountOwnership('body')` |

New `verifyAccountOwnership` middleware enforces self-only access (`req.user !== username → 403`), mirroring the existing pattern in the API-token controllers (which already did this correctly and are untouched).

### Won't break existing flows

- Self-service account deletion (`UserAccount.tsx`) passes the user's own username → allowed
- Admin user edit/delete (`EditUserForm.tsx`, Manager/Admin-only UI) → allowed by `verifyRoles`
- API token routes already enforced ownership → untouched
- Queue summary shown to all users → left open intentionally

## Tests

- New `Prefetch.test.tsx` (4 tests): role-gated prefetch behavior, dispatch into real store
- New `verifyAccountOwnership.test.ts` (7 tests, 100% coverage): self/owner allowed, others 403, missing user 401
- **UI**: lint clean, build clean, 1103 tests pass
- **Backend**: lint clean, build clean, 470 tests pass

## Changeset

Patch bump for `@bilbomd/ui` and `@bilbomd/backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
