### PR TITLE
feat(infra): show chart version and recent revisions in nersc status

### DIFF
--- a/infra/deploy-to-nersc.sh
+++ b/infra/deploy-to-nersc.sh
@@ -89,11 +89,29 @@ image_summary() {
   echo "--------------------------------"
 }
 
+# Print the chart version + appVersion from the local Chart.yaml.
+chart_summary() {
+  local chart_file="$CHART_PATH/Chart.yaml"
+  local version app_version
+  version=$(yq '.version' "$chart_file")
+  app_version=$(yq '.appVersion' "$chart_file")
+  echo -e "${BLUE}🧩 Chart $(basename "$chart_file"):${NC}"
+  printf "   %-12s %s\n" "version" "$version"
+  printf "   %-12s %s\n" "appVersion" "$app_version"
+  echo "--------------------------------"
+}
+
 # Read-only status block; reused at the end of deploy/rollback.
 show_status() {
+  chart_summary
+
   echo -e "${BLUE}📜 Helm status for $RELEASE:${NC}"
   helm status "$RELEASE" 2>/dev/null | grep -E '^(NAME|LAST DEPLOYED|NAMESPACE|STATUS|REVISION):' || \
     echo -e "${YELLOW}   (no release found)${NC}"
+  echo "--------------------------------"
+
+  echo -e "${BLUE}📜 Helm history for $RELEASE (last 5):${NC}"
+  helm history "$RELEASE" --max 5 2>/dev/null || echo -e "${YELLOW}   (no prior release)${NC}"
   echo "--------------------------------"
 
   echo -e "${BLUE}🚀 Deployments & pods in $NS:${NC}"


### PR DESCRIPTION
## Summary

Enhances `infra/deploy-to-nersc.sh` so the status output includes the chart/app version and recent release history.

- Adds `chart_summary()` which prints `version` and `appVersion` read directly from `helm/Chart.yaml`.
- Adds a `helm history "$RELEASE" --max 5` block to `show_status()`.

Because these live in `show_status()`, they appear with `status <env>` and also after `deploy`/`rollback`.

## Why

`./infra/deploy-to-nersc.sh status prod` already shows a lot of useful info, but didn't surface the chart `version`/`appVersion` or the last few revisions. The `helm history` block's `CHART` and `APP VERSION` columns make it easy to compare what's live against the local `Chart.yaml`.

## Example output (status)

```
🧩 Chart Chart.yaml:
   version      0.1.62
   appVersion   2.21.3
--------------------------------
📜 Helm status for bilbomd-nersc-prod:
...
📜 Helm history for bilbomd-nersc-prod (last 5):
REVISION  UPDATED  STATUS  CHART  APP VERSION  DESCRIPTION
...
```

## Testing

- `bash -n deploy-to-nersc.sh` passes (syntax check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)