### PR TITLE
ci: drop type=gha build cache from service image workflows

### DIFF
--- a/.github/workflows/colabfold-service-image.yml
+++ b/.github/workflows/colabfold-service-image.yml
@@ -100,9 +100,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
           platforms: linux/amd64
-          cache-from: |
-            type=gha,scope=colabfold-service
-            type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
-          cache-to: |
-            type=gha,scope=colabfold-service,mode=max
-            type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
+          # No type=gha cache here: this image is ~33GB, far above the 10GB
+          # per-repo Actions cache limit, so the export could never be reused
+          # and evicted the caches that could (e.g. pnpm-store used by CI).
+          # The registry buildcache already supplies every layer.
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/.github/workflows/of3-service-image.yml
+++ b/.github/workflows/of3-service-image.yml
@@ -101,9 +101,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
           platforms: linux/amd64
-          cache-from: |
-            type=gha,scope=of3-service
-            type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
-          cache-to: |
-            type=gha,scope=of3-service,mode=max
-            type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
+          # No type=gha cache here: this image is ~19GB, far above the 10GB
+          # per-repo Actions cache limit, so the export could never be reused
+          # and evicted the caches that could (e.g. pnpm-store used by CI).
+          # The registry buildcache already supplies every layer.
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max


### PR DESCRIPTION
## Problem

`colabfold-service-image.yml` and `of3-service-image.yml` both export a `mode=max` build cache to the GitHub Actions cache. Their images are **~33 GB** and **~19 GB**, against GitHub's **10 GB per-repo** Actions cache limit — so the export can never be fully retained, and therefore never usefully reused.

### It dominates the job

From the most recent colabfold-service build ([run 31432763571](https://github.com/bl1231/bilbomd/actions/runs/31432763571)):

| Phase | Duration |
|---|---|
| Setup, checkout, disk cleanup, buildx, login, metadata | ~48 s |
| Build — layers `#10`, `#11`, `#12` all `CACHED` | ~0 s |
| Registry cache export (`#15`) | **1.5 s** |
| **Actions cache export (`#16`)** | **1947 s (32.5 min)** |

```
#15 sending cache export 1.5s done          ← registry
#16 sending cache export 1947.0s done       ← gha
```

The registry cache import supplied every layer, including the `pip install`. The build did no work, then spent 32.5 minutes — 97% of the job — writing a cache that cannot be reused.

### It crowds out caches that do fit

Repo cache usage at the time of writing: **9.41 GB of the 10 GB budget**, 51 entries.

| Category | Entries | Size |
|---|---|---|
| `buildkit-blob-*` (from these two workflows) | 49 | **9.22 GB** |
| Everything else | 3 | 0.18 GB |

GitHub evicts least-recently-used once a repo exceeds 10 GB. The `pnpm-store-Linux-*` cache that **BilboMD CI** depends on is 0.18 GB in a bucket almost entirely consumed by container layers that can never fit — so normal CI runs pay for this too, via cache misses.

## Change

Drop `type=gha` from `cache-from` and `cache-to` in both workflows, keeping the registry buildcache that already does all the useful work:

```yaml
cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
cache-to:   type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
```

## Expected effect

- colabfold-service image job: **~33 min → ~1 min**
- ~9.2 GB of Actions cache budget returns to caches that benefit from it
- No change to build correctness — the registry cache already yields 100% layer hits

## Notes

- Existing `buildkit-blob-*` entries will age out on their own now that nothing writes them; they can also be purged directly with `gh cache delete` to reclaim the space immediately.
- Separately, that run also spent ~33 min queued waiting for a runner before the job started. That's runner availability, not workflow config, and is unaffected by this change.
- Verified both files still parse and are otherwise unchanged (9 steps each, `push`/`tags` intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
