### PR TITLE
fix(users): repair admin Edit User and add validation

### DIFF
--- a/.changeset/fix-admin-edit-user-roles.md
+++ b/.changeset/fix-admin-edit-user-roles.md
@@ -1,0 +1,6 @@
+---
+'@bilbomd/backend': patch
+'@bilbomd/ui': patch
+---
+
+Fix Admin "Edit User" failing with "Invalid username format" when changing a user's roles. The backend no longer requires (or changes) the username on update — admins edit roles, active status, and email only. The username is now shown read-only in the form. Added real client-side validation (valid email, at least one role) and a friendly duplicate-email check on the backend.

--- a/apps/backend/src/controllers/__tests__/usersController.test.ts
+++ b/apps/backend/src/controllers/__tests__/usersController.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Request, Response } from 'express'
+
+vi.mock('../../config/config.js', () => ({
+  getEnvVar: vi.fn().mockReturnValue('https://bilbomd.example.com')
+}))
+
+vi.mock('@bilbomd/mongodb-schema', () => ({
+  User: { findById: vi.fn(), findOne: vi.fn() },
+  Job: { findOne: vi.fn(), exists: vi.fn() }
+}))
+
+vi.mock('../../config/nodemailerConfig.js', () => ({
+  sendOtpEmail: vi.fn(),
+  sendUpdatedEmailMessage: vi.fn(),
+  sendDeleteAccountSuccessEmail: vi.fn()
+}))
+
+vi.mock('../../middleware/loggers.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn() }
+}))
+
+import { User } from '@bilbomd/mongodb-schema'
+import { updateUser } from '../usersController.js'
+
+const makeReq = (body: unknown): Request => ({ body }) as Request
+const makeRes = (): Response => {
+  const res = {} as Response
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  return res
+}
+
+// Chain the controller uses for the duplicate-email lookup:
+// User.findOne({ email }).collation(...).lean().exec()
+const findOneChain = (result: unknown) => ({
+  collation: () => ({ lean: () => ({ exec: () => Promise.resolve(result) }) })
+})
+
+const validBody = {
+  id: 'user-1',
+  roles: ['User'],
+  active: true,
+  email: 'user@example.com'
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('updateUser', () => {
+  it('returns 400 when id is missing', async () => {
+    const res = makeRes()
+    await updateUser(makeReq({ ...validBody, id: undefined }), res)
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'User ID is required'
+    })
+  })
+
+  it('returns 400 when roles are missing or empty', async () => {
+    const res = makeRes()
+    await updateUser(makeReq({ ...validBody, roles: [] }), res)
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Roles are required'
+    })
+  })
+
+  it('returns 400 when active is not a boolean', async () => {
+    const res = makeRes()
+    await updateUser(makeReq({ ...validBody, active: 'yes' }), res)
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Active status is required'
+    })
+  })
+
+  it('returns 400 when email is invalid', async () => {
+    const res = makeRes()
+    await updateUser(makeReq({ ...validBody, email: 'not-an-email' }), res)
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Invalid email format'
+    })
+  })
+
+  it('does NOT require a username (regression for "Invalid username format")', async () => {
+    const save = vi.fn().mockResolvedValue({ username: 'scott' })
+    vi.mocked(User.findById).mockReturnValue({
+      exec: () =>
+        Promise.resolve({ username: 'scott', roles: [], active: false, save })
+    } as never)
+    vi.mocked(User.findOne).mockReturnValue(findOneChain(null) as never)
+
+    const res = makeRes()
+    // Body intentionally has no `username` field.
+    await updateUser(makeReq(validBody), res)
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(save).toHaveBeenCalled()
+  })
+
+  it('returns 404 when the user does not exist', async () => {
+    vi.mocked(User.findById).mockReturnValue({
+      exec: () => Promise.resolve(null)
+    } as never)
+
+    const res = makeRes()
+    await updateUser(makeReq(validBody), res)
+    expect(res.status).toHaveBeenCalledWith(404)
+  })
+
+  it('returns 409 when the email belongs to another user', async () => {
+    const save = vi.fn()
+    vi.mocked(User.findById).mockReturnValue({
+      exec: () => Promise.resolve({ username: 'scott', save })
+    } as never)
+    vi.mocked(User.findOne).mockReturnValue(
+      findOneChain({ _id: 'someone-else' }) as never
+    )
+
+    const res = makeRes()
+    await updateUser(makeReq(validBody), res)
+    expect(res.status).toHaveBeenCalledWith(409)
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Duplicate email'
+    })
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('updates roles, active, and email then saves', async () => {
+    const user = {
+      username: 'scott',
+      roles: ['User'],
+      active: false,
+      email: 'old@example.com',
+      save: vi.fn().mockResolvedValue({ username: 'scott' })
+    }
+    vi.mocked(User.findById).mockReturnValue({
+      exec: () => Promise.resolve(user)
+    } as never)
+    // Duplicate-email lookup finds the same user (its own _id) -> allowed.
+    vi.mocked(User.findOne).mockReturnValue(
+      findOneChain({ _id: 'user-1' }) as never
+    )
+
+    const res = makeRes()
+    await updateUser(
+      makeReq({
+        id: 'user-1',
+        roles: ['Admin', 'User'],
+        active: true,
+        email: 'new@example.com'
+      }),
+      res
+    )
+
+    expect(user.roles).toEqual(['Admin', 'User'])
+    expect(user.active).toBe(true)
+    expect(user.email).toBe('new@example.com')
+    expect(user.save).toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'scott updated'
+    })
+  })
+})

--- a/apps/backend/src/controllers/usersController.ts
+++ b/apps/backend/src/controllers/usersController.ts
@@ -36,16 +36,15 @@ const getAllUsers = async (req: Request, res: Response) => {
   }
 }
 
+// Admins edit a user's roles, active status, and email. The username is the
+// login identity (often ORCID-derived) and is intentionally NOT editable here,
+// so it is neither required in the request nor changed.
 const updateUser = async (req: Request, res: Response): Promise<void> => {
-  const { id, username, roles, active, email } = req.body
+  const { id, roles, active, email } = req.body
 
   // Validate inputs
   if (!id) {
     res.status(400).json({ success: false, message: 'User ID is required' })
-    return
-  }
-  if (!username || !isValidUsername(username)) {
-    res.status(400).json({ success: false, message: 'Invalid username format' })
     return
   }
   if (!Array.isArray(roles) || !roles.length) {
@@ -71,17 +70,17 @@ const updateUser = async (req: Request, res: Response): Promise<void> => {
       return
     }
 
-    const duplicate = await User.findOne({ username })
+    // Guard against assigning an email already used by another account.
+    const duplicate = await User.findOne({ email })
       .collation({ locale: 'en', strength: 2 }) // provide case-insensitive search
       .lean()
       .exec()
 
     if (duplicate && duplicate?._id.toString() !== id) {
-      res.status(409).json({ success: false, message: 'Duplicate username' })
+      res.status(409).json({ success: false, message: 'Duplicate email' })
       return
     }
 
-    user.username = username
     user.roles = roles
     user.active = active
     user.email = email

--- a/apps/ui/src/features/users/EditUserForm.tsx
+++ b/apps/ui/src/features/users/EditUserForm.tsx
@@ -9,6 +9,7 @@ import {
   FormLabel,
   FormControl,
   FormGroup,
+  FormHelperText,
   Select,
   Typography,
   InputLabel,
@@ -145,6 +146,8 @@ const EditUserForm = ({ user }: EditUserFormProps) => {
           >
             {({
               values,
+              errors,
+              touched,
               isSubmitting,
               handleChange,
               handleBlur,
@@ -162,11 +165,11 @@ const EditUserForm = ({ user }: EditUserFormProps) => {
                       label="Username"
                       type="text"
                       autoComplete="off"
-                      disabled={isSubmitting}
+                      fullWidth
                       component={TextField}
-                      onChange={handleChange}
-                      onBlur={handleBlur}
                       value={values.username || ''}
+                      helperText="Username cannot be changed"
+                      slotProps={{ input: { readOnly: true } }}
                     />
                   </Grid>
                   <Grid sx={{ my: 2, width: '300px' }}>
@@ -182,6 +185,8 @@ const EditUserForm = ({ user }: EditUserFormProps) => {
                       onChange={handleChange}
                       onBlur={handleBlur}
                       value={values.email || ''}
+                      error={touched.email && Boolean(errors.email)}
+                      helperText={touched.email && errors.email}
                     />
                   </Grid>
 
@@ -202,11 +207,15 @@ const EditUserForm = ({ user }: EditUserFormProps) => {
                     {/* https://github.com/jaredpalmer/formik/issues/2123 */}
 
                     <FormLabel component="legend">Assign Roles</FormLabel>
-                    <FormControl sx={{ my: 2, width: 300 }}>
+                    <FormControl
+                      sx={{ my: 2, width: 300 }}
+                      error={touched.roles && Boolean(errors.roles)}
+                    >
                       <InputLabel id="roles">Roles</InputLabel>
                       <Select
                         labelId="roles"
                         id="roles"
+                        name="roles"
                         multiple={true}
                         value={values.roles}
                         onChange={(e) => {
@@ -215,6 +224,7 @@ const EditUserForm = ({ user }: EditUserFormProps) => {
                           )
                           void setFieldValue('roles', next)
                         }}
+                        onBlur={handleBlur}
                         input={<OutlinedInput label="Roles" />}
                         renderValue={(selected) =>
                           (selected as string[]).join(', ')
@@ -233,6 +243,11 @@ const EditUserForm = ({ user }: EditUserFormProps) => {
                           </MenuItem>
                         ))}
                       </Select>
+                      {touched.roles && errors.roles ? (
+                        <FormHelperText>
+                          {errors.roles as string}
+                        </FormHelperText>
+                      ) : null}
                     </FormControl>
                   </Grid>
                   <Grid>

--- a/apps/ui/src/schemas/ValidationSchemas.ts
+++ b/apps/ui/src/schemas/ValidationSchemas.ts
@@ -1,4 +1,4 @@
-import { boolean, object, string } from 'yup'
+import { array, boolean, object, string } from 'yup'
 
 export const userRegisterSchema = object().shape({
   email: string().email('Please enter a valid email').required('Required'),
@@ -13,5 +13,10 @@ export const userSignInSchema = object().shape({
 })
 
 export const editUserSchema = object().shape({
-  active: boolean()
+  email: string().email('Please enter a valid email').required('Required'),
+  roles: array()
+    .of(string())
+    .min(1, 'At least one role is required')
+    .required('At least one role is required'),
+  active: boolean().required('Required')
 })

--- a/apps/ui/src/schemas/__tests__/ValidationSchemas.test.ts
+++ b/apps/ui/src/schemas/__tests__/ValidationSchemas.test.ts
@@ -71,12 +71,38 @@ describe('userSignInSchema', () => {
 })
 
 describe('editUserSchema', () => {
-  it('accepts valid boolean active', async () => {
-    await expect(editUserSchema.isValid({ active: true })).resolves.toBe(true)
-    await expect(editUserSchema.isValid({ active: false })).resolves.toBe(true)
+  const validUser = {
+    email: 'user@example.com',
+    roles: ['User'],
+    active: true
+  }
+
+  it('accepts a valid user with email, roles, and active', async () => {
+    await expect(editUserSchema.isValid(validUser)).resolves.toBe(true)
+    await expect(
+      editUserSchema.isValid({ ...validUser, active: false })
+    ).resolves.toBe(true)
   })
 
-  it('accepts empty object (active is not required)', async () => {
-    await expect(editUserSchema.isValid({})).resolves.toBe(true)
+  it('rejects an invalid email', async () => {
+    await expect(
+      editUserSchema.isValid({ ...validUser, email: 'not-an-email' })
+    ).resolves.toBe(false)
+  })
+
+  it('rejects a missing email', async () => {
+    await expect(
+      editUserSchema.isValid({ roles: ['User'], active: true })
+    ).resolves.toBe(false)
+  })
+
+  it('rejects an empty roles array', async () => {
+    await expect(
+      editUserSchema.isValid({ ...validUser, roles: [] })
+    ).resolves.toBe(false)
+  })
+
+  it('rejects an empty object', async () => {
+    await expect(editUserSchema.isValid({})).resolves.toBe(false)
   })
 })


### PR DESCRIPTION
## Problem

The Admin-only **Edit User** form was completely broken: changing a user's roles (or anything else) failed with **"Invalid username format"**.

**Root cause:** the form never sent a `username` in the PATCH body, but the backend `updateUser` controller *required* one. `!username` was always true, so every update was rejected. The `UpdateUserDTO` type didn't even include `username`, so frontend and backend were out of sync.

## Changes

**Backend** (`usersController.ts`)
- `updateUser` no longer requires or modifies `username`. Admins edit **roles, active, and email** only — username is the login identity (often ORCID-derived) and is intentionally not editable.
- Replaced the obsolete duplicate-*username* check with a case-insensitive duplicate-*email* check returning a friendly `409 Duplicate email`.

**Frontend** (`EditUserForm.tsx`)
- Username field is now **read-only** with a "Username cannot be changed" helper.
- Email and Roles now show inline validation errors.

**Validation** (`ValidationSchemas.ts`)
- `editUserSchema` now validates email (required + valid), roles (≥ 1), and active (boolean). It was previously a near-empty schema.

**Tests**
- New `usersController.test.ts` (8 tests) incl. a regression test asserting username is *not* required.
- Updated `ValidationSchemas.test.ts` for the tightened schema.

## Verification

- `pnpm lint` ✓ (backend + ui)
- `pnpm build` (type-check) ✓ (backend + ui)
- Backend: 478 tests ✓ · UI: 1106 tests ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)