### PR TITLE
ci: auto-bump infra image tags inside the release PR

### DIFF
--- a/.github/workflows/changesets-release-pr.yml
+++ b/.github/workflows/changesets-release-pr.yml
@@ -57,6 +57,12 @@ jobs:
         if: steps.check_changesets.outputs.count != '0'
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version
+          # Bump package versions AND sync the in-house image tags in the
+          # infra compose/helm files in the same Version Packages PR, so the
+          # deployment files are already up to date the moment the release
+          # merges (no waiting for Renovate). changesets/action stages all
+          # working-tree changes (git add .), so the infra edits are committed
+          # onto the release branch alongside the version bumps.
+          version: pnpm run changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/infra/docker-compose-epyc.dev.yml
+++ b/infra/docker-compose-epyc.dev.yml
@@ -87,7 +87,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   backend:
-    image: ghcr.io/bl1231/bilbomd-backend:2.9.13
+    image: ghcr.io/bl1231/bilbomd-backend:2.9.14
     pull_policy: missing
     security_opt:
       - no-new-privileges:true
@@ -121,7 +121,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   worker:
-    image: ghcr.io/bl1231/bilbomd-worker:2.14.11
+    image: ghcr.io/bl1231/bilbomd-worker:2.14.12
     pull_policy: always
     security_opt:
       - no-new-privileges:true
@@ -251,7 +251,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   ui:
-    image: ghcr.io/bl1231/bilbomd-ui:2.21.4
+    image: ghcr.io/bl1231/bilbomd-ui:2.21.5
     pull_policy: missing
     security_opt:
       - seccomp:./seccomp/bilbomd-seccomp.json

--- a/infra/docker-compose-epyc.prod.yml
+++ b/infra/docker-compose-epyc.prod.yml
@@ -83,7 +83,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   backend:
-    image: ghcr.io/bl1231/bilbomd-backend:2.9.13
+    image: ghcr.io/bl1231/bilbomd-backend:2.9.14
     pull_policy: missing
     security_opt:
       - no-new-privileges:true
@@ -117,7 +117,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   worker:
-    image: ghcr.io/bl1231/bilbomd-worker:2.14.11
+    image: ghcr.io/bl1231/bilbomd-worker:2.14.12
     pull_policy: missing
     security_opt:
       - no-new-privileges:true
@@ -247,7 +247,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   ui:
-    image: ghcr.io/bl1231/bilbomd-ui:2.21.4
+    image: ghcr.io/bl1231/bilbomd-ui:2.21.5
     pull_policy: missing
     security_opt:
       - seccomp:./seccomp/bilbomd-seccomp.json

--- a/infra/docker-compose-hyperion.dev.yml
+++ b/infra/docker-compose-hyperion.dev.yml
@@ -11,7 +11,7 @@ networks:
 
 services:
   scoper:
-    image: ghcr.io/bl1231/bilbomd-scoper:1.7.17
+    image: ghcr.io/bl1231/bilbomd-scoper:1.7.18
     pull_policy: always
     security_opt:
       - no-new-privileges:true

--- a/infra/docker-compose-hyperion.prod.yml
+++ b/infra/docker-compose-hyperion.prod.yml
@@ -11,7 +11,7 @@ networks:
 
 services:
   scoper:
-    image: ghcr.io/bl1231/bilbomd-scoper:1.7.17
+    image: ghcr.io/bl1231/bilbomd-scoper:1.7.18
     pull_policy: always
     security_opt:
       - no-new-privileges:true

--- a/infra/helm/values-dev.yaml
+++ b/infra/helm/values-dev.yaml
@@ -53,7 +53,7 @@ ui:
   name: ui
   image:
     repository: ghcr.io/bl1231/bilbomd-ui
-    tag: 2.21.4
+    tag: 2.21.5
     pullPolicy: Always
     secret: ghcr
 
@@ -61,7 +61,7 @@ backend:
   name: backend
   image:
     repository: ghcr.io/bl1231/bilbomd-backend
-    tag: 2.9.13
+    tag: 2.9.14
     pullPolicy: Always
     secret: ghcr
 
@@ -69,6 +69,6 @@ worker:
   name: worker
   image:
     repository: ghcr.io/bl1231/bilbomd-worker
-    tag: 2.14.11
+    tag: 2.14.12
     pullPolicy: Always
     secret: ghcr

--- a/infra/helm/values-prod.yaml
+++ b/infra/helm/values-prod.yaml
@@ -53,7 +53,7 @@ ui:
   name: ui
   image:
     repository: ghcr.io/bl1231/bilbomd-ui
-    tag: 2.21.4
+    tag: 2.21.5
     pullPolicy: Always
     secret: ghcr
 
@@ -61,7 +61,7 @@ backend:
   name: backend
   image:
     repository: ghcr.io/bl1231/bilbomd-backend
-    tag: 2.9.13
+    tag: 2.9.14
     pullPolicy: Always
     secret: ghcr
 
@@ -69,6 +69,6 @@ worker:
   name: worker
   image:
     repository: ghcr.io/bl1231/bilbomd-worker
-    tag: 2.14.11
+    tag: 2.14.12
     pullPolicy: Always
     secret: ghcr

--- a/infra/scripts/sync-image-tags.mjs
+++ b/infra/scripts/sync-image-tags.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Sync in-house Docker image tags in deployment files to the versions in each
+// app's package.json. The Changesets release bumps apps/<app>/package.json and
+// CI builds/pushes ghcr.io/bl1231/bilbomd-<app>:<version>; this keeps the
+// compose + helm files pointed at those freshly released tags without waiting
+// for Renovate.
+//
+// Idempotent: running it when everything is already in sync changes nothing.
+// Only the four changeset-driven images are touched (backend/ui/worker/scoper).
+// Third-party (mongo, redis) and the non-changeset of3/colabfold service images
+// are intentionally left for Renovate.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+// service name (under apps/) -> ghcr image name suffix
+const services = [
+  { app: 'backend', image: 'bilbomd-backend' },
+  { app: 'ui', image: 'bilbomd-ui' },
+  { app: 'worker', image: 'bilbomd-worker' },
+  { app: 'scoper', image: 'bilbomd-scoper' }
+]
+
+// Deployment files that may reference any of the in-house images. Both compose
+// (inline `image: ghcr.io/...:tag`) and helm (`repository:`/`tag:` pair) layouts
+// are handled, and applying both transforms to every file is harmless.
+const targetFiles = [
+  'infra/docker-compose-epyc.dev.yml',
+  'infra/docker-compose-epyc.prod.yml',
+  'infra/docker-compose-hyperion.dev.yml',
+  'infra/docker-compose-hyperion.prod.yml',
+  'infra/helm/values-dev.yaml',
+  'infra/helm/values-prod.yaml'
+]
+
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const versionFor = (app) => {
+  const pkgPath = resolve(repoRoot, 'apps', app, 'package.json')
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+  if (!pkg.version) throw new Error(`No version field in ${pkgPath}`)
+  return pkg.version
+}
+
+const syncContent = (content, image, version) => {
+  const img = escapeRe(`ghcr.io/bl1231/${image}`)
+  // compose: `image: ghcr.io/bl1231/<image>:<tag>`
+  let next = content.replace(
+    new RegExp(`(${img}:)[^\\s"']+`, 'g'),
+    `$1${version}`
+  )
+  // helm: `repository: ghcr.io/bl1231/<image>` followed by `tag: <tag>`
+  next = next.replace(
+    new RegExp(`(repository:\\s*${img}\\s*\\n\\s*tag:\\s*)[^\\s#]+`, 'g'),
+    `$1${version}`
+  )
+  return next
+}
+
+const versions = Object.fromEntries(
+  services.map(({ app, image }) => [image, versionFor(app)])
+)
+
+let changedAny = false
+for (const file of targetFiles) {
+  const path = resolve(repoRoot, file)
+  const original = readFileSync(path, 'utf8')
+  let updated = original
+  for (const { image } of services) {
+    updated = syncContent(updated, image, versions[image])
+  }
+  if (updated !== original) {
+    writeFileSync(path, updated)
+    changedAny = true
+    console.log(`updated ${file}`)
+  }
+}
+
+const summary = services
+  .map(({ image }) => `${image}=${versions[image]}`)
+  .join(' ')
+console.log(
+  changedAny
+    ? `Synced infra image tags: ${summary}`
+    : `Infra image tags already in sync: ${summary}`
+)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "lint": "turbo run lint",
     "test": "turbo run test",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "sync:image-tags": "node infra/scripts/sync-image-tags.mjs",
+    "changeset:version": "changeset version && node infra/scripts/sync-image-tags.mjs"
   },
   "devDependencies": {
     "@bilbomd/eslint-config": "workspace:*",

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,17 @@
   },
   "packageRules": [
     {
+      "description": "In-house bilbomd images are auto-bumped on release by the sync-infra-image-tags CI job; Renovate ignores them",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/bl1231/bilbomd-backend",
+        "ghcr.io/bl1231/bilbomd-ui",
+        "ghcr.io/bl1231/bilbomd-worker",
+        "ghcr.io/bl1231/bilbomd-scoper"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Group container image updates across compose and helm into one PR",
       "matchManagers": ["docker-compose", "helm-values"],
       "matchDatasources": ["docker"],


### PR DESCRIPTION
Closes #936.

## What

When a Changesets "Version Packages" PR merges to `main`, CI builds and pushes new semver Docker images, but the deployment files (`infra/docker-compose-*.yml`, `infra/helm/values-*.yaml`) keep pointing at the previous tags until Renovate notices the new GHCR tags (weekly) and a Renovate PR is manually approved. This eliminates that lag and the manual step.

## Approach: bump infra inside the release PR

The correct new tag is simply `apps/<app>/package.json` `.version`, already known at release time. So the bump happens **as part of versioning**:

- The changesets release workflow now runs **`pnpm run changeset:version`** = `changeset version` (bumps package.json) **+** `node infra/scripts/sync-image-tags.mjs` (rewrites the in-house image tags in the infra files to match).
- `changesets/action` stages **all** working-tree changes (`git add .`, see its `src/github.ts:40`), so the infra edits land in the **same "Version Packages" PR** the maintainer already merges — no second PR, no bot pushing to a protected branch.

### Why not commit directly to main?

`main` is protected by an **active ruleset** ("main"): require-a-PR-before-merging (0 approvals, no required checks), block force pushes, restrict deletion, **no bypass actors**. (This is Rulesets, not Classic branch protection — which is why Settings→Branches shows nothing.) A direct `git push` to `main` from CI would be rejected, so the change is routed through the release PR by design.

### Tradeoff (accepted)

Infra references the new tag from the moment the release PR merges — a few minutes before CI finishes pushing the image. Benign: Hyperion/NERSC deploys are manual operator actions done after a release is ready, by which time the tag (and `latest`) exist.

## Changes

- **`infra/scripts/sync-image-tags.mjs`** — idempotent, dependency-free script syncing the four `bilbomd-{backend,ui,worker,scoper}` tags across the 6 compose + helm files. Runnable locally via `pnpm sync:image-tags`.
- **`package.json`** — add `changeset:version` and `sync:image-tags` scripts.
- **`.github/workflows/changesets-release-pr.yml`** — use `pnpm run changeset:version`.
- **`renovate.json`** — disable Renovate for the four in-house images (mongo/redis/of3/colabfold still managed by Renovate).
- **infra files** — bumped to current released versions (`backend 2.9.14`, `ui 2.21.5`, `worker 2.14.12`, `scoper 1.7.18`), clearing existing drift.

## Verification

- `node infra/scripts/sync-image-tags.mjs` bumps the live drift across the 6 infra files, then is a no-op on a second run; diff shows only `bilbomd-*` tags changed.
- Dry-tested `pnpm run changeset:version` with a throwaway changeset: a `@bilbomd/ui` patch bumped `apps/ui/package.json` **and** all UI infra references together in one run (then reverted).
- All edited YAML/JSON validated.
- No changeset: CI/infra-only change with no package code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)