### PR TITLE
chore(infra): clean up list-latest-tags.sh

### DIFF
--- a/infra/list-latest-tags.sh
+++ b/infra/list-latest-tags.sh
@@ -1,94 +1,148 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage:
-#   GH_OWNER=YOUR_ORG_OR_USERNAME ./latest-tags.sh
+# List the newest semver tag published to GHCR for each BilboMD container image.
 #
-# Optional:
-#   GITHUB_TOKEN=<token with read:packages>   # needed for curl fallback or private packages
-#   IMAGES="bilbomd-backend bilbomd-ui bilbomd-worker bilbomd-scoper"
+# Usage:
+#   ./list-latest-tags.sh
+#
+# Environment:
+#   GH_OWNER=<org-or-user>                    # default: bl1231
+#   IMAGES="bilbomd-backend bilbomd-ui ..."   # default: all BilboMD images
+#   GITHUB_TOKEN=<token with read:packages>   # only used for the curl fallback
+#
+# Requires jq, plus one of:
+#   - the gh CLI, authenticated with the read:packages scope, or
+#   - GITHUB_TOKEN set to a PAT with read:packages
+#
+# The GHCR package-versions API requires authentication even for public
+# packages, so an unscoped token will fail with 403/401.
 
 OWNER="${GH_OWNER:-bl1231}"
 IMAGES="${IMAGES:-bilbomd-backend bilbomd-ui bilbomd-worker-base bilbomd-worker bilbomd-scoper-base bilbomd-scoper bilbomd-of3-service bilbomd-colabfold bilbomd-colabfold-service}"
 
-if [[ -z "$OWNER" ]]; then
-  echo "GH_OWNER not set. Export GH_OWNER=your-org-or-username" >&2
-  exit 1
-fi
+have() { command -v "$1" >/dev/null 2>&1; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
 
-have_gh() { command -v gh >/dev/null 2>&1; }
-have_jq() { command -v jq >/dev/null 2>&1; }
+have jq || die "jq is required (brew install jq)"
 
-if ! have_jq; then
-  echo "jq is required" >&2
-  exit 1
-fi
-
-# Determine if OWNER is an org or a user (for the REST path prefix)
+# ---------------------------------------------------------------------------
+# Is OWNER an org or a user? Decides the REST path prefix.
+# ---------------------------------------------------------------------------
 SCOPE="users"
-if have_gh; then
-  if gh api -X GET "/orgs/${OWNER}" >/dev/null 2>&1; then
-    SCOPE="orgs"
-  fi
+if have gh; then
+  gh api -X GET "/orgs/${OWNER}" >/dev/null 2>&1 && SCOPE="orgs"
 else
-  # curl probe
-  if curl -fsSL -H "Accept: application/vnd.github+json" "https://api.github.com/orgs/${OWNER}" >/dev/null 2>&1; then
-    SCOPE="orgs"
+  curl -fsSL -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/orgs/${OWNER}" >/dev/null 2>&1 && SCOPE="orgs"
+fi
+
+versions_url() { printf '/%s/%s/packages/container/%s/versions' "$SCOPE" "$OWNER" "$1"; }
+
+# ---------------------------------------------------------------------------
+# Pick an auth method once, up front. Probing here means a missing scope is
+# reported a single time with a fix, instead of once per image.
+# ---------------------------------------------------------------------------
+PROBE="${IMAGES%% *}"
+METHOD=""
+GH_ERR=""
+
+if have gh; then
+  # Capture stderr only: 2>&1 aims stderr at the substitution, then stdout is discarded.
+  if GH_ERR="$(gh api -H "Accept: application/vnd.github+json" \
+      "$(versions_url "$PROBE")?per_page=1" 2>&1 >/dev/null)"; then
+    METHOD="gh"
   fi
 fi
 
-fetch_tags_with_gh() {
-  local pkg="$1"
-  # Pull all pages; collect all tags and created_at dates across versions
-  gh api \
-    -H "Accept: application/vnd.github+json" \
-    --paginate \
-    "/${SCOPE}/${OWNER}/packages/container/${pkg}/versions?per_page=100" \
-  | jq -r '.[] | .metadata.container.tags[]? as $tag | "\($tag) \(.created_at)"'
-}
-
-fetch_tags_with_curl() {
-  local pkg="$1"
-  if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-    echo "GITHUB_TOKEN not set for curl fallback; set it if packages are private" >&2
+if [[ -z "$METHOD" && -n "${GITHUB_TOKEN:-}" ]]; then
+  if curl -fsSL -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+      "https://api.github.com$(versions_url "$PROBE")?per_page=1" >/dev/null 2>&1; then
+    METHOD="curl"
   fi
-  curl -fsSL \
-    -H "Accept: application/vnd.github+json" \
-    ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} \
-    "https://api.github.com/${SCOPE}/${OWNER}/packages/container/${pkg}/versions?per_page=100" \
-  | jq -r '.[] | .metadata.container.tags[]? as $tag | "\($tag) \(.created_at)"'
+fi
+
+if [[ -z "$METHOD" ]]; then
+  {
+    printf 'Cannot read GHCR package versions for %s (probe image: %s).\n' "$OWNER" "$PROBE"
+    [[ -n "$GH_ERR" ]] && printf '  gh: %s\n' "$GH_ERR"
+    printf '\n'
+    case "$GH_ERR" in
+      *404*|*"Not Found"*)
+        printf 'A 404 usually means GH_OWNER or the image name is wrong, or the\n'
+        printf 'package is private and your token cannot see it.\n'
+        ;;
+      *)
+        printf 'Fix one of:\n'
+        printf '  gh auth refresh -h github.com -s read:packages   # grant gh the scope\n'
+        printf '  export GITHUB_TOKEN=<PAT with read:packages>     # use the curl fallback\n'
+        ;;
+    esac
+  } >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Fetch + parse
+# ---------------------------------------------------------------------------
+
+# versions JSON -> "<tag> <created_at>" lines. The type guard keeps an error
+# body (an object, not an array) from producing a jq "cannot index" message.
+parse_tags() {
+  jq -r 'if type == "array" then .[] else empty end
+         | .created_at as $created
+         | .metadata.container.tags[]?
+         | "\(.) \($created)"'
 }
 
+fetch_tags() {
+  local pkg="$1"
+  case "$METHOD" in
+    gh)
+      gh api -H "Accept: application/vnd.github+json" --paginate \
+        "$(versions_url "$pkg")?per_page=100" 2>/dev/null | parse_tags
+      ;;
+    curl)
+      # No pagination here: only the 100 most recent versions are considered.
+      curl -fsSL -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "https://api.github.com$(versions_url "$pkg")?per_page=100" 2>/dev/null | parse_tags
+      ;;
+  esac
+}
+
+# Keep strict semver tags only (no pre-release/build), highest version wins.
 latest_semver() {
-  # Input format: tag created_at
-  # Filter tags that look like strict semver X.Y.Z (no pre-release/build)
-  # Sort using sort -V (version aware) and return the last one with its date.
-  awk 'NF' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+ ' | sort -uV -k1,1 | tail -1
+  grep -E '^[0-9]+\.[0-9]+\.[0-9]+ ' | sort -uV -k1,1 | tail -1
 }
 
-for pkg in $IMAGES; do
-  tags=""
-  if have_gh; then
-    if ! tags="$(fetch_tags_with_gh "$pkg" || true)"; then tags=""; fi
+# ISO-8601 UTC -> local time. GNU date, then coreutils gdate, then BSD date.
+to_local_time() {
+  local iso="$1" epoch
+  date -d "$iso" "+%Y-%m-%d %H:%M:%S %Z" 2>/dev/null && return 0
+  gdate -d "$iso" "+%Y-%m-%d %H:%M:%S %Z" 2>/dev/null && return 0
+  epoch="$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" "+%s" 2>/dev/null || true)"
+  if [[ -n "$epoch" ]]; then
+    date -r "$epoch" "+%Y-%m-%d %H:%M:%S %Z"
+  else
+    printf '%s' "$iso"
   fi
-  if [[ -z "$tags" ]]; then
-    tags="$(fetch_tags_with_curl "$pkg" || true)"
+}
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+for pkg in $IMAGES; do
+  latest="$(fetch_tags "$pkg" | latest_semver || true)"
+  ver="${latest%% *}"
+
+  if [[ -z "$ver" ]]; then
+    printf '%s: (no semver tag found)\n' "$pkg"
+    continue
   fi
 
-  ver_and_date="$(printf '%s\n' "$tags" | latest_semver || true)"
-  ver="$(printf '%s' "$ver_and_date" | awk '{print $1}')"
-  date="$(printf '%s' "$ver_and_date" | awk '{print $2}')"
-  local_date=""
-  if [[ -n "$date" ]]; then
-    # Try GNU date (Linux), then gdate (macOS coreutils), then BSD date (macOS)
-    local_date="$(date -d "$date" "+%Y-%m-%d %H:%M:%S %Z" 2>/dev/null \
-      || gdate -d "$date" "+%Y-%m-%d %H:%M:%S %Z" 2>/dev/null \
-      || { epoch="$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$date" "+%s" 2>/dev/null)"; \
-           if [[ -n "$epoch" ]]; then date -r "$epoch" "+%Y-%m-%d %H:%M:%S %Z"; else echo "$date"; fi; })"
-  fi
-  if [[ -n "$ver" ]]; then
-    echo -e "${pkg}\t${ver}\t${local_date}\tghcr.io/${OWNER}/${pkg}:${ver}"
-  else
-    echo "${pkg}: (no semver tag found)"
-  fi
+  created="${latest#* }"
+  printf '%s\t%s\t%s\tghcr.io/%s/%s:%s\n' \
+    "$pkg" "$ver" "$(to_local_time "$created")" "$OWNER" "$pkg" "$ver"
 done


### PR DESCRIPTION
## Context

`infra/list-latest-tags.sh` was reporting `(no semver tag found)` for all nine images. The root cause was environmental — a `gh` token missing the `read:packages` scope — not a script bug. But diagnosing it surfaced several real problems, which this PR fixes.

## Bugs fixed

**The curl fallback could never authenticate.** The auth header was built with an unquoted expansion:

```bash
${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"}
```

The quotes inside the expansion aren't re-processed, so word-splitting broke this into four arguments — `-H`, `"Authorization:`, `Bearer`, `<token>"` — sending a malformed header plus two bogus URLs. The header is now a single quoted argument, on a code path only reachable when `GITHUB_TOKEN` is non-empty.

**Errors repeated once per image.** A missing scope printed the same 403/401/jq block nine times. Auth is now probed once up front; a scope problem prints one message with the fix command and exits non-zero. A 404 gets a distinct hint about `GH_OWNER`/image names instead of wrongly suggesting a scope refresh.

**jq noise on API errors.** Piping an error body (an object) into a filter expecting an array produced `Cannot index string with string "metadata"`. Now guarded with `if type == "array"`.

## Dead code removed

- `if ! tags="$(fetch_tags_with_gh "$pkg" || true)"` — the `|| true` guarantees success, so the `if !` branch was unreachable.
- `if [[ -z "$OWNER" ]]` — unreachable after `${GH_OWNER:-bl1231}`.

## Other cleanup

- Two near-identical fetch functions collapsed into one dispatching on the chosen method.
- Date-conversion cascade extracted into `to_local_time`.
- `echo -e` → `printf`.
- Usage comment said `./latest-tags.sh`; corrected to the real filename.

## Known limitation (kept, now documented)

The curl fallback doesn't paginate, so it only sees the 100 most recent versions. `gh --paginate` does. Marked with a comment rather than fixed.

## Verification

Run against `bash` 3.2 (the macOS default — no bash-4 constructs used):

- happy path — all nine images resolve
- `IMAGES` override
- missing `jq` → clean error
- missing `gh` with no token → single auth message
- unknown owner → 404-specific hint

No changeset: `infra/` isn't a versioned workspace package and no published artifact changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)