### PR TITLE
fix(ui): move Chi²/C1/C2 out of the residuals plot area (#971)

### DIFF
--- a/.changeset/ui-chi2-label-hidden-behind-residuals.md
+++ b/.changeset/ui-chi2-label-hidden-behind-residuals.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Fix Chi² / C1 / C2 values being hidden behind the residual trace on the "Chi² residuals" plots (#971). The values now render as a larger, theme-aware header line above the plot instead of as fixed-position SVG text inside the plot area. The ensemble/multi-state plot gains a matching row of colour-keyed Chi² chips for each visible ensemble, and the ensemble results table uses a larger font.

--- a/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
+++ b/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
@@ -1,5 +1,13 @@
 import { useState, Fragment } from 'react'
-import { Checkbox, Paper, TableHead, Typography } from '@mui/material'
+import {
+  Checkbox,
+  Chip,
+  Paper,
+  Stack,
+  TableHead,
+  Typography,
+  useTheme
+} from '@mui/material'
 import Grid from '@mui/material/Grid'
 import {
   Table,
@@ -62,6 +70,7 @@ const FoXSEnsembleCharts = ({
   maxYAxis,
   foxsData
 }: Props) => {
+  const theme = useTheme()
   // Initialize visibility state for each line
   const [visibility, setVisibility] = useState([
     false,
@@ -135,6 +144,28 @@ const FoXSEnsembleCharts = ({
       >
         Ensemble Models - Chi&sup2; residuals
       </Typography>
+      <Stack
+        direction="row"
+        spacing={1}
+        useFlexGap
+        sx={{ pl: 2, mb: 1, flexWrap: 'wrap' }}
+      >
+        {foxsData.map((item, index) =>
+          visibility[index] ? (
+            <Chip
+              key={index}
+              size="small"
+              label={`${getEnsembleSizeLabel(item.filename)}: ${item.chisq.toFixed(2)}`}
+              sx={{
+                bgcolor: getUniqueColor(index),
+                color: 'common.black',
+                fontSize: '0.95rem',
+                fontWeight: 600
+              }}
+            />
+          ) : null
+        )}
+      </Stack>
       <ResponsiveContainer
         width="100%"
         height={200}
@@ -168,7 +199,7 @@ const FoXSEnsembleCharts = ({
           ))}
           <ReferenceLine
             y={0}
-            stroke="black"
+            stroke={theme.palette.text.secondary}
           />
         </LineChart>
       </ResponsiveContainer>
@@ -180,9 +211,15 @@ const FoXSEnsembleCharts = ({
           >
             <TableHead>
               <TableRow>
-                <TableCell>Show</TableCell>
-                <TableCell>Ensemble Filename</TableCell>
-                <TableCell>Chi&sup2;</TableCell>
+                <TableCell sx={{ fontSize: '1rem', fontWeight: 700 }}>
+                  Show
+                </TableCell>
+                <TableCell sx={{ fontSize: '1rem', fontWeight: 700 }}>
+                  Ensemble Filename
+                </TableCell>
+                <TableCell sx={{ fontSize: '1rem', fontWeight: 700 }}>
+                  Chi&sup2;
+                </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -201,10 +238,14 @@ const FoXSEnsembleCharts = ({
                         />
                       </TableCell>
                       <TableCell>
-                        <Typography>{model.filename}</Typography>
+                        <Typography sx={{ fontSize: '1rem', fontWeight: 600 }}>
+                          {model.filename}
+                        </Typography>
                       </TableCell>
                       <TableCell>
-                        <Typography>{model.chisq.toFixed(2)}</Typography>
+                        <Typography sx={{ fontSize: '1rem', fontWeight: 600 }}>
+                          {model.chisq.toFixed(2)}
+                        </Typography>
                       </TableCell>
                     </TableRow>
                   )

--- a/apps/ui/src/features/foxs/__tests__/FoXSEnsembleCharts.test.tsx
+++ b/apps/ui/src/features/foxs/__tests__/FoXSEnsembleCharts.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import FoXSEnsembleCharts from '../FoXSEnsembleCharts'
 import { getEnsembleSizeLabel } from '../foxsUtils'
 import type { FoxsData } from '@bilbomd/bilbomd-types'
@@ -115,5 +116,40 @@ describe('FoXSEnsembleCharts', () => {
     expect(
       screen.queryByText('multi_state_model_1_1_1.dat')
     ).not.toBeInTheDocument()
+  })
+
+  // Part of #971: chi² is surfaced in a header line above the residuals plot,
+  // colour-keyed to each visible ensemble trace.
+  it('renders a chi² chip for each visible ensemble', () => {
+    const foxsData: FoxsData[] = [baseFoxsData, make1State(), make2State()]
+    render(
+      <FoXSEnsembleCharts
+        {...defaultProps}
+        foxsData={foxsData}
+      />
+    )
+    expect(screen.getByText('Ens. Size 1: 1.50')).toBeInTheDocument()
+    expect(screen.getByText('Ens. Size 2: 1.20')).toBeInTheDocument()
+    // The base dataset starts hidden, so it gets no chip.
+    expect(screen.queryByText(/sample\.dat: /)).not.toBeInTheDocument()
+  })
+
+  it('removes an ensemble chip when its checkbox is unchecked', async () => {
+    const user = userEvent.setup()
+    const foxsData: FoxsData[] = [baseFoxsData, make1State(), make2State()]
+    render(
+      <FoXSEnsembleCharts
+        {...defaultProps}
+        foxsData={foxsData}
+      />
+    )
+    expect(screen.getByText('Ens. Size 2: 1.20')).toBeInTheDocument()
+
+    // Table rows skip index 0, so the checkboxes map to ensembles 1 and 2.
+    const checkboxes = screen.getAllByRole('checkbox')
+    await user.click(checkboxes[1]!)
+
+    expect(screen.queryByText('Ens. Size 2: 1.20')).not.toBeInTheDocument()
+    expect(screen.getByText('Ens. Size 1: 1.50')).toBeInTheDocument()
   })
 })

--- a/apps/ui/src/features/scoperjob/FoXSChart.tsx
+++ b/apps/ui/src/features/scoperjob/FoXSChart.tsx
@@ -11,7 +11,7 @@ import {
   ReferenceArea,
   ErrorBar
 } from 'recharts'
-import { Typography } from '@mui/material'
+import { Box, Stack, Typography, useTheme } from '@mui/material'
 
 interface DataPoint {
   q: number
@@ -43,75 +43,6 @@ interface FoXSChartProps {
   excludedRanges?: ExcludedRange[]
 }
 
-interface CustomChartLabelProps {
-  chisq: number
-  c1: string
-  c2: string
-  x: number
-  y: number
-}
-
-const ChiSquaredChartLabel = ({
-  chisq,
-  c1,
-  c2,
-  x,
-  y
-}: CustomChartLabelProps) => {
-  return (
-    <>
-      <text
-        x={x}
-        y={y}
-        fill="black"
-        fontSize={16}
-      >
-        Chi²: {chisq.toFixed(2)}
-      </text>
-      <text
-        x={x + 80}
-        y={y}
-        fill="black"
-        fontSize={16}
-      >
-        C
-        <tspan
-          dy="3"
-          fontSize={10}
-        >
-          1
-        </tspan>
-        <tspan
-          dy="-3"
-          fontSize={14}
-        >
-          : {c1}
-        </tspan>
-      </text>
-      <text
-        x={x + 140}
-        y={y}
-        fill="black"
-        fontSize={16}
-      >
-        C
-        <tspan
-          dy="3"
-          fontSize={10}
-        >
-          2
-        </tspan>
-        <tspan
-          dy="-3"
-          fontSize={14}
-        >
-          : {c2}
-        </tspan>
-      </text>
-    </>
-  )
-}
-
 const logDomain = (dataMin: number): number => {
   if (!Number.isFinite(dataMin) || dataMin <= 0) return 0.001
   return Math.pow(10, Math.floor(Math.log10(dataMin)))
@@ -129,8 +60,7 @@ const FoXSChart = ({
   excludedCount = 0,
   excludedRanges = []
 }: FoXSChartProps) => {
-  const labelXPosition = 75
-  const labelYPosition = 20
+  const theme = useTheme()
 
   return (
     <>
@@ -217,6 +147,36 @@ const FoXSChart = ({
       >
         {title} - Chi&sup2; residuals
       </Typography>
+      <Stack
+        direction="row"
+        spacing={2.5}
+        useFlexGap
+        sx={{ pl: 2, mb: 1, flexWrap: 'wrap', color: 'text.primary' }}
+      >
+        <Typography sx={{ fontSize: '1.1rem', fontWeight: 600 }}>
+          Chi&sup2;: {chisq.toFixed(2)}
+        </Typography>
+        <Typography sx={{ fontSize: '1.1rem', fontWeight: 600 }}>
+          C
+          <Box
+            component="sub"
+            sx={{ fontSize: '0.7em' }}
+          >
+            1
+          </Box>
+          : {c1}
+        </Typography>
+        <Typography sx={{ fontSize: '1.1rem', fontWeight: 600 }}>
+          C
+          <Box
+            component="sub"
+            sx={{ fontSize: '0.7em' }}
+          >
+            2
+          </Box>
+          : {c2}
+        </Typography>
+      </Stack>
       <ResponsiveContainer
         width="100%"
         height={200}
@@ -255,16 +215,7 @@ const FoXSChart = ({
           />
           <ReferenceLine
             y={0}
-            stroke="black"
-            label={
-              <ChiSquaredChartLabel
-                chisq={chisq}
-                c1={c1}
-                c2={c2}
-                x={labelXPosition}
-                y={labelYPosition}
-              />
-            }
+            stroke={theme.palette.text.secondary}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/apps/ui/src/features/scoperjob/__tests__/FoXSChart.test.tsx
+++ b/apps/ui/src/features/scoperjob/__tests__/FoXSChart.test.tsx
@@ -1,0 +1,63 @@
+// apps/ui/src/features/scoperjob/__tests__/FoXSChart.test.tsx
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import FoXSChart from '../FoXSChart'
+
+const defaultProps = {
+  title: 'Original Model',
+  data: [
+    { q: 0.01, exp_intensity: 100.0, model_intensity: 98.0, error: 2.0 },
+    { q: 0.02, exp_intensity: 85.0, model_intensity: 84.0, error: 1.5 }
+  ],
+  residualsData: [
+    { q: 0.01, res: 1.0 },
+    { q: 0.02, res: -0.5 }
+  ],
+  chisq: 1.42,
+  c1: '1.01',
+  c2: '2.00',
+  minYAxis: -3,
+  maxYAxis: 3
+}
+
+describe('FoXSChart', () => {
+  it('renders both chart headings', () => {
+    render(<FoXSChart {...defaultProps} />)
+    expect(screen.getByText('Original Model - I vs. q')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Original Model - Chi² residuals/)
+    ).toBeInTheDocument()
+  })
+
+  // Regression test for #971: the Chi²/C1/C2 values used to be raw SVG <text>
+  // painted inside the residuals plot area, where the residual trace could
+  // draw over them. They now live in a DOM header line above the plot.
+  it('renders Chi², C1 and C2 as DOM text outside the plot area', () => {
+    const { container } = render(<FoXSChart {...defaultProps} />)
+
+    expect(screen.getByText(/Chi²: 1\.42/)).toBeInTheDocument()
+    expect(screen.getByText(/1\.01/)).toBeInTheDocument()
+    expect(screen.getByText(/2\.00/)).toBeInTheDocument()
+
+    // None of the stat values should be rendered as SVG <text> nodes.
+    const svgText = Array.from(container.querySelectorAll('svg text')).map(
+      (node) => node.textContent ?? ''
+    )
+    expect(svgText.some((text) => text.includes('1.42'))).toBe(false)
+  })
+
+  it('renders the excluded-points warning only when points were excluded', () => {
+    const { rerender } = render(<FoXSChart {...defaultProps} />)
+    expect(screen.queryByText(/excluded from/)).not.toBeInTheDocument()
+
+    rerender(
+      <FoXSChart
+        {...defaultProps}
+        excludedCount={2}
+        excludedRanges={[{ x1: 0.3, x2: 0.4 }]}
+      />
+    )
+    expect(screen.getByText(/2 points excluded from/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #971

## Problem

On the job results page, the "Original Model - Chi² residuals" plot printed Chi², C₁ and C₂ as raw SVG `<text>` at hardcoded coordinates (`x=75, y=20`) **inside the plot area**, passed via the `label` prop of the `y=0` `ReferenceLine`. The residuals `LineChart` has no top margin, so y=20 sits squarely in the data band and the residual trace routinely drew over the numbers — worst on the results page, where these plots render in half-width grid columns.

The issue also asked for a bigger font "for both initial and multiple states".

## Changes

**`apps/ui/src/features/scoperjob/FoXSChart.tsx`**
- Removed `ChiSquaredChartLabel` and the hardcoded `labelXPosition` / `labelYPosition`.
- Chi²/C₁/C₂ now render as a wrapping MUI header line under the chart title at `1.1rem` / 600 weight, with real `<sub>` subscripts instead of hand-rolled `<tspan dy>`.
- Impossible to occlude, larger, theme-aware, and it wraps rather than clips at half width.
- One edit fixes **three** chart instances: `FoXSAnalysis.tsx` ("Original Model") and `ScoperFoXSAnalysis.tsx` ("Original Model" + "Scoper Model").

**`apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx`**
- Added a matching header row above the ensemble residuals plot: one Chi² chip per **visible** ensemble, colour-keyed to its trace by reusing the existing `getUniqueColor` / `getEnsembleSizeLabel`. It tracks the same `visibility` state that drives the plot, so unchecking a state in the table removes its chip.
- Bumped the ensemble results table font. The table stays — its checkboxes are the visibility toggle for the N-state plots.

**Both files**
- The `y=0` reference line was hardcoded `black`; now uses `theme.palette.text.secondary`, which also fixes it in dark mode.

## Tests

- New `apps/ui/src/features/scoperjob/__tests__/FoXSChart.test.tsx` — asserts the values render as DOM text, and specifically that `1.42` no longer appears in any `svg text` node (direct regression test for this bug).
- Extended `FoXSEnsembleCharts.test.tsx` — chips appear for visible ensembles and disappear when a checkbox is unchecked.

`pnpm -F @bilbomd/ui lint`, `build` and `test` all pass (1111 tests).

## Still to verify

Not yet checked in a running browser — worth a look on a real `auto`/`pdb` job and a `scoper` job, in both light and dark mode, plus a narrow window to confirm the stats line wraps rather than clips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)