### PR TITLE
ci(worker): run Python tests in CI (light + in-image)

### DIFF
--- a/.changeset/worker-python-tests-ci.md
+++ b/.changeset/worker-python-tests-ci.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Add Python tests to the CI pipeline. The worker image now bundles `pytest` in its OpenMM environment so the image is self-testable, and CI gains two gated jobs: a fast "Python tests (light)" job for the OpenMM-free tests (tools/python + stdlib worker scripts) and a "Worker Python tests (in image)" job that runs the OpenMM-dependent tests inside the built worker image. Pytest configuration is centralized in a root `pyproject.toml`, and OpenMM-dependent tests self-skip where the stack is unavailable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,75 @@ jobs:
             WORKER_VERSION=${{ env.VERSION }}
           # Removed local cache-from/cache-to for GitHub-hosted runners
 
+  # Fast feedback: run the OpenMM-free Python tests (tools/python + the stdlib
+  # worker script tests). OpenMM-dependent tests skip here (see importorskip) and
+  # run for real in worker-python-tests below.
+  python-tests-light:
+    name: Python tests (light)
+    if: needs.changes.outputs.worker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'github-actions[bot]')
+    needs: [changes]
+    runs-on: [ubuntu-24.04]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tools/python/requirements-test.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tools/python/requirements-test.txt
+
+      - name: Run Python tests (OpenMM-free)
+        run: pytest
+
+  # Authoritative: run the OpenMM-dependent worker tests inside the built worker
+  # image (the only place the conda openmm/pdbfixer stack exists). Reuses the
+  # worker job's build cache and loads the image locally instead of pushing.
+  worker-python-tests:
+    name: Worker Python tests (in image)
+    if: needs.changes.outputs.worker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'github-actions[bot]')
+    needs: [changes, lint, worker]
+    runs-on: [ubuntu-24.04]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Free up disk space
+        run: |
+          # The worker image is large (~12 GB); reclaim space so `load` has room.
+          sudo rm -rf /opt/hostedtoolcache /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup || true
+          df -h /
+
+      - name: Read version
+        run: echo "VERSION=$(jq -r .version 'apps/worker/package.json')" >> $GITHUB_ENV
+
+      - name: Build worker image (load locally)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/worker/bilbomd-worker.dockerfile
+          load: true
+          push: false
+          tags: bilbomd-worker:pytest
+          cache-from: type=gha,scope=worker
+          build-args: |
+            USER_ID=${{ vars.USER_ID || '1001' }}
+            GROUP_ID=${{ vars.GROUP_ID || '1234' }}
+            WORKER_GIT_HASH=${{ github.sha }}
+            WORKER_VERSION=${{ env.VERSION }}
+
+      - name: Run OpenMM Python tests inside the image
+        run: |
+          docker run --rm bilbomd-worker:pytest \
+            /opt/envs/openmm/bin/python -m pytest \
+            /app/scripts/openmm /app/scripts/test_strip_cofactors.py \
+            -o addopts="-q" -p no:cacheprovider
+
   scoper:
     name: Build & Push scoper
     if: needs.changes.outputs.scoper == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'github-actions[bot]')
@@ -1088,6 +1157,8 @@ jobs:
         scoper-unit-tests,
         scoper-typecheck,
         backend-integration-tests,
+        python-tests-light,
+        worker-python-tests,
       ]
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'github-actions[bot]')
     env:
@@ -1104,11 +1175,13 @@ jobs:
       SCOPER_UNIT: ${{ needs['scoper-unit-tests'].result }}
       SCOPER_TYPE: ${{ needs['scoper-typecheck'].result }}
       BACKEND_INT: ${{ needs['backend-integration-tests'].result }}
+      PY_LIGHT: ${{ needs['python-tests-light'].result }}
+      WORKER_PY: ${{ needs['worker-python-tests'].result }}
     steps:
       - name: Check build results
         run: |
           set -e
-          for job in LINT BACKEND UI WORKER SCOPER SCHEMA MDUTILS BACKEND_UNIT UI_UNIT WORKER_UNIT SCOPER_UNIT SCOPER_TYPE BACKEND_INT; do
+          for job in LINT BACKEND UI WORKER SCOPER SCHEMA MDUTILS BACKEND_UNIT UI_UNIT WORKER_UNIT SCOPER_UNIT SCOPER_TYPE BACKEND_INT PY_LIGHT WORKER_PY; do
             result="${!job}"
             echo "$job result: $result"
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,8 @@ jobs:
     if: needs.changes.outputs.worker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'github-actions[bot]')
     needs: [changes, lint]
     runs-on: [ubuntu-24.04]
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -385,6 +387,7 @@ jobs:
       # Removed local buildx cache setup for GitHub-hosted runners
 
       - name: Build & Push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -433,41 +436,33 @@ jobs:
   # worker job's build cache and loads the image locally instead of pushing.
   worker-python-tests:
     name: Worker Python tests (in image)
-    if: needs.changes.outputs.worker == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'github-actions[bot]')
+    # Runs the OpenMM-dependent tests inside the exact image the worker job just
+    # pushed (pulled by digest — no rebuild). Skips on forks, which don't push.
+    if: needs.changes.outputs.worker == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'github-actions[bot]')
     needs: [changes, lint, worker]
     runs-on: [ubuntu-24.04]
+    permissions:
+      contents: read
+      packages: read
     steps:
-      - uses: actions/checkout@v7
-
-      - uses: docker/setup-buildx-action@v4
-
       - name: Free up disk space
         run: |
-          # The worker image is large (~12 GB); reclaim space so `load` has room.
+          # The worker image is large (~12 GB); reclaim space for the pull.
           sudo rm -rf /opt/hostedtoolcache /usr/local/lib/android /usr/share/dotnet /usr/local/.ghcup || true
           df -h /
 
-      - name: Read version
-        run: echo "VERSION=$(jq -r .version 'apps/worker/package.json')" >> $GITHUB_ENV
-
-      - name: Build worker image (load locally)
-        uses: docker/build-push-action@v7
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
         with:
-          context: .
-          file: apps/worker/bilbomd-worker.dockerfile
-          load: true
-          push: false
-          tags: bilbomd-worker:pytest
-          cache-from: type=gha,scope=worker
-          build-args: |
-            USER_ID=${{ vars.USER_ID || '1001' }}
-            GROUP_ID=${{ vars.GROUP_ID || '1234' }}
-            WORKER_GIT_HASH=${{ github.sha }}
-            WORKER_VERSION=${{ env.VERSION }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run OpenMM Python tests inside the image
+      - name: Run OpenMM Python tests inside the pushed image
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/bilbomd-worker@${{ needs.worker.outputs.digest }}
         run: |
-          docker run --rm bilbomd-worker:pytest \
+          docker run --rm "$IMAGE" \
             /opt/envs/openmm/bin/python -m pytest \
             /app/scripts/openmm /app/scripts/test_strip_cofactors.py \
             -o addopts="-q" -p no:cacheprovider

--- a/apps/worker/bilbomd-worker.dockerfile
+++ b/apps/worker/bilbomd-worker.dockerfile
@@ -71,6 +71,11 @@ COPY --chown=bilbo:bilbomd --from=build /out/ .
 # Copy centralized shared scripts (e.g., autorg.py)
 COPY --chown=bilbo:bilbomd tools/python/ /app/scripts/
 
+# Install pytest into the OpenMM env so the image is self-testable — CI runs the
+# Python test suite (including OpenMM-dependent tests) inside this image. Small
+# footprint and not on the runtime hot path.
+RUN /opt/envs/openmm/bin/pip install --no-cache-dir pytest pytest-cov
+
 ENV NODE_ENV=production
 USER bilbo:bilbomd
 EXPOSE 3000

--- a/apps/worker/scripts/openmm/conftest.py
+++ b/apps/worker/scripts/openmm/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest bootstrap for the OpenMM worker scripts.
+
+Adds this directory (``apps/worker/scripts/openmm``) to ``sys.path`` so tests can
+import the sibling ``utils`` package (e.g. ``from utils.model_prep import ...``)
+regardless of the directory pytest is invoked from. Mirrors the runtime layout,
+where these scripts run with the openmm dir on the path.
+"""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)

--- a/apps/worker/scripts/openmm/utils/test_model_prep.py
+++ b/apps/worker/scripts/openmm/utils/test_model_prep.py
@@ -15,6 +15,10 @@ import pytest
 # scripts/openmm on the path so `from utils.<mod>` (used inside model_prep) resolves
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+# Skip (rather than error) where the OpenMM conda stack is unavailable, e.g. the
+# lightweight CI job. These tests run for real inside the worker image.
+pytest.importorskip("openmm")
+
 from openmm import Vec3
 from openmm.app import Element, ForceField, Topology
 from openmm.unit import angstroms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+# Root pytest configuration for the repository's Python code.
+#
+# The Python lives in two trees with different dependency weights:
+#   - tools/python/**            (numpy / biopython / igraph — pip-installable)
+#   - apps/worker/scripts/**     (some modules need the OpenMM conda stack)
+#
+# Tests that require OpenMM guard themselves with `pytest.importorskip("openmm")`
+# so they are skipped (not errored) in lightweight environments and run for real
+# inside the worker image. See CONTRIBUTING / the CI workflow for how each tier
+# is executed.
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-q --strict-markers"
+testpaths = ["apps/worker/scripts", "tools/python"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*", "*Tests"]
+python_functions = ["test_*"]
+markers = [
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]

--- a/tools/python/conftest.py
+++ b/tools/python/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest bootstrap for the tools/python scripts.
+
+Adds this directory to ``sys.path`` so the modules' bare sibling imports
+(e.g. ``from saxs_utils import ...`` inside ``autorg.py``) resolve during tests,
+matching the runtime layout where these scripts run from ``/app/scripts``.
+"""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)

--- a/tools/python/pyproject.toml
+++ b/tools/python/pyproject.toml
@@ -77,28 +77,7 @@ docstring-code-format = false
 # enabled.
 docstring-code-line-length = "dynamic"
 
-
-[tool.pytest.ini_options]
-minversion = "8.0"
-addopts = "-q --strict-markers --disable-warnings --maxfail=1 --cov --cov-report=term-missing"
-# Only discover and run tests that live under tools/python
-testpaths = ["tools/python"]
-python_files = ["test_*.py", "*_test.py"]
-python_classes = ["Test*", "*Tests"]
-python_functions = ["test_*"]
-markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
-
-[tool.coverage.run]
-branch = true
-source = ["tools/python"]
-omit = ["*/.venv/*", "*/venv/*", "*/node_modules/*"]
-
-[tool.coverage.report]
-show_missing = true
-skip_covered = false
-exclude_lines = [
-  "if __name__ == .__main__.:",
-  "pragma: no cover",
-  "raise NotImplementedError",
-  "pass",
-]
+# NOTE: pytest / coverage configuration lives in the repository-root pyproject.toml
+# so a single config covers both tools/python and apps/worker/scripts. This file is
+# limited to ruff settings (it is also copied into the worker image as
+# /app/scripts/pyproject.toml, where a pytest section would otherwise take effect).

--- a/tools/python/requirements-test.txt
+++ b/tools/python/requirements-test.txt
@@ -1,0 +1,8 @@
+# Dependencies for the lightweight (no-OpenMM) Python test job.
+# Covers the tools/python test targets; the apps/worker/scripts stdlib tests
+# need nothing beyond pytest. OpenMM-dependent tests are skipped in this tier.
+pytest
+numpy
+pyyaml
+biopython
+python-igraph


### PR DESCRIPTION
## Summary

Wires the repository's Python tests into CI. Until now **neither `pnpm test` nor CI ran any Python** — `pnpm test` (vitest) covers only the TS packages, and `ci.yml` ran lint + Docker builds + the JS unit-test jobs. This adds two gated jobs plus the config to make the Python suites runnable and consistent.

Implements items 1–3 from the discussion on #950. (Item 4 — "wire vitest into CI" — turned out to be **already done**: `worker-unit-tests`/`ui-unit-tests`/`scoper-unit-tests`/`backend-unit-tests` already run vitest and feed the `gate` job. No follow-up needed there.)

## Why two jobs

The Python splits into two dependency tiers:

| Tier | Deps | Where it can run |
|---|---|---|
| Light | numpy / biopython / igraph / pyyaml | any runner (`setup-python` + pip) |
| Heavy | openmm, pdbfixer, openff, rdkit | only inside the worker conda image |

So OpenMM-dependent tests (`test_model_prep.py`) can only run inside the worker image.

## Changes

**Foundation (item 1)**
- Root `pyproject.toml` centralizes pytest config, discovering both `tools/python` and `apps/worker/scripts`.
- Removed the duplicate `[tool.pytest.*]` / `[tool.coverage.*]` from `tools/python/pyproject.toml` (kept ruff); it's copied into the image as `/app/scripts/pyproject.toml` and would otherwise force `--cov`/`testpaths`.
- Added `conftest.py` bootstraps (`apps/worker/scripts/openmm`, `tools/python`) so `utils.*` / bare sibling imports resolve regardless of invocation dir.
- `test_model_prep.py` now guards with `pytest.importorskip("openmm")` → skips (not errors) where the stack is absent.
- Worker Dockerfile installs `pytest`+`pytest-cov` into the openmm env so the image is self-testable.

**CI (items 2 & 3)**
- `Python tests (light)` — `setup-python`, `pip install -r tools/python/requirements-test.txt`, `pytest`. OpenMM tests self-skip. ✅ passing.
- `Worker Python tests (in image)` — **reuses the exact image the `worker` job pushed**: that job now exposes its build `digest` as an output, and this job pulls the image by digest and runs `pytest` inside it. No rebuild. Skips on fork PRs (which don't push); the light job still covers those. Includes a disk-cleanup step (the image is ~12 GB).
- Both registered with the `gate` (branch-protection) job.

## Verification (local)
- Light suite from repo root: **55 passed, 1 skipped** (`test_model_prep` skipped without OpenMM). Confirmed passing in real CI (25s).
- In-image run (simulated against `bilbomd-worker:2.14.11` with these files mounted): **71 passed** (glycam 31 + model_prep 27 + strip_cofactors 13).
- Confirmed the Dockerfile `pip install` line succeeds in the openmm env.
- `actionlint` clean (only pre-existing info-level shellcheck notes shared with existing jobs); YAML + gate wiring validated.

## Notes / follow-ups
- To block merges, ensure the required status check covers these — the `gate` job already depends on both new jobs, so gating on **Branch Protection Gate** is sufficient.
- Baking `pytest` into the worker runtime image is the low-friction choice; alternatively it could move to the base image (needs a base-version bump). Happy to switch if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
