### PR TITLE
chore(infra): bump SF API token expiry and chart version

### DIFF
--- a/infra/helm/Chart.yaml
+++ b/infra/helm/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.61
+version: 0.1.62
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: '2.20.4'
+appVersion: '2.21.5'

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -4,4 +4,4 @@ nersc_repo: m4659
 cfs_dir: /global/cfs/cdirs
 pscratch: /pscratch/sd/s/sclassen
 sfapi:
-  token_expires: '2026-07-01 13:02'
+  token_expires: '2026-08-03 08:11'


### PR DESCRIPTION
## Summary

Records the Superfacility API credential rotation in the helm chart:
- `sfapi.token_expires`: `2026-07-01 13:02` → `2026-08-03 08:11`
- chart `version`: `0.1.61` → `0.1.62`, `appVersion`: `2.20.4` → `2.21.5`

The new token expiry is surfaced in the UI via the backend `/configs` endpoint (`SFAPI_TOKEN_EXPIRES`).

## Status

Already applied to **dev** and **prod** via `infra/update_sfapi.sh`. This PR captures the working-tree changes in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)