### PR TITLE
docs: update README badges to match current versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CI Status](https://github.com/bl1231/bilbomd/actions/workflows/ci.yml/badge.svg)](https://github.com/bl1231/bilbomd/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Berkeley%20Lab%20Non--Commercial-blue.svg)](https://github.com/bl1231/bilbomd/blob/main/LICENSE.txt)
-[![Node](https://img.shields.io/badge/node-v24.14.1-brightgreen?logo=node.js)](https://nodejs.org/)
-[![pnpm](https://img.shields.io/badge/pnpm-10.33.0-orange?logo=pnpm)](https://pnpm.io/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![Node](https://img.shields.io/badge/node-v26.3.1-brightgreen?logo=node.js)](https://nodejs.org/)
+[![pnpm](https://img.shields.io/badge/pnpm-11.5.3-orange?logo=pnpm)](https://pnpm.io/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.x-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![Turborepo](https://img.shields.io/badge/Turborepo-monorepo-blueviolet?logo=turborepo)](https://turbo.build/)
 [![Docker](https://img.shields.io/badge/Docker-ghcr.io-2496ED?logo=docker)](https://github.com/bl1231?tab=packages&repo_name=bilbomd)
 [![Last Commit](https://img.shields.io/github/last-commit/bl1231/bilbomd)](https://github.com/bl1231/bilbomd/commits/main/)


### PR DESCRIPTION
## Summary

Updated out-of-date version badges in `README.md` to match the actual repo configuration:

| Badge | Before | After | Source |
|-------|--------|-------|--------|
| Node | `v24.14.1` | `v26.3.1` | `.nvmrc` |
| pnpm | `10.33.0` | `11.5.3` | root `package.json` `packageManager` |
| TypeScript | `5.x` | `6.x` | root `package.json` `typescript: ^6.0.3` |

The remaining badges (CI Status, License, Turborepo, Docker, Last Commit) were verified as accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)