### PR TITLE
feat(nersc): live SFAPI token expiration from /account/clients

### DIFF
--- a/.changeset/live-sfapi-token-expiration.md
+++ b/.changeset/live-sfapi-token-expiration.md
@@ -1,0 +1,6 @@
+---
+'@bilbomd/backend': minor
+'@bilbomd/ui': minor
+---
+
+Show the Superfacility API token expiration live instead of from a hand-maintained value. The backend adds an authenticated `/sfapi/account/clients` endpoint that reads the configured client's `expiresAt` directly from NERSC, and the UI TokenExpirationChip now sources its date from that endpoint. The static `SFAPI_TOKEN_EXPIRES` config value (and the `sfapi.token_expires` Helm value / configmap entry) is removed, so the expiration display can no longer drift out of date.

--- a/apps/backend/src/controllers/configsController.ts
+++ b/apps/backend/src/controllers/configsController.ts
@@ -53,7 +53,6 @@ export const getConfigsStuff = async (
 
     // Log environment variables for debugging.
     const envVars = [
-      'SFAPI_TOKEN_EXPIRES',
       'USE_NERSC',
       'NERSC_PROJECT',
       'SENDMAIL_USER',
@@ -82,7 +81,6 @@ export const getConfigsStuff = async (
       deploySite: process.env.BILBOMD_DEPLOY_SITE || '',
       useNersc: process.env.USE_NERSC || 'false',
       nerscProject: process.env.NERSC_PROJECT || 'm1234',
-      tokenExpires: process.env.SFAPI_TOKEN_EXPIRES || '2024-05-22 04:20',
       sendMailUser: process.env.SENDMAIL_USER || 'bilbomd@lbl.gov',
       enableBilboMdSANS: process.env.ENABLE_BILBOMD_SANS || 'false',
       enableBilboMdMulti: process.env.ENABLE_BILBOMD_MULTI || 'false',

--- a/apps/backend/src/controllers/sfapiController.ts
+++ b/apps/backend/src/controllers/sfapiController.ts
@@ -133,6 +133,13 @@ async function makeUnauthenticatedSFApiRequest<T>({
   }
 }
 
+interface SfapiClient {
+  name: string
+  clientId: string
+  expiresAt: string
+  comments?: string | null
+}
+
 const getStatus = async (req: Request, res: Response) => {
   const { success, data, error } = await makeUnauthenticatedSFApiRequest({
     endpoint: '/status'
@@ -226,4 +233,43 @@ const getProjectHours = async (req: Request, res: Response) => {
   }
 }
 
-export { getStatus, getOutages, getUser, getProjectHours }
+// Return the expiration for our own SFAPI client. /account/clients lists all of
+// the account's clients (GREEN scope, which our RED client token also satisfies);
+// we filter to the configured SFAPI_CLIENT_ID so the UI can show a live, always
+// up-to-date expiration instead of a hand-maintained value.
+const getClientExpiration = async (req: Request, res: Response) => {
+  if (!req.sfApiToken) {
+    res.status(401).json({ error: 'No SF API token provided.' })
+    return
+  }
+
+  const clientId = process.env.SFAPI_CLIENT_ID
+  if (!clientId) {
+    res.status(500).json({ error: 'SFAPI_CLIENT_ID is not configured.' })
+    return
+  }
+
+  const { success, data, error } = await makeSFApiRequest<SfapiClient[]>({
+    endpoint: '/account/clients',
+    token: req.sfApiToken as string
+  })
+
+  if (!success) {
+    res.status(500).json({ error })
+    return
+  }
+
+  const client = data?.find((c) => c.clientId === clientId)
+  if (!client) {
+    res.status(404).json({ error: 'Configured SF API client not found.' })
+    return
+  }
+
+  res.json({
+    clientId: client.clientId,
+    name: client.name,
+    expiresAt: client.expiresAt
+  })
+}
+
+export { getStatus, getOutages, getUser, getProjectHours, getClientExpiration }

--- a/apps/backend/src/routes/sfapi.ts
+++ b/apps/backend/src/routes/sfapi.ts
@@ -3,7 +3,8 @@ import {
   getStatus,
   getOutages,
   getUser,
-  getProjectHours
+  getProjectHours,
+  getClientExpiration
 } from '../controllers/sfapiController.js'
 import { ensureSFAuthenticated } from '../middleware/tokenManager.js'
 // import verifyJWT from '../middleware/verifyJWT'
@@ -21,6 +22,7 @@ router.use(ensureSFAuthenticated)
 
 // Protected routes
 router.route('/account').get(getUser)
+router.route('/account/clients').get(getClientExpiration)
 router.route('/account/projects/:repocode').get(getProjectHours)
 
 export default router

--- a/apps/ui/src/app/api/sfapiSlice.ts
+++ b/apps/ui/src/app/api/sfapiSlice.ts
@@ -9,6 +9,6 @@ const baseQuery = fetchBaseQuery({
 export const superfacilityApiSlice = createApi({
   reducerPath: 'superfacilityApi',
   baseQuery: baseQuery,
-  tagTypes: ['Status', 'Project', 'Outages'],
+  tagTypes: ['Status', 'Project', 'Outages', 'ClientExpiration'],
   endpoints: () => ({})
 })

--- a/apps/ui/src/features/nersc/TokenExpirationChip.tsx
+++ b/apps/ui/src/features/nersc/TokenExpirationChip.tsx
@@ -8,19 +8,18 @@ import {
   subWeeks
 } from 'date-fns'
 import { formatDateSafe, parseDateSafe } from 'utils/dates'
-import { useGetConfigsQuery } from 'slices/configsApiSlice'
+import { useGetSfapiClientExpirationQuery } from 'slices/nerscApiSlice'
 
 const TokenExpirationChip = () => {
   const now = new Date()
-  const { data, error, isLoading } = useGetConfigsQuery('configData')
+  const { data, isLoading } = useGetSfapiClientExpirationQuery()
 
   if (isLoading) return <div>Loading...</div>
-  if (error) return <div>Error loading configuration data</div>
 
-  // Check if data is undefined
-  if (!data) return <div>No configuration data available</div>
-
-  const expirationDate = parseDateSafe(data?.tokenExpires)
+  // The expiration is fetched live from the Superfacility API. If the request
+  // failed (e.g. the client has already expired and can no longer authenticate),
+  // data is undefined and the chip falls back to "Expires: unknown".
+  const expirationDate = parseDateSafe(data?.expiresAt)
 
   let chipColor: string
   let chipLabel: string

--- a/apps/ui/src/slices/nerscApiSlice.ts
+++ b/apps/ui/src/slices/nerscApiSlice.ts
@@ -28,6 +28,12 @@ interface ProjectHours {
   gpu_hours_used: number
 }
 
+interface SfapiClientExpiration {
+  clientId: string
+  name: string
+  expiresAt: string
+}
+
 type NerscSystemStatuses = NerscSystemStatus[]
 type NerscPlannedOutages = NerscPlannedOutage[]
 
@@ -53,6 +59,13 @@ export const nerscApiSlice = superfacilityApiSlice.injectEndpoints({
         method: 'GET'
       }),
       providesTags: ['Project']
+    }),
+    getSfapiClientExpiration: builder.query<SfapiClientExpiration, void>({
+      query: () => ({
+        url: 'account/clients',
+        method: 'GET'
+      }),
+      providesTags: ['ClientExpiration']
     })
   })
 })
@@ -60,5 +73,6 @@ export const nerscApiSlice = superfacilityApiSlice.injectEndpoints({
 export const {
   useGetNerscStatusQuery,
   useGetNerscOutagesQuery,
-  useGetProjectHoursQuery
+  useGetProjectHoursQuery,
+  useGetSfapiClientExpirationQuery
 } = nerscApiSlice

--- a/infra/helm/templates/bilbomd-configmaps.yaml
+++ b/infra/helm/templates/bilbomd-configmaps.yaml
@@ -26,7 +26,6 @@ data:
   USE_NERSC: 'true'
   NERSC_PROJECT: 'm4659'
   SFAPI_URL: https://api.nersc.gov/api/v1.2
-  SFAPI_TOKEN_EXPIRES: '{{ .Values.sfapi.token_expires }}'
   SCRIPT_DIR: '{{ .Values.cfs_dir }}/{{ .Values.nersc_repo }}/{{ .Values.scripts }}'
   UPLOAD_DIR: '{{ .Values.cfs_dir }}/{{ .Values.nersc_repo }}/{{ .Values.uploads }}'
   WORK_DIR: '{{ .Values.pscratch }}/{{ .Values.working_dir }}'

--- a/infra/helm/values.yaml
+++ b/infra/helm/values.yaml
@@ -3,5 +3,3 @@ docker_registry: registry.nersc.gov
 nersc_repo: m4659
 cfs_dir: /global/cfs/cdirs
 pscratch: /pscratch/sd/s/sclassen
-sfapi:
-  token_expires: '2026-08-03 08:11'


### PR DESCRIPTION
## Summary

Replaces the hand-maintained `SFAPI_TOKEN_EXPIRES` value with a **live** read from NERSC, so the Superfacility API token expiration displayed in the admin panel can never drift out of date.

This is the "live-only, existing red client" approach — **no new secret required**: the existing red client already carries `GREEN` scope, proven by the already-working `/account` and `/account/projects` endpoints (RED ⊇ YELLOW ⊇ GREEN).

## Changes

**Backend**
- `sfapiController.ts` — new `getClientExpiration`: authenticated call to NERSC `GET /account/clients`, filters the returned array to the configured `SFAPI_CLIENT_ID`, returns `{ clientId, name, expiresAt }` (404 if not found).
- `routes/sfapi.ts` — wires `GET /sfapi/account/clients` behind the existing `ensureSFAuthenticated` middleware.

**Frontend**
- `nerscApiSlice.ts` — new `getSfapiClientExpiration` query + `SfapiClientExpiration` type; `sfapiSlice.ts` — added `ClientExpiration` tag.
- `TokenExpirationChip.tsx` — sources `expiresAt` from the live query. If the request fails (e.g. the client is already expired and can no longer authenticate), the chip degrades to **"Expires: unknown"** instead of an error box. Color logic (green / orange / dark-orange / red-Expired) unchanged.

**Removed static plumbing**
- `tokenExpires` from the backend config response (+ its env-log list)
- `SFAPI_TOKEN_EXPIRES` from `bilbomd-configmaps.yaml`
- `sfapi.token_expires` from `values.yaml`
- `red-client/EXPIRES.md` (gitignored, so not in this diff)

## Verification
- `pnpm lint` — backend + ui clean
- `pnpm build` — both succeed
- `pnpm test` — backend **478 passed**, ui **1106 passed**
- Changeset added (`minor` for backend + ui)

## Testing on dev after image build
Once the PR Docker image is published, deploy to dev and confirm:
- The admin panel's SFAPI token chip shows a real date/countdown (endpoint returns our client + `expiresAt` parses).
- Backend logs show the authenticated `/account/clients` call succeeding.

## Out of scope / future
A separate long-lived **green monitor client** could report the red client's expiry even after red has expired (closes the "unknown when already expired" gap). Deferred — not needed for the core early-warning use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)