### PR TITLE
fix(worker): reconstruct glycan bonds and correct GLYCAM naming for branched N-glycans

### DIFF
--- a/.changeset/glycam-glycosidic-bonds.md
+++ b/.changeset/glycam-glycosidic-bonds.md
@@ -1,0 +1,10 @@
+---
+'@bilbomd/worker': minor
+---
+
+Fix OpenMM glycoprotein preparation for branched and complex N-glycans. Previously, glycoprotein jobs failed during energy minimization with `Template match failed for residue: NLN` because the GLYCAM-renamed glycan was imported without any glycosidic linkages or sugar-skeleton bonds, and branched/reducing-end sugars were assigned incorrect GLYCAM residue names.
+
+- `glycam_rename.py`: derive the full set of substituted hydroxyls for every sugar and map it to the correct GLYCAM linkage prefix (including branched letter codes such as `VMB`, `XMA`), so reducing-end and branch-point sugars are named correctly (e.g. an O4-linked reducing GlcNAc is now `4YB`, not `0YB`).
+- `model_prep.py`: recognize letter-prefixed GLYCAM codes; rebuild sugar intra-residue bonds from the GLYCAM templates; and add protein→sugar and sugar→sugar glycosidic bonds by geometry.
+
+Verified end-to-end on a previously failing high-mannose glycoprotein job (minimization now completes successfully). Adds Python test coverage for the new naming and bond-repair logic.

--- a/apps/worker/scripts/openmm/utils/glycam_rename.py
+++ b/apps/worker/scripts/openmm/utils/glycam_rename.py
@@ -4,8 +4,11 @@ Converts standard PDB carbohydrate residue names and their attached protein resi
 into the GLYCAM naming scheme required by amber14/GLYCAM_06j-1.xml.
 
 GLYCAM naming convention (3-character codes):
-  - Character 1: linkage position on THIS residue (0 = reducing-end free/protein-linked,
-    2/3/4/6 = which oxygen bonds to C1 of the non-reducing sugar in the chain)
+  - Character 1: which hydroxyl oxygen(s) of THIS residue are substituted by a
+    child sugar. 0 = none (terminal); 2/3/4/6 = a single O2/O3/O4/O6 linkage;
+    branched sugars use a letter code (e.g. V = 3,6; X = 2,6; W = 3,4; U = 4,6).
+    The residue's own C1 bond (to its parent sugar or the protein/aglycon) is
+    always implied.
   - Character 2: sugar identity letter (Y=GlcNAc, M=Man, G=Glc, A=Gal, F=Fuc, ...)
   - Character 3: anomeric configuration (A=alpha, B=beta)
 
@@ -311,6 +314,8 @@ def rename_glycam_residues(pdb_text: str) -> tuple[str, list[str]]:
     protein_renames: dict[tuple, str] = {}
     # Maps sugar residue key → new GLYCAM name
     sugar_renames: dict[tuple, str] = {}
+    # Maps protein-linked (reducing-end) sugar key → human-readable link description
+    protein_linked_sugars: dict[tuple, str] = {}
 
     log_lines: list[str] = []
 
@@ -331,21 +336,21 @@ def rename_glycam_residues(pdb_text: str) -> tuple[str, list[str]]:
 
         # Identify which is protein and which is sugar
         pairs = [(res1, atom1, res2, atom2), (res2, atom2, res1, atom1)]
-        for prot_res, prot_atom_name, sug_res, sug_atom_name in pairs:
+        for prot_res, prot_atom_name, sug_res, _sug_atom_name in pairs:
             if (prot_res.resname in PROTEIN_RESNAMES and
                     sug_res.resname in CARBOHYDRATE_RESNAMES):
                 _handle_glycan_link(
-                    prot_res, prot_atom_name, sug_res, sug_atom_name,
-                    protein_renames, sugar_renames, log_lines
+                    prot_res, prot_atom_name, sug_res,
+                    protein_renames, protein_linked_sugars, log_lines
                 )
                 break
 
-    # Distance-based fallback for sugar residues not yet renamed
-    # (handles PDB files without LINK records, e.g. some deposited structures)
+    # Distance-based fallback for protein-linked sugars not covered by a LINK
+    # record (handles PDB files without LINK records, e.g. some deposited structures)
     for key, res in residues.items():
         if res.resname not in CARBOHYDRATE_RESNAMES:
             continue
-        if key in sugar_renames:
+        if key in protein_linked_sugars:
             continue  # already handled via LINK
 
         c1 = res.get_atom("C1")
@@ -364,32 +369,49 @@ def rename_glycam_residues(pdb_text: str) -> tuple[str, list[str]]:
                 continue
 
             _handle_glycan_link(
-                prot_res, candidate_atom.name, res, "C1",
-                protein_renames, sugar_renames, log_lines
+                prot_res, candidate_atom.name, res,
+                protein_renames, protein_linked_sugars, log_lines
             )
+            break
 
-    # Sugar-to-sugar linkage: assign linkage-position prefix for mid-chain sugars
+    # Assign the GLYCAM linkage-position prefix for every carbohydrate residue,
+    # based on the full set of hydroxyls substituted by child sugars. This handles
+    # branched sugars (e.g. a 3,6-linked core mannose → VMB) and protein-linked
+    # reducing ends alike: a reducing-end sugar's name still reflects downstream
+    # substitution (e.g. an O4-substituted N-linked GlcNAc → 4YB, not 0YB).
     for key, res in residues.items():
         if res.resname not in CARBOHYDRATE_RESNAMES:
             continue
-        if key in sugar_renames:
-            continue  # already renamed (protein-linked reducing end)
 
-        # This sugar is not directly bonded to protein — it's mid-chain or terminal.
-        # Determine what oxygen of a neighbouring sugar C1 bonds to this residue.
         sugar_letter = SUGAR_LETTER.get(res.resname)
         if sugar_letter is None:
+            log_lines.append(
+                f"  WARNING: unknown sugar {res.resname} {res.chain_id}"
+                f"{res.resseq:4d} — skipping GLYCAM rename"
+            )
             continue
 
-        linkage_pos = _find_incoming_linkage_position(res, residues, atom_index)
+        positions = _find_child_linkage_positions(res, atom_index)
+        prefix = _linkage_prefix(positions)
         is_alpha = _is_alpha_anomer(res)
         anomer = "A" if is_alpha else "B"
-        glycam_name = f"{linkage_pos}{sugar_letter}{anomer}"
+        glycam_name = f"{prefix}{sugar_letter}{anomer}"
         sugar_renames[key] = glycam_name
-        log_lines.append(
-            f"  {res.resname} {res.chain_id}{res.resseq:4d} → {glycam_name} "
-            f"(mid-chain, linkage at O{linkage_pos}, {'alpha' if is_alpha else 'beta'})"
-        )
+
+        if key in protein_linked_sugars:
+            log_lines.append(
+                f"  {res.resname} {res.chain_id}{res.resseq:4d} → {glycam_name} "
+                f"({protein_linked_sugars[key]}, GLYCAM {glycam_name})"
+            )
+        else:
+            branch = (
+                "terminal" if not positions
+                else "linkage at " + ", ".join(f"O{p}" for p in sorted(positions))
+            )
+            log_lines.append(
+                f"  {res.resname} {res.chain_id}{res.resseq:4d} → {glycam_name} "
+                f"({branch}, {'alpha' if is_alpha else 'beta'})"
+            )
 
     # --- Apply renames to lines ---
     # Build a mapping from line_index → new 3-char resname
@@ -434,12 +456,17 @@ def _handle_glycan_link(
     prot_res: Residue,
     prot_atom_name: str,
     sug_res: Residue,
-    _sug_atom_name: str,
     protein_renames: dict,
-    sugar_renames: dict,
+    protein_linked_sugars: dict,
     log_lines: list,
 ) -> None:
-    """Determine GLYCAM names for a protein-residue / sugar-residue pair."""
+    """Rename a glycosylated protein residue and mark the attached reducing-end sugar.
+
+    Renames ASN→NLN, THR→OLT, SER→OLS and records the linked sugar in
+    ``protein_linked_sugars``. The sugar's own GLYCAM name (including any
+    downstream branch prefix) is assigned later in the unified naming pass, so
+    that a reducing-end sugar substituted at, say, O4 is named 4YB rather than 0YB.
+    """
     sugar_letter = SUGAR_LETTER.get(sug_res.resname)
     if sugar_letter is None:
         log_lines.append(
@@ -448,80 +475,93 @@ def _handle_glycan_link(
         )
         return
 
-    is_alpha = _is_alpha_anomer(sug_res)
-    anomer = "A" if is_alpha else "B"
-
     prot_key = prot_res.key
     sug_key = sug_res.key
 
     if prot_res.resname == "ASN" and prot_atom_name == "ND2":
-        # N-linked glycan: ASN → NLN, sugar → 0YB (beta) or 0YA (alpha) for GlcNAc
-        glycam_sugar = f"0{sugar_letter}{anomer}"
         protein_renames[prot_key] = "NLN"
-        sugar_renames[sug_key] = glycam_sugar
+        protein_linked_sugars[sug_key] = "N-linked reducing end via ND2"
         log_lines.append(
-            f"  ASN {prot_res.chain_id}{prot_res.resseq:4d} → NLN "
-            f"(N-linked via ND2)"
+            f"  ASN {prot_res.chain_id}{prot_res.resseq:4d} → NLN (N-linked via ND2)"
         )
-        log_lines.append(
-            f"  {sug_res.resname} {sug_res.chain_id}{sug_res.resseq:4d} → {glycam_sugar} "
-            f"(N-linked reducing end, {'alpha' if is_alpha else 'beta'}, GLYCAM {glycam_sugar})"
-        )
-
     elif prot_res.resname == "THR" and prot_atom_name in ("OG1", "OG"):
-        # O-linked to Thr: THR → OLT, sugar → 0XA/0XB
-        glycam_sugar = f"0{sugar_letter}{anomer}"
         protein_renames[prot_key] = "OLT"
-        sugar_renames[sug_key] = glycam_sugar
+        protein_linked_sugars[sug_key] = "O-linked reducing end on Thr via OG1"
         log_lines.append(
-            f"  THR {prot_res.chain_id}{prot_res.resseq:4d} → OLT "
-            f"(O-linked via OG1)"
+            f"  THR {prot_res.chain_id}{prot_res.resseq:4d} → OLT (O-linked via OG1)"
         )
-        log_lines.append(
-            f"  {sug_res.resname} {sug_res.chain_id}{sug_res.resseq:4d} → {glycam_sugar} "
-            f"(O-linked reducing end on Thr, {'alpha' if is_alpha else 'beta'})"
-        )
-
     elif prot_res.resname == "SER" and prot_atom_name == "OG":
-        # O-linked to Ser: SER → OLS, sugar → 0XA/0XB
-        glycam_sugar = f"0{sugar_letter}{anomer}"
         protein_renames[prot_key] = "OLS"
-        sugar_renames[sug_key] = glycam_sugar
+        protein_linked_sugars[sug_key] = "O-linked reducing end on Ser via OG"
         log_lines.append(
-            f"  SER {prot_res.chain_id}{prot_res.resseq:4d} → OLS "
-            f"(O-linked via OG)"
-        )
-        log_lines.append(
-            f"  {sug_res.resname} {sug_res.chain_id}{sug_res.resseq:4d} → {glycam_sugar} "
-            f"(O-linked reducing end on Ser, {'alpha' if is_alpha else 'beta'})"
+            f"  SER {prot_res.chain_id}{prot_res.resseq:4d} → OLS (O-linked via OG)"
         )
 
 
-def _find_incoming_linkage_position(
+# GLYCAM linkage-position code (first character of a sugar residue name).
+# The set lists which hydroxyl oxygens (O2/O3/O4/O6) of the sugar are substituted
+# by a child (non-reducing) sugar's anomeric carbon. Mono-substituted sugars use
+# the position digit; multiply-substituted (branched) sugars use a GLYCAM-06
+# letter code. The sugar's own C1 (bond to its parent or the aglycon) is always
+# implied and is not encoded here.
+_LINKAGE_PREFIX: dict[frozenset[int], str] = {
+    frozenset(): "0",
+    frozenset({2}): "2",
+    frozenset({3}): "3",
+    frozenset({4}): "4",
+    frozenset({6}): "6",
+    frozenset({2, 3}): "Z",
+    frozenset({2, 4}): "Y",
+    frozenset({2, 6}): "X",
+    frozenset({3, 4}): "W",
+    frozenset({3, 6}): "V",
+    frozenset({4, 6}): "U",
+    frozenset({2, 3, 4}): "T",
+    frozenset({2, 3, 6}): "S",
+    frozenset({2, 4, 6}): "R",
+    frozenset({3, 4, 6}): "Q",
+    frozenset({2, 3, 4, 6}): "P",
+}
+
+
+def _linkage_prefix(positions: frozenset[int]) -> str:
+    """Map a set of substituted oxygen positions to the GLYCAM residue prefix."""
+    prefix = _LINKAGE_PREFIX.get(positions)
+    if prefix is None:
+        # Non-standard substitution pattern with no GLYCAM-06 code; fall back to
+        # the lowest occupied position as a best effort.
+        prefix = str(min(positions)) if positions else "0"
+    return prefix
+
+
+def _find_child_linkage_positions(
     res: Residue,
-    residues: dict[tuple, Residue],
     atom_index: list,
-) -> str:
-    """Find which oxygen (O2, O3, O4, O6) of this sugar is bonded to C1 of another sugar.
+) -> frozenset[int]:
+    """Return the oxygen positions (2, 3, 4, 6) on this sugar bonded to another
+    sugar's anomeric C1 — i.e. the positions where child sugars attach.
 
-    Returns the position digit as a string (e.g., "4" for O4-C1 linkage), or "0" if
-    this is a non-reducing terminal with no incoming bond.
+    An empty set denotes a non-reducing terminal sugar (prefix "0").
     """
+    positions: set[int] = set()
     for on_name in ("O2", "O3", "O4", "O6"):
         on_atom = res.get_atom(on_name)
         if on_atom is None:
             continue
         on_coords = (on_atom.x, on_atom.y, on_atom.z)
-        for coords, chain_id, resseq, candidate in atom_index:
+        for coords, _chain_id, _resseq, candidate in atom_index:
             if candidate.resname not in CARBOHYDRATE_RESNAMES:
                 continue
             if candidate.name != "C1":
                 continue
-            if (chain_id, resseq, candidate.resname) == (res.chain_id, res.resseq, res.resname):
+            if (candidate.chain_id, candidate.resseq, candidate.icode) == (
+                res.chain_id, res.resseq, res.icode
+            ):
                 continue
             if _distance(on_coords, coords) <= BOND_THRESHOLD:
-                return on_name[1]  # "2", "3", "4", or "6"
-    return "0"
+                positions.add(int(on_name[1]))
+                break
+    return frozenset(positions)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/worker/scripts/openmm/utils/model_prep.py
+++ b/apps/worker/scripts/openmm/utils/model_prep.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from io import StringIO
 
 from openmm.app import ForceField, Modeller, PDBFile
+from openmm.unit import angstroms
 from pdbfixer import PDBFixer
 
 from utils.glycam_rename import rename_glycam_residues
@@ -65,8 +66,23 @@ _GLYCAM_PROTEIN_BONDS: dict[str, list[tuple[str, str]]] = {
 }
 
 
+# Valid first characters of a GLYCAM sugar residue code: the linkage-position
+# digits (0/2/3/4/6) plus the branched-linkage letter codes (P–Z). See
+# glycam_rename._LINKAGE_PREFIX. Letter-prefixed codes (e.g. VMB for a 3,6-linked
+# mannose) must be recognised here or they would be deleted as unknown residues.
+_GLYCAM_LINKAGE_PREFIXES: frozenset[str] = frozenset("0123456789PQRSTUVWXYZ")
+
+
 def _is_glycam_name(name: str) -> bool:
-    return name in _GLYCAM_PROTEIN_NAMES or (len(name) == 3 and name[0].isdigit())
+    if name in _GLYCAM_PROTEIN_NAMES:
+        return True
+    if len(name) != 3:
+        return False
+    return (
+        name[0] in _GLYCAM_LINKAGE_PREFIXES
+        and name[1].isalpha()
+        and name[2] in ("A", "B")
+    )
 
 
 def _repair_glycam_protein_topology(topology) -> int:
@@ -112,6 +128,111 @@ def _repair_glycam_protein_topology(topology) -> int:
             _add_bond(prev_C, atom.get("N"),
                       f"{prev_res.name}[{prev_res.id}].C -- {res.name}[{res.id}].N")
 
+    return added
+
+
+def _add_glycam_sugar_intra_bonds(topology, forcefield: ForceField) -> int:
+    """Add missing intra-residue heavy-atom bonds for GLYCAM sugar residues.
+
+    OpenMM's PDB reader leaves sugar residues (GLYCAM names like 0YB, 4YB, VMB)
+    with no skeleton bonds because their residue names are unknown at parse time.
+    Expected bonds are read directly from the GLYCAM ForceField templates; bonds
+    touching an atom not yet in the topology (e.g. hydrogens, added later by
+    addHydrogens) are skipped. Mirrors _add_charmm36_intra_bonds for CHARMM36
+    backbone residues. Returns the number of bonds added.
+    """
+    existing_bonds: set[tuple[int, int]] = set()
+    for bond in topology.bonds():
+        existing_bonds.add((bond[0].index, bond[1].index))
+        existing_bonds.add((bond[1].index, bond[0].index))
+
+    added = 0
+    for res in topology.residues():
+        if not _is_glycam_name(res.name) or res.name in _GLYCAM_PROTEIN_NAMES:
+            continue
+        tmpl = forcefield._templates.get(res.name)
+        if tmpl is None:
+            continue
+        atom_by_name = {a.name: a for a in res.atoms()}
+        for bond in tmpl.bonds:
+            a1_name = tmpl.atoms[bond[0]].name
+            a2_name = tmpl.atoms[bond[1]].name
+            if a1_name not in atom_by_name or a2_name not in atom_by_name:
+                continue  # atom not yet in topology (e.g. hydrogen)
+            a1 = atom_by_name[a1_name]
+            a2 = atom_by_name[a2_name]
+            if (a1.index, a2.index) not in existing_bonds:
+                topology.addBond(a1, a2)
+                existing_bonds.add((a1.index, a2.index))
+                existing_bonds.add((a2.index, a1.index))
+                added += 1
+    return added
+
+
+# Sugar oxygens that accept a glycosidic bond from another sugar's anomeric C1,
+# and the protein side-chain atoms that accept the reducing-end sugar's C1.
+_GLYCOSIDIC_SUGAR_ACCEPTORS: frozenset[str] = frozenset({"O2", "O3", "O4", "O6"})
+_GLYCOSIDIC_PROTEIN_ACCEPTORS: frozenset[str] = frozenset({"ND2", "OG", "OG1"})
+_GLYCOSIDIC_BOND_CUTOFF = 1.9  # Å — generous upper bound for a covalent bond
+
+
+def _repair_glycam_glycosidic_bonds(topology, positions) -> int:
+    """Add missing glycosidic linkage bonds for a glycan.
+
+    Each sugar's anomeric carbon (C1) is bonded to its acceptor — a protein
+    residue's linking atom (NLN.ND2 / OLS.OG / OLT.OG1) for the reducing end, or a
+    parent sugar's hydroxyl oxygen (O2/O3/O4/O6). The acceptor is chosen by
+    proximity (nearest candidate within the covalent cutoff), reconstructing both
+    protein→sugar and sugar→sugar linkages for arbitrary glycan trees. These bonds
+    are never created by OpenMM's PDB reader because the residues are unknown to it.
+    Returns the number of bonds added.
+
+    Note: only C1-anomeric sugars are handled; sugars linked through a different
+    anomeric carbon (e.g. sialic acid, C2) are not connected here.
+    """
+    coords = positions.value_in_unit(angstroms)
+    cutoff_sq = _GLYCOSIDIC_BOND_CUTOFF ** 2
+
+    existing_bonds: set[tuple[int, int]] = set()
+    for bond in topology.bonds():
+        existing_bonds.add((bond[0].index, bond[1].index))
+        existing_bonds.add((bond[1].index, bond[0].index))
+
+    anomeric_carbons: list = []
+    acceptors: list = []
+    for res in topology.residues():
+        is_sugar = _is_glycam_name(res.name) and res.name not in _GLYCAM_PROTEIN_NAMES
+        for atom in res.atoms():
+            if is_sugar and atom.name == "C1":
+                anomeric_carbons.append(atom)
+            elif is_sugar and atom.name in _GLYCOSIDIC_SUGAR_ACCEPTORS:
+                acceptors.append(atom)
+            elif (res.name in _GLYCAM_PROTEIN_NAMES
+                    and atom.name in _GLYCOSIDIC_PROTEIN_ACCEPTORS):
+                acceptors.append(atom)
+
+    added = 0
+    for c1 in anomeric_carbons:
+        cx = coords[c1.index]
+        best = None
+        best_sq = cutoff_sq
+        for acc in acceptors:
+            if acc.residue.index == c1.residue.index:
+                continue
+            ax = coords[acc.index]
+            d_sq = (cx[0] - ax[0]) ** 2 + (cx[1] - ax[1]) ** 2 + (cx[2] - ax[2]) ** 2
+            if d_sq <= best_sq:
+                best_sq = d_sq
+                best = acc
+        if best is not None and (c1.index, best.index) not in existing_bonds:
+            topology.addBond(c1, best)
+            existing_bonds.add((c1.index, best.index))
+            existing_bonds.add((best.index, c1.index))
+            logger.info(
+                f"  Glycosidic bond: {c1.residue.name}[{c1.residue.id}].C1 -- "
+                f"{best.residue.name}[{best.residue.id}].{best.name}"
+            )
+            added += 1
     return added
 
 
@@ -714,6 +835,17 @@ def prepare_modeller(
         n_repaired = _repair_glycam_protein_topology(fixer.topology)
         if n_repaired:
             logger.info(f"Repaired {n_repaired} missing bond(s) for GLYCAM protein residues.")
+        # GLYCAM sugar residues are unknown to OpenMM's PDB reader, so they arrive
+        # with no heavy-atom skeleton bonds and no glycosidic linkages. Rebuild the
+        # intra-residue bonds from the GLYCAM templates, then the inter-residue
+        # glycosidic bonds (protein→sugar and sugar→sugar) by geometry. Without
+        # these, createSystem() cannot match the NLN/sugar templates.
+        n_intra = _add_glycam_sugar_intra_bonds(fixer.topology, forcefield)
+        if n_intra:
+            logger.info(f"Added {n_intra} intra-residue bond(s) for GLYCAM sugar residues.")
+        n_glyco = _repair_glycam_glycosidic_bonds(fixer.topology, fixer.positions)
+        if n_glyco:
+            logger.info(f"Added {n_glyco} glycosidic linkage bond(s).")
         # Skip addMissingHydrogens: it triggers CCD downloads for GLYCAM residue names
         # whose mmCIF entries contain '?' coordinates that PDBFixer cannot parse.
         # Hydrogens are added below via modeller.addHydrogens() using GLYCAM_06j-1.xml.

--- a/apps/worker/scripts/openmm/utils/test_glycam_rename.py
+++ b/apps/worker/scripts/openmm/utils/test_glycam_rename.py
@@ -8,7 +8,13 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
-from glycam_rename import rename_glycam_residues, _is_alpha_anomer, Residue, Atom
+from glycam_rename import (
+    rename_glycam_residues,
+    _is_alpha_anomer,
+    _linkage_prefix,
+    Residue,
+    Atom,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -118,8 +124,8 @@ class TestNLinkedRenaming:
         for line in result.splitlines():
             if "A 903" in line and line.startswith(("ATOM", "HETATM")):
                 resname = line[17:20].strip()
-                # Should be 0NB (terminal beta GlcNAc) or 0NA (alpha)
-                assert resname.startswith("0N"), f"Expected 0N*, got {resname!r}: {line!r}"
+                # Terminal GlcNAc (GLYCAM letter Y) → 0YB (beta) or 0YA (alpha)
+                assert resname.startswith("0Y"), f"Expected 0Y*, got {resname!r}: {line!r}"
 
     def test_log_mentions_nln(self):
         _, log = rename_glycam_residues(_n_linked_nag_pdb())
@@ -263,3 +269,91 @@ class TestAnomerDetermination:
         # NAG with no coordinates → DEFAULT_BETA
         res = Residue(resname="NAG", chain_id="A", resseq=1, icode="")
         assert _is_alpha_anomer(res) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: branched / reducing-end GLYCAM linkage naming
+# ---------------------------------------------------------------------------
+
+def _resnames_by_resseq(pdb_text: str) -> dict:
+    """Map residue sequence number → GLYCAM residue name (first atom seen)."""
+    out: dict = {}
+    for line in pdb_text.splitlines():
+        if line.startswith(("ATOM", "HETATM")):
+            resseq = int(line[22:26])
+            out.setdefault(resseq, line[17:20].strip())
+    return out
+
+
+def _reducing_end_4yb_pdb() -> str:
+    """ASN A1 N-linked to NAG A2 (O4-substituted → 4YB) and NAG A3 terminal (→ 0YB)."""
+    lines = [
+        _atom_line(1, "ND2", "ASN", "A", 1, 0.0, 0.0, 0.0),
+        _atom_line(2, "CG",  "ASN", "A", 1, -1.4, 0.0, 0.0),
+        # reducing GlcNAc: C1 bonded to ND2, O4 substituted by the next GlcNAc
+        _atom_line(3, "C1", "NAG", "A", 2, 1.44, 0.0, 0.0, "HETATM"),
+        _atom_line(4, "C2", "NAG", "A", 2, 2.90, 0.0, 0.0, "HETATM"),
+        _atom_line(5, "O5", "NAG", "A", 2, 1.44, 1.5, 0.0, "HETATM"),
+        _atom_line(6, "O4", "NAG", "A", 2, 1.44, 5.0, 0.0, "HETATM"),
+        # terminal GlcNAc: C1 bonded to A2's O4
+        _atom_line(7, "C1", "NAG", "A", 3, 1.44, 6.4, 0.0, "HETATM"),
+        _atom_line(8, "O5", "NAG", "A", 3, 1.44, 7.9, 0.0, "HETATM"),
+    ]
+    return "".join(lines)
+
+
+def _branched_mannose_pdb() -> str:
+    """Core BMA A10 branched at O3 and O6 (→ VMB) with two terminal MAN children (→ 0MA)."""
+    lines = [
+        _atom_line(1, "C1", "BMA", "A", 10, 0.0, 0.0, 0.0, "HETATM"),
+        _atom_line(2, "C2", "BMA", "A", 10, 1.5, 0.0, 0.0, "HETATM"),
+        _atom_line(3, "O5", "BMA", "A", 10, 0.0, 1.5, 0.0, "HETATM"),
+        _atom_line(4, "O1", "BMA", "A", 10, 0.0, 0.0, -1.5, "HETATM"),  # beta
+        _atom_line(5, "O3", "BMA", "A", 10, 10.0, 0.0, 0.0, "HETATM"),
+        _atom_line(6, "O6", "BMA", "A", 10, 0.0, 10.0, 0.0, "HETATM"),
+        # child mannose bonded at O3
+        _atom_line(7, "C1", "MAN", "A", 11, 11.4, 0.0, 0.0, "HETATM"),
+        # child mannose bonded at O6
+        _atom_line(8, "C1", "MAN", "A", 12, 0.0, 11.4, 0.0, "HETATM"),
+    ]
+    return "".join(lines)
+
+
+class TestBranchedGlycanNaming:
+    def test_reducing_end_glcnac_gets_branch_prefix(self):
+        result, _ = rename_glycam_residues(_reducing_end_4yb_pdb())
+        names = _resnames_by_resseq(result)
+        assert names[1] == "NLN"
+        assert names[2] == "4YB"  # O4-substituted reducing end, NOT 0YB
+        assert names[3] == "0YB"  # terminal
+
+    def test_double_branched_mannose_gets_letter_code(self):
+        result, _ = rename_glycam_residues(_branched_mannose_pdb())
+        names = _resnames_by_resseq(result)
+        assert names[10] == "VMB"  # 3,6-branched beta-mannose
+        assert names[11] == "0MA"
+        assert names[12] == "0MA"
+
+
+class TestLinkagePrefix:
+    @pytest.mark.parametrize(
+        "positions,expected",
+        [
+            (frozenset(), "0"),
+            (frozenset({2}), "2"),
+            (frozenset({4}), "4"),
+            (frozenset({2, 3}), "Z"),
+            (frozenset({2, 6}), "X"),
+            (frozenset({3, 4}), "W"),
+            (frozenset({3, 6}), "V"),
+            (frozenset({4, 6}), "U"),
+            (frozenset({2, 3, 4}), "T"),
+            (frozenset({3, 4, 6}), "Q"),
+            (frozenset({2, 3, 4, 6}), "P"),
+        ],
+    )
+    def test_prefix_mapping(self, positions, expected):
+        assert _linkage_prefix(positions) == expected
+
+    def test_unknown_pattern_falls_back_to_lowest_position(self):
+        assert _linkage_prefix(frozenset({5})) == "5"

--- a/apps/worker/scripts/openmm/utils/test_model_prep.py
+++ b/apps/worker/scripts/openmm/utils/test_model_prep.py
@@ -1,0 +1,149 @@
+"""Tests for GLYCAM helpers in model_prep.py.
+
+These require the OpenMM stack (openmm, pdbfixer) and the GLYCAM force field, so
+they run in the worker's `openmm` conda environment (e.g. `pnpm -F @bilbomd/worker
+run test:python`), not on a bare host.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/openmm on the path so `from utils.<mod>` (used inside model_prep) resolves
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from openmm import Vec3
+from openmm.app import Element, ForceField, Topology
+from openmm.unit import angstroms
+
+from utils.model_prep import (  # noqa: E402
+    _add_glycam_sugar_intra_bonds,
+    _is_glycam_name,
+    _repair_glycam_glycosidic_bonds,
+)
+
+
+# ---------------------------------------------------------------------------
+# _is_glycam_name
+# ---------------------------------------------------------------------------
+
+class TestIsGlycamName:
+    @pytest.mark.parametrize(
+        "name",
+        ["0YB", "0YA", "4YB", "0MA", "2MA", "NLN", "OLS", "OLT",
+         "VMB", "XMA", "WYB", "UMA", "PMB"],  # letter-prefixed branch codes
+    )
+    def test_recognises_glycam_residues(self, name):
+        assert _is_glycam_name(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        ["ALA", "GLY", "HOH", "FAD", "ND2", "0Y", "0YBX", "", "MG"],
+    )
+    def test_rejects_non_glycam_residues(self, name):
+        assert _is_glycam_name(name) is False
+
+
+# ---------------------------------------------------------------------------
+# Topology construction helpers
+# ---------------------------------------------------------------------------
+
+def _add_atoms(topology, residue, names_coords):
+    """Add named C/N/O atoms to a residue; return {name: atom} and coords list."""
+    atoms = {}
+    coords = []
+    for name, xyz in names_coords:
+        element = Element.getBySymbol(name[0])
+        atoms[name] = topology.addAtom(name, element, residue)
+        coords.append(Vec3(*xyz))
+    return atoms, coords
+
+
+# ---------------------------------------------------------------------------
+# _repair_glycam_glycosidic_bonds
+# ---------------------------------------------------------------------------
+
+class TestGlycosidicBondRepair:
+    def _build(self):
+        """NLN.ND2 — 0YB.C1, and 0YB.O4 — 4YB.C1 (coords in Ångström)."""
+        top = Topology()
+        chain = top.addChain()
+        coords = []
+
+        nln = top.addResidue("NLN", chain)
+        a, c = _add_atoms(top, nln, [("ND2", (0.0, 0.0, 0.0))])
+        coords += c
+
+        red = top.addResidue("0YB", chain)  # reducing-end GlcNAc
+        a2, c = _add_atoms(top, red, [("C1", (1.44, 0.0, 0.0)),
+                                      ("O4", (1.44, 5.0, 0.0))])
+        coords += c
+
+        nxt = top.addResidue("4YB", chain)  # next GlcNAc
+        a3, c = _add_atoms(top, nxt, [("C1", (1.44, 6.4, 0.0))])
+        coords += c
+
+        return top, coords * angstroms
+
+    def test_creates_protein_and_sugar_linkages(self):
+        top, positions = self._build()
+        added = _repair_glycam_glycosidic_bonds(top, positions)
+        assert added == 2
+
+        bonded = {
+            frozenset((f"{b[0].residue.name}.{b[0].name}",
+                       f"{b[1].residue.name}.{b[1].name}"))
+            for b in top.bonds()
+        }
+        assert frozenset(("0YB.C1", "NLN.ND2")) in bonded      # N-glycosidic
+        assert frozenset(("4YB.C1", "0YB.O4")) in bonded       # sugar-sugar
+
+    def test_idempotent(self):
+        top, positions = self._build()
+        assert _repair_glycam_glycosidic_bonds(top, positions) == 2
+        # second pass must not duplicate existing bonds
+        assert _repair_glycam_glycosidic_bonds(top, positions) == 0
+
+    def test_ignores_atoms_beyond_cutoff(self):
+        top = Topology()
+        chain = top.addChain()
+        red = top.addResidue("0YB", chain)
+        _add_atoms(top, red, [("C1", (0.0, 0.0, 0.0))])
+        far = top.addResidue("4YB", chain)
+        _add_atoms(top, far, [("O4", (5.0, 0.0, 0.0))])  # 5 Å > cutoff
+        positions = [Vec3(0.0, 0.0, 0.0), Vec3(5.0, 0.0, 0.0)] * angstroms
+        assert _repair_glycam_glycosidic_bonds(top, positions) == 0
+
+
+# ---------------------------------------------------------------------------
+# _add_glycam_sugar_intra_bonds
+# ---------------------------------------------------------------------------
+
+class TestSugarIntraBonds:
+    def test_adds_template_bonds_for_sugar(self):
+        forcefield = ForceField("amber19-all.xml", "amber14/GLYCAM_06j-1.xml",
+                                "implicit/gbn2.xml")
+        top = Topology()
+        chain = top.addChain()
+        res = top.addResidue("0MA", chain)  # alpha-mannose, terminal
+        # ring heavy atoms present in the 0MA template, no bonds yet
+        _add_atoms(top, res, [
+            ("C1", (0.0, 0.0, 0.0)), ("C2", (1.5, 0.0, 0.0)),
+            ("C3", (2.5, 1.0, 0.0)), ("C4", (2.0, 2.0, 0.0)),
+            ("C5", (0.5, 2.0, 0.0)), ("O5", (0.0, 1.0, 0.0)),
+        ])
+        assert not list(top.bonds())
+        added = _add_glycam_sugar_intra_bonds(top, forcefield)
+        assert added > 0  # e.g. C1-C2, C2-C3, C5-O5, ...
+
+    def test_no_bonds_for_protein_residue(self):
+        forcefield = ForceField("amber19-all.xml", "amber14/GLYCAM_06j-1.xml",
+                                "implicit/gbn2.xml")
+        top = Topology()
+        chain = top.addChain()
+        res = top.addResidue("NLN", chain)  # protein GLYCAM residue, not a sugar
+        _add_atoms(top, res, [("N", (0.0, 0.0, 0.0)), ("CA", (1.5, 0.0, 0.0))])
+        assert _add_glycam_sugar_intra_bonds(top, forcefield) == 0


### PR DESCRIPTION
## Summary

Fixes OpenMM glycoprotein preparation for **branched / complex N-glycans**, which previously crashed during energy minimization. Closes #949.

Root cause (see #949 for the full investigation): the "Phase 1" glycoprotein path only repaired protein-side connectivity. The GLYCAM-renamed glycan was imported with **no glycosidic linkages and no sugar-skeleton bonds**, and `glycam_rename.py` assigned **incorrect GLYCAM names** to reducing-end and branch-point sugars. The first symptom was:

```
No template found for residue 9 (NLN). ... the set of externally bonded atoms
is missing 1 N atom.
```
(the missing `NLN.ND2 → sugar.C1` N-glycosidic bond).

## Changes

**`glycam_rename.py`**
- Compute the *full set* of child-linkage positions for every sugar and map it to the correct GLYCAM prefix — including branched letter codes (`Z/Y/X/W/V/U/T/S/R/Q/P`).
- Reducing-end sugars now reflect downstream substitution (e.g. an O4-linked reducing GlcNAc → `4YB`, not `0YB`); the 3,6-branched core mannose → `VMB`; a 2,6-branched arm mannose → `XMA`.

**`model_prep.py`**
- `_is_glycam_name`: recognize letter-prefixed multi-linkage codes (otherwise `VMB`/`XMA`/… were treated as unknown and deleted).
- `_add_glycam_sugar_intra_bonds`: rebuild sugar intra-residue heavy-atom bonds from the GLYCAM templates (mirrors the existing CHARMM36 path).
- `_repair_glycam_glycosidic_bonds`: add protein→sugar and sugar→sugar glycosidic bonds by geometry (nearest acceptor to each anomeric C1).

## Testing

- **Python** (`pnpm -F @bilbomd/worker test:python`): 58 passed — new coverage for branched/reducing-end naming, the linkage-prefix map, and the bond-repair functions (`test_model_prep.py`). Also fixes a pre-existing incorrect assertion in `test_glycam_rename.py` (expected `0N*` for GlcNAc, whose GLYCAM letter is `Y`).
- **End-to-end**: ran the actual edited `minimize.py` on the previously failing high-mannose glycoprotein job in the worker container — `addHydrogens` → `createSystem` → minimization all succeed (PE ≈ −58,000 kJ/mol; 376 sugar intra bonds + 32 glycosidic bonds added).
- lint ✅ · build ✅ · worker vitest 179 passed ✅

## Known limitations

- Geometry-based linkage detection does not cover sialic acid (anomeric C2) or non-C1 anomeric linkages.
- Branch-name derivation is distance-based; LINK records are used only for protein-site detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
