### PR TITLE
fix(backend): enforce job ownership on /jobs/:id routes (#981)

### DIFF
--- a/.changeset/backend-job-ownership-check.md
+++ b/.changeset/backend-job-ownership-check.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/backend': patch
+---
+
+Security: enforce job ownership on all `/jobs/:id*` routes and `/external/jobs/:id/results`. A new `verifyJobOwnership` middleware returns 404 unless the requester owns the job or holds the Admin/Manager role, closing an IDOR where any authenticated user could read, download, or delete any job by id. Also sanitizes the PDB filename in `downloadPDB`. Fixes #981.

--- a/apps/backend/src/controllers/__tests__/foxsController.test.ts
+++ b/apps/backend/src/controllers/__tests__/foxsController.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Request, Response } from 'express'
+import { Types } from 'mongoose'
+
+const { mockJobFindOne, mockAccess } = vi.hoisted(() => ({
+  mockJobFindOne: vi.fn(),
+  mockAccess: vi.fn()
+}))
+
+vi.mock('../../config/config.js', () => ({
+  getEnvVar: vi.fn().mockReturnValue('/data')
+}))
+
+vi.mock('../../middleware/loggers.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+vi.mock('fs-extra', () => ({
+  default: { promises: { access: mockAccess } }
+}))
+
+vi.mock('../../services/foxs/foxsDataService.js', () => ({
+  buildBilboFoxsData: vi.fn(),
+  buildScoperFoxsData: vi.fn()
+}))
+
+vi.mock('@bilbomd/mongodb-schema', () => ({
+  Job: { findOne: mockJobFindOne }
+}))
+
+import { downloadPDB } from '../foxsController.js'
+
+const jobId = new Types.ObjectId().toString()
+
+const createMockResponse = () => {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    sendFile: vi.fn()
+  }
+  return res as unknown as Response & typeof res
+}
+
+describe('downloadPDB', () => {
+  let res: ReturnType<typeof createMockResponse>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    res = createMockResponse()
+    mockAccess.mockResolvedValue(undefined)
+  })
+
+  it('returns 400 when the job id is missing', async () => {
+    const req = { params: { pdb: 'model.pdb' } } as unknown as Request
+    await downloadPDB(req, res)
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({ message: 'Job ID required.' })
+  })
+
+  it('returns 400 when the pdb filename is missing', async () => {
+    const req = { params: { id: jobId } } as unknown as Request
+    await downloadPDB(req, res)
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({ message: 'PDB filename required.' })
+  })
+
+  it('returns 404 when no job matches the id', async () => {
+    mockJobFindOne.mockReturnValue({ exec: vi.fn().mockResolvedValue(null) })
+    const req = {
+      params: { id: jobId, pdb: 'model.pdb' }
+    } as unknown as Request
+    await downloadPDB(req, res)
+    expect(res.status).toHaveBeenCalledWith(404)
+    expect(res.json).toHaveBeenCalledWith({
+      message: `No job matches ID ${jobId}.`
+    })
+    expect(res.sendFile).not.toHaveBeenCalled()
+  })
+
+  it('sends the PDB from the job results directory', async () => {
+    mockJobFindOne.mockReturnValue({
+      exec: vi.fn().mockResolvedValue({ uuid: 'abc-123' })
+    })
+    const req = {
+      params: { id: jobId, pdb: 'model.pdb' }
+    } as unknown as Request
+    await downloadPDB(req, res)
+    expect(mockAccess).toHaveBeenCalledWith('/data/abc-123/results/model.pdb')
+    expect(res.sendFile).toHaveBeenCalledWith(
+      '/data/abc-123/results/model.pdb',
+      expect.any(Function)
+    )
+  })
+
+  it('strips directory components from the pdb filename', async () => {
+    mockJobFindOne.mockReturnValue({
+      exec: vi.fn().mockResolvedValue({ uuid: 'abc-123' })
+    })
+    const req = {
+      params: { id: jobId, pdb: '../../etc/passwd' }
+    } as unknown as Request
+    await downloadPDB(req, res)
+    expect(res.sendFile).toHaveBeenCalledWith(
+      '/data/abc-123/results/passwd',
+      expect.any(Function)
+    )
+  })
+
+  it('returns 500 when the PDB file is not accessible', async () => {
+    mockJobFindOne.mockReturnValue({
+      exec: vi.fn().mockResolvedValue({ uuid: 'abc-123' })
+    })
+    mockAccess.mockRejectedValue(new Error('ENOENT'))
+    const req = {
+      params: { id: jobId, pdb: 'missing.pdb' }
+    } as unknown as Request
+    await downloadPDB(req, res)
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.sendFile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/controllers/foxsController.ts
+++ b/apps/backend/src/controllers/foxsController.ts
@@ -34,7 +34,12 @@ const downloadPDB = async (req: Request, res: Response) => {
     res.status(204).json({ message: `No job matches ID ${jobId}.` })
     return
   }
-  const pdbFile = path.join(uploadFolder, job.uuid, 'results', pdbFilename)
+  const pdbFile = path.join(
+    uploadFolder,
+    job.uuid,
+    'results',
+    path.basename(pdbFilename)
+  )
 
   try {
     await fs.promises.access(pdbFile)

--- a/apps/backend/src/controllers/foxsController.ts
+++ b/apps/backend/src/controllers/foxsController.ts
@@ -31,7 +31,7 @@ const downloadPDB = async (req: Request, res: Response) => {
   logger.info('Looking up job', { jobId })
   const job = await Job.findOne({ _id: jobId }).exec()
   if (!job) {
-    res.status(204).json({ message: `No job matches ID ${jobId}.` })
+    res.status(404).json({ message: `No job matches ID ${jobId}.` })
     return
   }
   const pdbFile = path.join(

--- a/apps/backend/src/middleware/__tests__/verifyJobOwnership.test.ts
+++ b/apps/backend/src/middleware/__tests__/verifyJobOwnership.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Request, Response, NextFunction } from 'express'
+import { Types } from 'mongoose'
+import type { IUser } from '@bilbomd/mongodb-schema'
+import { verifyJobOwnership } from '../verifyJobOwnership.js'
+
+const { mockJobExists, mockMultiJobExists, mockUserFindOne } = vi.hoisted(
+  () => ({
+    mockJobExists: vi.fn(),
+    mockMultiJobExists: vi.fn(),
+    mockUserFindOne: vi.fn()
+  })
+)
+
+vi.mock('../loggers.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+vi.mock('@bilbomd/mongodb-schema', () => ({
+  Job: { exists: mockJobExists },
+  MultiJob: { exists: mockMultiJobExists },
+  User: { findOne: mockUserFindOne }
+}))
+
+const userId = new Types.ObjectId()
+const jobId = new Types.ObjectId().toString()
+
+describe('verifyJobOwnership middleware', () => {
+  let mockRequest: Partial<Request>
+  let mockResponse: Partial<Response>
+  let mockNext: NextFunction
+  let statusSpy: ReturnType<typeof vi.fn>
+  let jsonSpy: ReturnType<typeof vi.fn>
+
+  const mockUserLookup = (user: { _id: Types.ObjectId } | null) => {
+    mockUserFindOne.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue(user)
+      })
+    })
+  }
+
+  const run = () =>
+    verifyJobOwnership(
+      mockRequest as Request,
+      mockResponse as Response,
+      mockNext
+    )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockNext = vi.fn()
+    jsonSpy = vi.fn()
+    statusSpy = vi.fn(() => ({ json: jsonSpy }))
+    mockRequest = { params: { id: jobId } }
+    mockResponse = { status: statusSpy as unknown as Response['status'] }
+    mockUserLookup({ _id: userId })
+    mockJobExists.mockResolvedValue(null)
+    mockMultiJobExists.mockResolvedValue(null)
+  })
+
+  describe('id validation', () => {
+    it('returns 400 when the id is missing', async () => {
+      mockRequest.params = {}
+      mockRequest.user = 'alice'
+      mockRequest.roles = ['User']
+      await run()
+      expect(statusSpy).toHaveBeenCalledWith(400)
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when the id is not a 24-hex ObjectId', async () => {
+      mockRequest.params = { id: 'not-an-object-id' }
+      mockRequest.user = 'alice'
+      mockRequest.roles = ['User']
+      await run()
+      expect(statusSpy).toHaveBeenCalledWith(400)
+      expect(jsonSpy).toHaveBeenCalledWith({ message: 'Invalid Job ID format.' })
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('JWT-authenticated requests', () => {
+    it('returns 401 when no authenticated user is present', async () => {
+      await run()
+      expect(statusSpy).toHaveBeenCalledWith(401)
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockUserFindOne).not.toHaveBeenCalled()
+    })
+
+    it('calls next() for Admin without touching the database', async () => {
+      mockRequest.user = 'admin'
+      mockRequest.roles = ['Admin']
+      await run()
+      expect(mockNext).toHaveBeenCalledOnce()
+      expect(statusSpy).not.toHaveBeenCalled()
+      expect(mockUserFindOne).not.toHaveBeenCalled()
+      expect(mockJobExists).not.toHaveBeenCalled()
+      expect(mockMultiJobExists).not.toHaveBeenCalled()
+    })
+
+    it('calls next() for Manager without touching the database', async () => {
+      mockRequest.user = 'manager'
+      mockRequest.roles = ['User', 'Manager']
+      await run()
+      expect(mockNext).toHaveBeenCalledOnce()
+      expect(statusSpy).not.toHaveBeenCalled()
+      expect(mockJobExists).not.toHaveBeenCalled()
+    })
+
+    it('calls next() when the user owns the Job', async () => {
+      mockRequest.user = 'alice'
+      mockRequest.roles = ['User']
+      mockJobExists.mockResolvedValue({ _id: jobId })
+      await run()
+      expect(mockUserFindOne).toHaveBeenCalledWith({ username: 'alice' })
+      expect(mockJobExists).toHaveBeenCalledWith({
+        _id: jobId,
+        $or: [{ user: userId }, { 'user._id': userId }]
+      })
+      expect(mockMultiJobExists).not.toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalledOnce()
+      expect(statusSpy).not.toHaveBeenCalled()
+    })
+
+    it('calls next() when the user owns the MultiJob', async () => {
+      mockRequest.user = 'alice'
+      mockRequest.roles = ['User']
+      mockJobExists.mockResolvedValue(null)
+      mockMultiJobExists.mockResolvedValue({ _id: jobId })
+      await run()
+      expect(mockMultiJobExists).toHaveBeenCalledWith({
+        _id: jobId,
+        $or: [{ user: userId }, { 'user._id': userId }]
+      })
+      expect(mockNext).toHaveBeenCalledOnce()
+      expect(statusSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns 404 when the job belongs to someone else', async () => {
+      mockRequest.user = 'bob'
+      mockRequest.roles = ['User']
+      await run()
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(statusSpy).toHaveBeenCalledWith(404)
+      expect(jsonSpy).toHaveBeenCalledWith({
+        message: `No job matches ID ${jobId}.`
+      })
+    })
+
+    it('returns 404 when the job does not exist at all', async () => {
+      mockRequest.user = 'alice'
+      mockRequest.roles = ['User']
+      await run()
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(statusSpy).toHaveBeenCalledWith(404)
+    })
+
+    it('returns 401 when the username has no user record', async () => {
+      mockRequest.user = 'ghost'
+      mockRequest.roles = ['User']
+      mockUserLookup(null)
+      await run()
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(statusSpy).toHaveBeenCalledWith(401)
+      expect(mockJobExists).not.toHaveBeenCalled()
+    })
+
+    it('treats missing roles as an ordinary user', async () => {
+      mockRequest.user = 'alice'
+      mockRequest.roles = undefined
+      mockJobExists.mockResolvedValue({ _id: jobId })
+      await run()
+      expect(mockNext).toHaveBeenCalledOnce()
+    })
+
+    it('returns 500 when the database lookup throws', async () => {
+      mockRequest.user = 'alice'
+      mockRequest.roles = ['User']
+      mockJobExists.mockRejectedValue(new Error('boom'))
+      await run()
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(statusSpy).toHaveBeenCalledWith(500)
+    })
+  })
+
+  describe('API-token-authenticated requests', () => {
+    const apiUser = (roles: string[]) =>
+      ({
+        _id: userId,
+        username: 'api-user',
+        roles
+      }) as unknown as IUser
+
+    it('calls next() when the API user owns the job', async () => {
+      mockRequest.apiUser = apiUser(['User'])
+      mockJobExists.mockResolvedValue({ _id: jobId })
+      await run()
+      expect(mockUserFindOne).not.toHaveBeenCalled()
+      expect(mockJobExists).toHaveBeenCalledWith({
+        _id: jobId,
+        $or: [{ user: userId }, { 'user._id': userId }]
+      })
+      expect(mockNext).toHaveBeenCalledOnce()
+    })
+
+    it('returns 404 when the API user does not own the job', async () => {
+      mockRequest.apiUser = apiUser(['User'])
+      await run()
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(statusSpy).toHaveBeenCalledWith(404)
+    })
+
+    it('prefers the JWT identity when both req.user and req.apiUser are set', async () => {
+      mockRequest.user = 'admin'
+      mockRequest.roles = ['Admin']
+      mockRequest.apiUser = apiUser(['User'])
+      await run()
+      expect(mockNext).toHaveBeenCalledOnce()
+      expect(mockJobExists).not.toHaveBeenCalled()
+    })
+
+    it('calls next() for an API user with the Admin role', async () => {
+      mockRequest.apiUser = apiUser(['Admin'])
+      await run()
+      expect(mockNext).toHaveBeenCalledOnce()
+      expect(mockJobExists).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/backend/src/middleware/verifyJobOwnership.ts
+++ b/apps/backend/src/middleware/verifyJobOwnership.ts
@@ -1,0 +1,93 @@
+import { Request, Response, NextFunction } from 'express'
+import { Types } from 'mongoose'
+import { Job, MultiJob, User } from '@bilbomd/mongodb-schema'
+import { logger } from './loggers.js'
+
+const PRIVILEGED_ROLES = ['Admin', 'Manager']
+const OBJECT_ID_RE = /^[0-9a-fA-F]{24}$/
+
+// Guards every `/:id` job route so a caller can only act on a job they own.
+// Admins and Managers may act on any job. Works for both auth paths:
+//   - verifyJWT / verifyVideoSession set `req.user` (username) + `req.roles`
+//   - verifyAPIToken sets `req.apiUser` (full IUser document)
+// When `req.user` is present it takes precedence over `req.apiUser`.
+// Jobs store the owner as an embedded `{ user: { _id } }` object while
+// MultiJobs store a plain ObjectId ref, so the ownership filter checks both
+// shapes — the same filter `getAllJobs` uses.
+//
+// Non-owned and non-existent ids both yield 404 so the endpoint cannot be used
+// to confirm that a given job id exists.
+const verifyJobOwnership = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const rawId = req.params.id
+  const jobId = Array.isArray(rawId) ? rawId[0] : rawId
+
+  if (!jobId || !OBJECT_ID_RE.test(jobId)) {
+    res.status(400).json({ message: 'Invalid Job ID format.' })
+    return
+  }
+
+  try {
+    let roles: string[]
+    let userId: Types.ObjectId | undefined
+    let requester: string
+
+    // Prefer the JWT/session identity; fall back to the API-token identity.
+    if (req.user) {
+      roles = req.roles ?? []
+      requester = req.user
+    } else if (req.apiUser) {
+      roles = req.apiUser.roles ?? []
+      userId = req.apiUser._id as Types.ObjectId
+      requester = req.apiUser.username ?? String(userId)
+    } else {
+      res.status(401).json({ message: 'Unauthorized' })
+      return
+    }
+
+    if (roles.some((role) => PRIVILEGED_ROLES.includes(role))) {
+      next()
+      return
+    }
+
+    if (!userId) {
+      const user = await User.findOne({ username: req.user })
+        .select('_id')
+        .lean<{ _id: Types.ObjectId }>()
+      if (!user) {
+        logger.warn(
+          `verifyJobOwnership: no user record for username ${req.user}`
+        )
+        res.status(401).json({ message: 'Unauthorized' })
+        return
+      }
+      userId = user._id
+    }
+
+    const ownerFilter = {
+      _id: jobId,
+      $or: [{ user: userId }, { 'user._id': userId }]
+    }
+
+    const owned =
+      (await Job.exists(ownerFilter)) ?? (await MultiJob.exists(ownerFilter))
+
+    if (!owned) {
+      logger.warn(
+        `Access denied: ${requester} attempted to access job ${jobId} they do not own`
+      )
+      res.status(404).json({ message: `No job matches ID ${jobId}.` })
+      return
+    }
+
+    next()
+  } catch (error) {
+    logger.error(`verifyJobOwnership error for job ${jobId}: ${error}`)
+    res.status(500).json({ message: 'Failed to verify job ownership.' })
+  }
+}
+
+export { verifyJobOwnership }

--- a/apps/backend/src/routes/external.ts
+++ b/apps/backend/src/routes/external.ts
@@ -3,6 +3,7 @@ import { createApiJob } from '../controllers/external/createApiJob.js'
 import { getApiJobStatus } from '../controllers/external/jobStatus.js'
 import { getExternalJobResults } from '../controllers/external/getResults.js'
 import { verifyAPIToken } from '../middleware/verifyAPIToken.js'
+import { verifyJobOwnership } from '../middleware/verifyJobOwnership.js'
 import { logApiRequest } from '../middleware/logApiRequests.js'
 
 const router = express.Router()
@@ -260,6 +261,6 @@ router.get('/:id/status', getApiJobStatus)
  *                 value:
  *                   message: An error occurred while processing your request.
  */
-router.get('/:id/results', getExternalJobResults)
+router.get('/:id/results', verifyJobOwnership, getExternalJobResults)
 
 export default router

--- a/apps/backend/src/routes/jobs.ts
+++ b/apps/backend/src/routes/jobs.ts
@@ -15,6 +15,7 @@ import getMovies from '../controllers/movies/getMovies.js'
 import streamVideo from '../controllers/movies/streamVideo.js'
 import { checkFiles } from '../controllers/resubmitController.js'
 import { verifyJWT } from '../middleware/verifyJWT.js'
+import { verifyJobOwnership } from '../middleware/verifyJobOwnership.js'
 import { setVideoSession, verifyVideoSession } from '../middleware/videoAuth.js'
 import { logger } from '../middleware/loggers.js'
 const router = express.Router()
@@ -38,18 +39,22 @@ router.use((req, res, next) => {
 
 router.route('/').get(getAllJobs).post(createNewJob)
 
-router.route('/:id').get(getJobById)
-router.route('/:id').delete(deleteJob)
-router.route('/:id/results').get(downloadJobResults)
-router.route('/:id/results/foxs').get(getFoxsData)
-router.route('/:id/results/:pdb').get(downloadPDB)
-router.route('/:id/logs').get(getLogForStep)
-router.route('/:id/check-files').get(checkFiles)
+// Every /:id route must pass verifyJobOwnership: the caller has to own the job
+// or hold the Admin/Manager role. The movie routes enforce ownership inline.
+router
+  .route('/:id')
+  .get(verifyJobOwnership, getJobById)
+  .delete(verifyJobOwnership, deleteJob)
+router.route('/:id/results').get(verifyJobOwnership, downloadJobResults)
+router.route('/:id/results/foxs').get(verifyJobOwnership, getFoxsData)
+router.route('/:id/results/:pdb').get(verifyJobOwnership, downloadPDB)
+router.route('/:id/logs').get(verifyJobOwnership, getLogForStep)
+router.route('/:id/check-files').get(verifyJobOwnership, checkFiles)
 router.route('/:id/movies').get(getMovies)
 router
   .route('/:id/movies/:label/:filename')
   .get(verifyVideoSession, streamVideo)
-router.route('/:id/:filename').get(getFile)
+router.route('/:id/:filename').get(verifyJobOwnership, getFile)
 router.route('/bilbomd-auto').post(createNewJob)
 router.route('/bilbomd-scoper').post(createNewJob)
 router.route('/bilbomd-alphafold').post(createNewJob)

--- a/apps/backend/test/integration/externalJobResults.test.ts
+++ b/apps/backend/test/integration/externalJobResults.test.ts
@@ -78,7 +78,7 @@ describe('/api/v1/external/jobs/:id/results', () => {
       .set('Accept', 'application/json')
 
     expect(res.status).toBe(400)
-    expect(res.body.message).toBe('Invalid job ID format')
+    expect(res.body.message).toBe('Invalid Job ID format.')
   })
 
   test('should return 404 if job not found', async () => {
@@ -91,7 +91,24 @@ describe('/api/v1/external/jobs/:id/results', () => {
       .set('Accept', 'application/json')
 
     expect(res.status).toBe(404)
-    expect(res.body.message).toContain('No job matches that ID')
+    expect(res.body.message).toContain('No job matches ID')
+  })
+
+  test("should return 404 for another API user's job", async () => {
+    const other = await seedApiTokenUser({
+      email: 'other-results@example.com',
+      username: 'apitestuser-other',
+      token: 'other-user-token-0987654321'
+    })
+    const job = await Job.findOne({ title: 'Test Job for Results' })
+
+    const res = await request(app)
+      .get(`/api/v1/external/jobs/${job?._id}/results`)
+      .set('Authorization', `Bearer ${other.token}`)
+      .set('Accept', 'application/json')
+
+    expect(res.status).toBe(404)
+    expect(res.body.message).toContain('No job matches ID')
   })
 
   test('should return 401 if Authorization header is missing', async () => {

--- a/apps/backend/test/integration/jobs.test.ts
+++ b/apps/backend/test/integration/jobs.test.ts
@@ -59,12 +59,16 @@ interface JobType {
   username: string
 }
 
-const generateAccessToken = (email?: string): string => {
+const generateAccessToken = (
+  email?: string,
+  username = 'testuser1',
+  roles: string[] = ['User']
+): string => {
   const userEmail = email ?? 'testuser1@example.com'
   const accessTokenPayload: JwtPayload = {
     UserInfo: {
-      username: 'testuser1',
-      roles: ['User'],
+      username,
+      roles,
       email: userEmail
     }
   }
@@ -74,6 +78,17 @@ const generateAccessToken = (email?: string): string => {
   })
   return accessToken
 }
+
+const createOtherUser = async (): Promise<IUser> =>
+  User.create({
+    username: 'testuser2',
+    email: 'testuser2@example.com',
+    roles: ['User'],
+    confirmationCode: {
+      code: '67890',
+      expiresAt: new Date(Date.now() + 3600000)
+    }
+  })
 
 const createNewJob = async (user: IUser) => {
   const now = new Date()
@@ -190,6 +205,27 @@ describe('GET /api/v1/jobs/:id', () => {
     const newJob = await createNewJob(testUser1)
     const res = await request(app)
       .get(`/api/v1/jobs/${newJob._id}`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toBeDefined()
+  })
+  test("should return 404 for another user's job", async () => {
+    expect.assertions(2)
+    const otherUser = await createOtherUser()
+    const otherJob = await createNewJob(otherUser)
+    const token = generateAccessToken()
+    const res = await request(app)
+      .get(`/api/v1/jobs/${otherJob._id}`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.statusCode).toBe(404)
+    expect(res.body.message).toBe(`No job matches ID ${otherJob._id}.`)
+  })
+  test("should allow an Admin to read another user's job", async () => {
+    const otherUser = await createOtherUser()
+    const otherJob = await createNewJob(otherUser)
+    const token = generateAccessToken(undefined, 'testuser1', ['Admin'])
+    const res = await request(app)
+      .get(`/api/v1/jobs/${otherJob._id}`)
       .set('Authorization', `Bearer ${token}`)
     expect(res.statusCode).toBe(200)
     expect(res.body).toBeDefined()
@@ -355,14 +391,25 @@ describe('DELETE /api/v1/jobs/:id', () => {
     expect(res.body.message).toBe('Unauthorized')
   })
 
-  test('should return 202 if Job ID not found (still queued)', async () => {
+  test('should return 404 if Job ID not found', async () => {
     const token = generateAccessToken()
     const id = new mongoose.Types.ObjectId().toString()
     const res = await request(app)
       .delete(`/api/v1/jobs/${id}`)
       .set('Authorization', `Bearer ${token}`)
-    expect(res.statusCode).toBe(202)
-    expect(res.body.message).toMatch(/queued/i)
+    expect(res.statusCode).toBe(404)
+    expect(res.body.message).toBe(`No job matches ID ${id}.`)
+  })
+
+  test("should return 404 when deleting another user's job", async () => {
+    const otherUser = await createOtherUser()
+    const otherJob = await createNewJob(otherUser)
+    const token = generateAccessToken()
+    const res = await request(app)
+      .delete(`/api/v1/jobs/${otherJob._id}`)
+      .set('Authorization', `Bearer ${token}`)
+    expect(res.statusCode).toBe(404)
+    expect(await Job.findById(otherJob._id)).not.toBeNull()
   })
 
   test('should return 202 if directory is missing (worker will handle)', async () => {


### PR DESCRIPTION
## Summary

Fixes #981.

Every `/api/v1/jobs/:id…` route was guarded only by `verifyJWT`, which proves the caller is *some* logged-in user — not that they own the job. Only `getAllJobs` and the movie handlers actually checked ownership; nine other id-scoped handlers did not (`getJobById`, `deleteJob`, `downloadJobResults`, `getFoxsData`, `downloadPDB`, `getLogForStep`, `checkFiles`, `getFile`, and `external/getResults`). Any authenticated user who knew/guessed a job `_id` could read, download, or **delete** any job.

## Changes

- **New `verifyJobOwnership` middleware** (`apps/backend/src/middleware/verifyJobOwnership.ts`): Admin/Manager pass with no DB work; otherwise resolves the requester (JWT `req.user` → `User._id`, or API-token `req.apiUser._id`) and checks `Job.exists` / `MultiJob.exists` with the same `$or: [{ user }, { 'user._id' }]` filter `getAllJobs` uses. Non-owned **and** non-existent ids both return `404` so the endpoint can't be used to confirm an id exists.
- Applied to all seven `/:id` routes in `routes/jobs.ts` and to `/:id/results` in `routes/external.ts`. Movie routes untouched (already enforce ownership inline); `/public/*` token routes untouched.
- `downloadPDB`: `path.basename()` the PDB filename (matches `fileDownloadController`).
- Changeset: `@bilbomd/backend` patch.

## Behaviour changes

- `DELETE /jobs/:id` for an unknown id now returns `404` instead of queuing a no-op delete (`202`).
- Anonymous jobs (no `user`) are `404` for ordinary logged-in users via `/jobs/:id`; still reachable via `/public/*` token routes and by Admin/Manager.

## Tests

- 16 new unit tests (`src/middleware/__tests__/verifyJobOwnership.test.ts`): id validation, 401 w/o identity, Admin/Manager bypass, Job/MultiJob owner, non-owner 404, unknown username, API-token path, JWT-over-apiUser precedence, DB error → 500.
- Integration (`test/integration/jobs.test.ts`, `externalJobResults.test.ts`): cross-user GET/DELETE → 404, Admin reads another user's job, API-token non-owner → 404.
- `pnpm -F @bilbomd/backend lint` ✅ `build` ✅ unit 498/498 ✅ integration 63/63 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)