### PR TITLE
feat: add dimensionless Kratky plot to FoXS analysis panel

### DIFF
--- a/.changeset/dimensionless-kratky-plot.md
+++ b/.changeset/dimensionless-kratky-plot.md
@@ -1,0 +1,7 @@
+---
+'@bilbomd/bilbomd-types': minor
+'@bilbomd/backend': minor
+'@bilbomd/ui': minor
+---
+
+Add a dimensionless Kratky plot to the FoXS analysis panel. autorg.py now emits i0, rg_exact, r2, and qrg bounds alongside the existing Rg values; the backend attaches the Guinier fit (Rg, I0, fit window) to FoXS analysis responses, computing it on demand via autorg.py and caching the result as autorg.json in the job directory so existing completed jobs benefit without reprocessing. The UI renders a dimensionless Kratky chart ((qRg)²·I(q)/I(0) vs qRg) below the I(q) plots, overlaying the experimental curve with the original model and ensemble model curves, with reference crosshairs at the globular peak position (√3, 1.104).

--- a/apps/backend/src/controllers/jobs/utils/autoRg.ts
+++ b/apps/backend/src/controllers/jobs/utils/autoRg.ts
@@ -48,7 +48,10 @@ const getAutoRg = async (req: Request, res: Response) => {
           rg_min: autorgResults.rg_min,
           rg_max: autorgResults.rg_max,
           qmin: autorgResults.qmin,
-          qmax: autorgResults.qmax
+          qmax: autorgResults.qmax,
+          rg_exact: autorgResults.rg_exact,
+          i0: autorgResults.i0,
+          r2: autorgResults.r2
         })
         // await new Promise((resolve) => setTimeout(resolve, 5000))
         // Not sure if this is a NetApp issue or a Docker issue, but sometimes this fails

--- a/apps/backend/src/services/foxs/__tests__/foxsDataService.test.ts
+++ b/apps/backend/src/services/foxs/__tests__/foxsDataService.test.ts
@@ -3,6 +3,9 @@ import { buildBilboFoxsData, buildScoperFoxsData } from '../foxsDataService.js'
 
 vi.mock('fs-extra')
 vi.mock('../foxsParser.js')
+vi.mock('../guinierService.js', () => ({
+  getGuinierFit: vi.fn().mockResolvedValue(undefined)
+}))
 vi.mock('../../../config/config.js', () => ({
   getEnvVar: () => '/data'
 }))
@@ -64,6 +67,36 @@ describe('buildBilboFoxsData', () => {
     const result = await buildBilboFoxsData(makeJob())
     expect(result[0].filename).toMatch(/minimization_output_experiment/)
     expect(result.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('attaches the Guinier fit to the base dataset when available', async () => {
+    const { default: fs } = await import('fs-extra')
+    const parser = await import('../foxsParser.js')
+    const guinierService = await import('../guinierService.js')
+
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(fs.access).mockResolvedValue(undefined)
+    vi.mocked(fs.readFile)
+      .mockResolvedValueOnce(makeDatContent() as never)
+      .mockResolvedValue('c1 = 1.05 c2 = 0.02' as never)
+    vi.mocked(fs.readdir).mockResolvedValue([] as never)
+
+    vi.mocked(parser.parseFileContent).mockReturnValue([
+      { q: 0.001, exp_intensity: 100, model_intensity: 99, error: 2 }
+    ])
+    vi.mocked(parser.extractChiSquared).mockReturnValue(1.23)
+    vi.mocked(parser.extractC1C2).mockResolvedValue({ c1: '1.05', c2: '0.02' })
+
+    const fit = { rg: 40.4, i0: 1234.5, qmin: 0.012, qmax: 0.032, r2: 0.99 }
+    vi.mocked(guinierService.getGuinierFit).mockResolvedValue(fit)
+
+    const result = await buildBilboFoxsData(makeJob())
+
+    expect(guinierService.getGuinierFit).toHaveBeenCalledWith(
+      '/data/test-uuid',
+      'experiment.dat'
+    )
+    expect(result[0].guinier).toEqual(fit)
   })
 
   it('throws FOXS_DATA_UNAVAILABLE when no dat and no ensembles', async () => {

--- a/apps/backend/src/services/foxs/__tests__/guinierService.test.ts
+++ b/apps/backend/src/services/foxs/__tests__/guinierService.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getGuinierFit, toGuinierFit } from '../guinierService.js'
+
+vi.mock('fs-extra')
+vi.mock('../../../middleware/loggers.js', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }
+}))
+vi.mock('../../../controllers/jobs/utils/autoRg.js', () => ({
+  spawnAutoRgCalculator: vi.fn()
+}))
+
+const freshAutoRgResults = {
+  rg: 40,
+  rg_min: 36,
+  rg_max: 60,
+  qmin: 0.012,
+  qmax: 0.032,
+  rg_exact: 40.4,
+  i0: 1234.5,
+  r2: 0.99,
+  qrg_min: 0.48,
+  qrg_max: 1.29
+}
+
+describe('toGuinierFit', () => {
+  it('maps AutoRg results to a GuinierFit using the unrounded Rg', () => {
+    expect(toGuinierFit(freshAutoRgResults)).toEqual({
+      rg: 40.4,
+      i0: 1234.5,
+      qmin: 0.012,
+      qmax: 0.032,
+      r2: 0.99
+    })
+  })
+
+  it('falls back to rounded rg when rg_exact is absent', () => {
+    const noExact = { ...freshAutoRgResults, rg_exact: undefined }
+    expect(toGuinierFit(noExact)?.rg).toBe(40)
+  })
+
+  it('returns undefined for results lacking i0 (pre-Kratky autorg output)', () => {
+    expect(
+      toGuinierFit({ rg: 40, rg_min: 36, rg_max: 60, qmin: 0.01, qmax: 0.03 })
+    ).toBeUndefined()
+  })
+})
+
+describe('getGuinierFit', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns the cached fit without spawning AutoRg', async () => {
+    const { default: fs } = await import('fs-extra')
+    const { spawnAutoRgCalculator } = await import(
+      '../../../controllers/jobs/utils/autoRg.js'
+    )
+    vi.mocked(fs.pathExists).mockResolvedValue(true as never)
+    vi.mocked(fs.readJson).mockResolvedValue(freshAutoRgResults as never)
+
+    const fit = await getGuinierFit('/data/uuid', 'experiment.dat')
+
+    expect(fit).toMatchObject({ rg: 40.4, i0: 1234.5 })
+    expect(spawnAutoRgCalculator).not.toHaveBeenCalled()
+  })
+
+  it('recomputes when the cache predates the i0 field', async () => {
+    const { default: fs } = await import('fs-extra')
+    const { spawnAutoRgCalculator } = await import(
+      '../../../controllers/jobs/utils/autoRg.js'
+    )
+    // cache exists (stale), then experimental .dat exists
+    vi.mocked(fs.pathExists).mockResolvedValue(true as never)
+    vi.mocked(fs.readJson).mockResolvedValue({
+      rg: 40,
+      rg_min: 36,
+      rg_max: 60,
+      qmin: 0.01,
+      qmax: 0.03
+    } as never)
+    vi.mocked(spawnAutoRgCalculator).mockResolvedValue(freshAutoRgResults)
+
+    const fit = await getGuinierFit('/data/uuid', 'experiment.dat')
+
+    expect(spawnAutoRgCalculator).toHaveBeenCalledWith(
+      '/data/uuid',
+      'experiment.dat'
+    )
+    expect(fs.writeJson).toHaveBeenCalledWith(
+      '/data/uuid/autorg.json',
+      freshAutoRgResults
+    )
+    expect(fit).toMatchObject({ rg: 40.4, i0: 1234.5 })
+  })
+
+  it('computes, caches, and returns the fit on a cache miss', async () => {
+    const { default: fs } = await import('fs-extra')
+    const { spawnAutoRgCalculator } = await import(
+      '../../../controllers/jobs/utils/autoRg.js'
+    )
+    // no cache, but experimental .dat present
+    vi.mocked(fs.pathExists)
+      .mockResolvedValueOnce(false as never)
+      .mockResolvedValueOnce(true as never)
+    vi.mocked(spawnAutoRgCalculator).mockResolvedValue(freshAutoRgResults)
+
+    const fit = await getGuinierFit('/data/uuid', 'experiment.dat')
+
+    expect(fs.writeJson).toHaveBeenCalledWith(
+      '/data/uuid/autorg.json',
+      freshAutoRgResults
+    )
+    expect(fit).toEqual({
+      rg: 40.4,
+      i0: 1234.5,
+      qmin: 0.012,
+      qmax: 0.032,
+      r2: 0.99
+    })
+  })
+
+  it('returns undefined when the experimental .dat file is missing', async () => {
+    const { default: fs } = await import('fs-extra')
+    const { spawnAutoRgCalculator } = await import(
+      '../../../controllers/jobs/utils/autoRg.js'
+    )
+    vi.mocked(fs.pathExists).mockResolvedValue(false as never)
+
+    const fit = await getGuinierFit('/data/uuid', 'experiment.dat')
+
+    expect(fit).toBeUndefined()
+    expect(spawnAutoRgCalculator).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined (does not throw) when AutoRg fails', async () => {
+    const { default: fs } = await import('fs-extra')
+    const { spawnAutoRgCalculator } = await import(
+      '../../../controllers/jobs/utils/autoRg.js'
+    )
+    vi.mocked(fs.pathExists)
+      .mockResolvedValueOnce(false as never)
+      .mockResolvedValueOnce(true as never)
+    vi.mocked(spawnAutoRgCalculator).mockRejectedValue(
+      new Error('autorg blew up')
+    )
+
+    await expect(
+      getGuinierFit('/data/uuid', 'experiment.dat')
+    ).resolves.toBeUndefined()
+  })
+})

--- a/apps/backend/src/services/foxs/foxsDataService.ts
+++ b/apps/backend/src/services/foxs/foxsDataService.ts
@@ -11,6 +11,7 @@ import {
   extractScoperC1C2,
   readTopKNum
 } from './foxsParser.js'
+import { getGuinierFit } from './guinierService.js'
 
 const uploadFolder = path.join(getEnvVar('DATA_VOL'))
 
@@ -141,6 +142,14 @@ const buildBilboFoxsData = async (job: IJob): Promise<FoxsData[]> => {
         details: { datBase: datFileBase }
       }
     )
+  }
+
+  // Attach the Guinier fit of the experimental profile (for dimensionless
+  // Kratky normalization in the UI). Absence is non-fatal — the UI degrades
+  // to an informative alert.
+  const guinier = await getGuinierFit(jobDir, job.data_file)
+  if (guinier && data[0]) {
+    data[0].guinier = guinier
   }
 
   return data

--- a/apps/backend/src/services/foxs/guinierService.ts
+++ b/apps/backend/src/services/foxs/guinierService.ts
@@ -1,0 +1,61 @@
+import path from 'path'
+import fs from 'fs-extra'
+import { logger } from '../../middleware/loggers.js'
+import { GuinierFit } from '@bilbomd/bilbomd-types'
+import { AutoRgResults } from '../../types/bilbomd.js'
+import { spawnAutoRgCalculator } from '../../controllers/jobs/utils/autoRg.js'
+
+// Cached AutoRg output, written into the job directory on first request so
+// completed jobs (including old ones) only ever pay the cost once.
+const GUINIER_CACHE_FILENAME = 'autorg.json'
+
+const toGuinierFit = (results: AutoRgResults): GuinierFit | undefined => {
+  // Caches written before autorg.py emitted i0 lack the fields needed for
+  // Kratky normalization — treat them as a miss so they get recomputed.
+  if (results?.i0 == null) return undefined
+  return {
+    rg: results.rg_exact ?? results.rg,
+    i0: results.i0,
+    qmin: results.qmin,
+    qmax: results.qmax,
+    ...(results.r2 != null ? { r2: results.r2 } : {})
+  }
+}
+
+/**
+ * Return the Guinier fit (Rg, I0, fit window) for a job's experimental SAXS
+ * profile, computing it via autorg.py and caching the result in the job
+ * directory. Returns undefined (never throws) when the fit is unavailable —
+ * callers should degrade gracefully.
+ */
+const getGuinierFit = async (
+  jobDir: string,
+  dataFileName: string
+): Promise<GuinierFit | undefined> => {
+  const cacheFile = path.join(jobDir, GUINIER_CACHE_FILENAME)
+  try {
+    if (await fs.pathExists(cacheFile)) {
+      const cached = (await fs.readJson(cacheFile)) as AutoRgResults
+      const fit = toGuinierFit(cached)
+      if (fit) return fit
+      logger.info(
+        `Stale Guinier cache (missing i0) in ${jobDir} — recomputing`
+      )
+    }
+
+    const expDatFile = path.join(jobDir, dataFileName)
+    if (!(await fs.pathExists(expDatFile))) {
+      logger.warn(`Experimental .dat file not found for Guinier fit: ${expDatFile}`)
+      return undefined
+    }
+
+    const results = await spawnAutoRgCalculator(jobDir, dataFileName)
+    await fs.writeJson(cacheFile, results)
+    return toGuinierFit(results)
+  } catch (error) {
+    logger.warn(`Guinier fit unavailable for ${jobDir}: ${error}`)
+    return undefined
+  }
+}
+
+export { getGuinierFit, toGuinierFit, GUINIER_CACHE_FILENAME }

--- a/apps/backend/src/types/bilbomd.d.ts
+++ b/apps/backend/src/types/bilbomd.d.ts
@@ -73,6 +73,13 @@ export type AutoRgResults = {
   rg_max: number
   qmin: number
   qmax: number
+  // Optional fields emitted by newer autorg.py versions (absent in cached
+  // results produced before they were added)
+  rg_exact?: number
+  i0?: number
+  r2?: number
+  qrg_min?: number
+  qrg_max?: number
 }
 
 export type DispatchUser = {

--- a/apps/ui/src/features/foxs/ClickableLegend.tsx
+++ b/apps/ui/src/features/foxs/ClickableLegend.tsx
@@ -1,0 +1,78 @@
+import { useTheme } from '@mui/material'
+
+type LegendEntry = {
+  value?: string | number
+  color?: string
+  dataKey?: unknown
+}
+
+type Props = {
+  payload?: ReadonlyArray<LegendEntry>
+  isHidden: (dataKey: string) => boolean
+  onToggle: (dataKey: string) => void
+}
+
+/**
+ * Custom recharts Legend content: prefixes an all-caps hint so users know
+ * the entries are clickable, then renders each series with a line-swatch
+ * icon. Hidden series are grayed out with a strikethrough. Pass via
+ * <Legend content={(props) => <ClickableLegend payload={props.payload} ... />} />
+ */
+const ClickableLegend = ({ payload, isHidden, onToggle }: Props) => {
+  const theme = useTheme()
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        columnGap: 16,
+        rowGap: 4,
+        userSelect: 'none'
+      }}
+    >
+      <span
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: 0.5,
+          color: theme.palette.text.secondary
+        }}
+      >
+        CLICK TO TOGGLE VISIBILITY &rarr;
+      </span>
+      {(payload ?? []).map((entry, i) => {
+        const key = typeof entry.dataKey === 'string' ? entry.dataKey : ''
+        const hidden = key ? isHidden(key) : false
+        const color = hidden ? theme.palette.text.disabled : entry.color
+        return (
+          <span
+            key={`${key}-${i}`}
+            onClick={() => key && onToggle(key)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 5,
+              cursor: 'pointer',
+              color,
+              textDecoration: hidden ? 'line-through' : undefined
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                width: 14,
+                height: 2,
+                backgroundColor: color
+              }}
+            />
+            {entry.value}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+export default ClickableLegend

--- a/apps/ui/src/features/foxs/DimensionlessKratkyChart.tsx
+++ b/apps/ui/src/features/foxs/DimensionlessKratkyChart.tsx
@@ -1,0 +1,192 @@
+import { Fragment } from 'react'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+  ReferenceDot
+} from 'recharts'
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+  useTheme
+} from '@mui/material'
+import { FoxsData, GuinierFit } from '@bilbomd/bilbomd-types'
+import { getEnsembleSizeLabel, getUniqueColor } from './foxsUtils'
+import { buildKratkyData, GLOBULAR_QRG, GLOBULAR_PEAK } from './kratkyUtils'
+
+type Props = {
+  foxsData: FoxsData[]
+  guinier: GuinierFit
+}
+
+const DimensionlessKratkyChart = ({ foxsData, guinier }: Props) => {
+  const theme = useTheme()
+  const kratkyData = buildKratkyData(foxsData, guinier)
+
+  if (!kratkyData.length) return null
+
+  return (
+    <Box>
+      <Typography
+        variant="h5"
+        sx={{ pl: 2, m: 1 }}
+      >
+        Dimensionless Kratky
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{ pl: 2, mb: 1, color: 'text.secondary' }}
+      >
+        (qR<sub>g</sub>)²·I(q)/I(0) vs. qR<sub>g</sub> — crosshairs mark the
+        peak position of a compact globular particle (√3, 1.104). Curves that
+        plateau or rise indicate flexibility/extension.
+      </Typography>
+      <ResponsiveContainer
+        width="100%"
+        height={300}
+      >
+        <LineChart
+          data={kratkyData}
+          margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="qRg"
+            type="number"
+            scale="linear"
+            domain={[0, 'auto']}
+            label={{
+              value: 'qRg',
+              position: 'insideBottomRight',
+              offset: -5
+            }}
+            tickFormatter={(v: number) => v.toFixed(1)}
+          />
+          <YAxis
+            type="number"
+            domain={[0, 'auto']}
+            label={{
+              value: '(qRg)²·I(q)/I(0)',
+              angle: -90,
+              position: 'insideLeft'
+            }}
+            tickFormatter={(v: number) => v.toFixed(2)}
+            width={70}
+          />
+          <Tooltip
+            labelFormatter={(label) => `qRg = ${Number(label).toFixed(3)}`}
+          />
+          <Legend
+            iconType="line"
+            verticalAlign="bottom"
+            height={30}
+            layout="horizontal"
+            align="center"
+          />
+          <ReferenceLine
+            x={GLOBULAR_QRG}
+            stroke={theme.palette.text.secondary}
+            strokeDasharray="4 4"
+          />
+          <ReferenceLine
+            y={GLOBULAR_PEAK}
+            stroke={theme.palette.text.secondary}
+            strokeDasharray="4 4"
+          />
+          <ReferenceDot
+            x={GLOBULAR_QRG}
+            y={GLOBULAR_PEAK}
+            r={4}
+            fill={theme.palette.text.secondary}
+            stroke="none"
+            label={{
+              value: 'globular ref.',
+              position: 'right',
+              fontSize: 11,
+              fill: theme.palette.text.secondary
+            }}
+          />
+          <Line
+            type="monotone"
+            dataKey="exp"
+            name="Exp"
+            stroke="#8884d8"
+            dot={false}
+            isAnimationActive={false}
+          />
+          {foxsData.map((item, index) => (
+            <Fragment key={index}>
+              <Line
+                type="monotone"
+                dataKey={`kratky_model_${index}`}
+                name={
+                  index === 0
+                    ? 'Original Model'
+                    : getEnsembleSizeLabel(item.filename)
+                }
+                stroke={getUniqueColor(index)}
+                dot={false}
+                isAnimationActive={false}
+              />
+            </Fragment>
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+      <Table
+        size="small"
+        sx={{ mt: 1, ml: 2, width: 'auto' }}
+      >
+        <TableBody>
+          <TableRow>
+            <TableCell
+              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}
+            >
+              Rg (Guinier)
+            </TableCell>
+            <TableCell sx={{ py: 0.25, pr: 3, border: 0, fontSize: '0.75rem' }}>
+              {guinier.rg.toFixed(2)} Å
+            </TableCell>
+            <TableCell
+              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}
+            >
+              I(0)
+            </TableCell>
+            <TableCell sx={{ py: 0.25, border: 0, fontSize: '0.75rem' }}>
+              {guinier.i0.toExponential(2)}
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell
+              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}
+            >
+              Guinier fit range
+            </TableCell>
+            <TableCell sx={{ py: 0.25, pr: 3, border: 0, fontSize: '0.75rem' }}>
+              q: {guinier.qmin.toFixed(4)}–{guinier.qmax.toFixed(4)} Å⁻¹
+            </TableCell>
+            <TableCell
+              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}
+            >
+              r²
+            </TableCell>
+            <TableCell sx={{ py: 0.25, border: 0, fontSize: '0.75rem' }}>
+              {guinier.r2 != null ? guinier.r2.toFixed(3) : 'n/a'}
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Box>
+  )
+}
+
+export default DimensionlessKratkyChart

--- a/apps/ui/src/features/foxs/DimensionlessKratkyChart.tsx
+++ b/apps/ui/src/features/foxs/DimensionlessKratkyChart.tsx
@@ -38,13 +38,13 @@ const DimensionlessKratkyChart = ({ foxsData, guinier }: Props) => {
   return (
     <Box>
       <Typography
-        variant="h5"
+        variant="h4"
         sx={{ pl: 2, m: 1 }}
       >
         Dimensionless Kratky
       </Typography>
       <Typography
-        variant="body2"
+        variant="body1"
         sx={{ pl: 2, mb: 1, color: 'text.secondary' }}
       >
         (qR<sub>g</sub>)²·I(q)/I(0) vs. qR<sub>g</sub> — crosshairs mark the
@@ -135,6 +135,7 @@ const DimensionlessKratkyChart = ({ foxsData, guinier }: Props) => {
                     : getEnsembleSizeLabel(item.filename)
                 }
                 stroke={getUniqueColor(index)}
+                strokeWidth={index === 0 ? 2.5 : 1}
                 dot={false}
                 isAnimationActive={false}
               />

--- a/apps/ui/src/features/foxs/DimensionlessKratkyChart.tsx
+++ b/apps/ui/src/features/foxs/DimensionlessKratkyChart.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import { Fragment, useState } from 'react'
 import {
   LineChart,
   Line,
@@ -23,6 +23,7 @@ import {
 import { FoxsData, GuinierFit } from '@bilbomd/bilbomd-types'
 import { getEnsembleSizeLabel, getUniqueColor } from './foxsUtils'
 import { buildKratkyData, GLOBULAR_QRG, GLOBULAR_PEAK } from './kratkyUtils'
+import ClickableLegend from './ClickableLegend'
 
 type Props = {
   foxsData: FoxsData[]
@@ -32,6 +33,13 @@ type Props = {
 const DimensionlessKratkyChart = ({ foxsData, guinier }: Props) => {
   const theme = useTheme()
   const kratkyData = buildKratkyData(foxsData, guinier)
+
+  // Curves hidden via legend click, keyed by series dataKey. Hidden series
+  // keep their legend entry (grayed out) so they can be toggled back on.
+  const [hiddenSeries, setHiddenSeries] = useState<Record<string, boolean>>({})
+  const toggleSeries = (dataKey: string) => {
+    setHiddenSeries((prev) => ({ ...prev, [dataKey]: !prev[dataKey] }))
+  }
 
   if (!kratkyData.length) return null
 
@@ -87,11 +95,15 @@ const DimensionlessKratkyChart = ({ foxsData, guinier }: Props) => {
             labelFormatter={(label) => `qRg = ${Number(label).toFixed(3)}`}
           />
           <Legend
-            iconType="line"
             verticalAlign="bottom"
             height={30}
-            layout="horizontal"
-            align="center"
+            content={(props) => (
+              <ClickableLegend
+                payload={props.payload}
+                isHidden={(key) => !!hiddenSeries[key]}
+                onToggle={toggleSeries}
+              />
+            )}
           />
           <ReferenceLine
             x={GLOBULAR_QRG}
@@ -122,6 +134,7 @@ const DimensionlessKratkyChart = ({ foxsData, guinier }: Props) => {
             name="Exp"
             stroke="#8884d8"
             dot={false}
+            hide={!!hiddenSeries['exp']}
             isAnimationActive={false}
           />
           {foxsData.map((item, index) => (
@@ -135,8 +148,9 @@ const DimensionlessKratkyChart = ({ foxsData, guinier }: Props) => {
                     : getEnsembleSizeLabel(item.filename)
                 }
                 stroke={getUniqueColor(index)}
-                strokeWidth={index === 0 ? 2.5 : 1}
+                strokeWidth={2.5}
                 dot={false}
+                hide={!!hiddenSeries[`kratky_model_${index}`]}
                 isAnimationActive={false}
               />
             </Fragment>
@@ -150,37 +164,37 @@ const DimensionlessKratkyChart = ({ foxsData, guinier }: Props) => {
         <TableBody>
           <TableRow>
             <TableCell
-              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}
+              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.875rem' }}
             >
               Rg (Guinier)
             </TableCell>
-            <TableCell sx={{ py: 0.25, pr: 3, border: 0, fontSize: '0.75rem' }}>
+            <TableCell sx={{ py: 0.25, pr: 3, border: 0, fontSize: '0.875rem' }}>
               {guinier.rg.toFixed(2)} Å
             </TableCell>
             <TableCell
-              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}
+              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.875rem' }}
             >
               I(0)
             </TableCell>
-            <TableCell sx={{ py: 0.25, border: 0, fontSize: '0.75rem' }}>
+            <TableCell sx={{ py: 0.25, border: 0, fontSize: '0.875rem' }}>
               {guinier.i0.toExponential(2)}
             </TableCell>
           </TableRow>
           <TableRow>
             <TableCell
-              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}
+              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.875rem' }}
             >
               Guinier fit range
             </TableCell>
-            <TableCell sx={{ py: 0.25, pr: 3, border: 0, fontSize: '0.75rem' }}>
+            <TableCell sx={{ py: 0.25, pr: 3, border: 0, fontSize: '0.875rem' }}>
               q: {guinier.qmin.toFixed(4)}–{guinier.qmax.toFixed(4)} Å⁻¹
             </TableCell>
             <TableCell
-              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.75rem' }}
+              sx={{ py: 0.25, pr: 2, border: 0, color: 'text.secondary', fontSize: '0.875rem' }}
             >
               r²
             </TableCell>
-            <TableCell sx={{ py: 0.25, border: 0, fontSize: '0.75rem' }}>
+            <TableCell sx={{ py: 0.25, border: 0, fontSize: '0.875rem' }}>
               {guinier.r2 != null ? guinier.r2.toFixed(3) : 'n/a'}
             </TableCell>
           </TableRow>

--- a/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
+++ b/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
@@ -1,21 +1,5 @@
-import { useState, Fragment } from 'react'
-import {
-  Checkbox,
-  Chip,
-  Paper,
-  Stack,
-  TableHead,
-  Typography,
-  useTheme
-} from '@mui/material'
-import Grid from '@mui/material/Grid'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableRow
-} from '@mui/material'
+import { useState } from 'react'
+import { Chip, Stack, Typography, useTheme } from '@mui/material'
 import {
   LineChart,
   Line,
@@ -29,6 +13,7 @@ import {
 } from 'recharts'
 import { FoxsData } from '@bilbomd/bilbomd-types'
 import { getEnsembleSizeLabel, getUniqueColor } from './foxsUtils'
+import ClickableLegend from './ClickableLegend'
 
 type CombinedFoxsData = {
   q: number
@@ -54,17 +39,37 @@ const FoXSEnsembleCharts = ({
   foxsData
 }: Props) => {
   const theme = useTheme()
-  // Initialize visibility state for each line
-  const [visibility, setVisibility] = useState([
-    false,
-    ...new Array(foxsData.length - 1).fill(true)
-  ])
-  // Handle checkbox change
-  const handleCheckboxChange = (index: number) => {
-    const newVisibility = visibility.slice()
-    newVisibility[index] = !newVisibility[index]
-    setVisibility(newVisibility)
+
+  // Series hidden via legend/chip click, keyed by ensemble index (shared
+  // between the I(q) and residual charts so both stay in sync). The
+  // experimental curve maps to index -1. The base dataset (index 0) has its
+  // own "Original Model" charts, so it is not rendered here at all.
+  const [hidden, setHidden] = useState<Record<number, boolean>>({})
+  const toggleIndex = (index: number) => {
+    setHidden((prev) => ({ ...prev, [index]: !prev[index] }))
   }
+  // 'model_intensity_2' / 'residual_2' -> 2, 'exp_intensity' -> -1
+  const seriesIndex = (dataKey: string): number => {
+    const match = dataKey.match(/_(\d+)$/)
+    return match ? Number(match[1]) : -1
+  }
+  const isHiddenKey = (dataKey: string) => !!hidden[seriesIndex(dataKey)]
+  const toggleKey = (dataKey: string) => toggleIndex(seriesIndex(dataKey))
+
+  const legendContent = (props: {
+    payload?: ReadonlyArray<{
+      value?: string | number
+      color?: string
+      dataKey?: unknown
+    }>
+  }) => (
+    <ClickableLegend
+      payload={props.payload}
+      isHidden={isHiddenKey}
+      onToggle={toggleKey}
+    />
+  )
+
   return (
     <>
       <Typography
@@ -90,11 +95,9 @@ const FoXSEnsembleCharts = ({
           />
           <Tooltip />
           <Legend
-            iconType="line"
             verticalAlign="bottom"
             height={30}
-            layout="horizontal"
-            align="center"
+            content={legendContent}
           />
           <Line
             yAxisId="left"
@@ -104,21 +107,22 @@ const FoXSEnsembleCharts = ({
             stroke="#8884d8"
             activeDot={{ r: 8 }}
             dot={{ strokeWidth: 1 }}
+            hide={!!hidden[-1]}
           />
-          {foxsData.map((item, index) => (
-            <Fragment key={index}>
-              {visibility[index] && (
-                <Line
-                  yAxisId="left"
-                  type="monotone"
-                  dataKey={`model_intensity_${index}`}
-                  name={getEnsembleSizeLabel(item.filename)}
-                  stroke={getUniqueColor(index)}
-                  dot={{ strokeWidth: 1 }}
-                />
-              )}
-            </Fragment>
-          ))}
+          {foxsData.map((item, index) =>
+            index === 0 ? null : (
+              <Line
+                key={index}
+                yAxisId="left"
+                type="monotone"
+                dataKey={`model_intensity_${index}`}
+                name={getEnsembleSizeLabel(item.filename)}
+                stroke={getUniqueColor(index)}
+                dot={{ strokeWidth: 1 }}
+                hide={!!hidden[index]}
+              />
+            )
+          )}
         </LineChart>
       </ResponsiveContainer>
       <Typography
@@ -134,16 +138,20 @@ const FoXSEnsembleCharts = ({
         sx={{ pl: 2, mb: 1, flexWrap: 'wrap' }}
       >
         {foxsData.map((item, index) =>
-          visibility[index] ? (
+          index !== 0 ? (
             <Chip
               key={index}
               size="small"
               label={`${getEnsembleSizeLabel(item.filename)}: ${item.chisq.toFixed(2)}`}
+              onClick={() => toggleIndex(index)}
+              aria-pressed={!hidden[index]}
               sx={{
                 bgcolor: getUniqueColor(index),
                 color: 'common.black',
                 fontSize: '0.95rem',
-                fontWeight: 600
+                fontWeight: 600,
+                opacity: hidden[index] ? 0.35 : 1,
+                '&:hover': { bgcolor: getUniqueColor(index) }
               }}
             />
           ) : null
@@ -162,81 +170,28 @@ const FoXSEnsembleCharts = ({
           <YAxis domain={[minYAxis, maxYAxis]} />
           <Tooltip />
           <Legend
-            iconType="line"
             verticalAlign="bottom"
             height={30}
-            layout="horizontal"
-            align="center"
+            content={legendContent}
           />
-          {foxsData.map((item, index) => (
-            <Fragment key={index}>
-              {visibility[index] && (
-                <Line
-                  type="monotone"
-                  dataKey={`residual_${index}`}
-                  name={getEnsembleSizeLabel(item.filename)}
-                  stroke={getUniqueColor(index)}
-                />
-              )}
-            </Fragment>
-          ))}
+          {foxsData.map((item, index) =>
+            index === 0 ? null : (
+              <Line
+                key={index}
+                type="monotone"
+                dataKey={`residual_${index}`}
+                name={getEnsembleSizeLabel(item.filename)}
+                stroke={getUniqueColor(index)}
+                hide={!!hidden[index]}
+              />
+            )
+          )}
           <ReferenceLine
             y={0}
             stroke={theme.palette.text.secondary}
           />
         </LineChart>
       </ResponsiveContainer>
-      <Grid sx={{ ml: { xs: 0, md: 8 } }}>
-        <TableContainer component={Paper}>
-          <Table
-            size="small"
-            aria-label="bilbomd multifoxs ensemble results"
-          >
-            <TableHead>
-              <TableRow>
-                <TableCell sx={{ fontSize: '1rem', fontWeight: 700 }}>
-                  Show
-                </TableCell>
-                <TableCell sx={{ fontSize: '1rem', fontWeight: 700 }}>
-                  Ensemble Filename
-                </TableCell>
-                <TableCell sx={{ fontSize: '1rem', fontWeight: 700 }}>
-                  Chi&sup2;
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {foxsData.slice(0).map(
-                (model, index) =>
-                  index !== 0 && (
-                    <TableRow
-                      key={index}
-                      style={{ backgroundColor: getUniqueColor(index) }}
-                    >
-                      <TableCell sx={{ p: 0 }}>
-                        <Checkbox
-                          checked={visibility[index]}
-                          onChange={() => handleCheckboxChange(index)}
-                          color="default"
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <Typography sx={{ fontSize: '1rem', fontWeight: 600 }}>
-                          {model.filename}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography sx={{ fontSize: '1rem', fontWeight: 600 }}>
-                          {model.chisq.toFixed(2)}
-                        </Typography>
-                      </TableCell>
-                    </TableRow>
-                  )
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Grid>
     </>
   )
 }

--- a/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
+++ b/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
@@ -68,7 +68,7 @@ const FoXSEnsembleCharts = ({
   return (
     <>
       <Typography
-        variant="h5"
+        variant="h4"
         sx={{ pl: 2, m: 1 }}
       >{`Ensemble Models - I vs. q`}</Typography>
       <ResponsiveContainer
@@ -122,7 +122,7 @@ const FoXSEnsembleCharts = ({
         </LineChart>
       </ResponsiveContainer>
       <Typography
-        variant="h5"
+        variant="h4"
         sx={{ pl: 2, m: 1, mt: 3 }}
       >
         Ensemble Models - Chi&sup2; residuals

--- a/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
+++ b/apps/ui/src/features/foxs/FoXSEnsembleCharts.tsx
@@ -28,7 +28,7 @@ import {
   ReferenceLine
 } from 'recharts'
 import { FoxsData } from '@bilbomd/bilbomd-types'
-import { getEnsembleSizeLabel } from './foxsUtils'
+import { getEnsembleSizeLabel, getUniqueColor } from './foxsUtils'
 
 type CombinedFoxsData = {
   q: number
@@ -47,23 +47,6 @@ type Props = {
   minYAxis: number
   maxYAxis: number
 }
-const colors = [
-  '#4e79a7', // muted blue
-  '#f28e2b', // muted safety orange
-  '#59a14f', // muted asparagus green
-  '#e15759', // muted brick red
-  '#b07aa1', // muted purple
-  '#9c755f', // muted chestnut brown
-  '#f1b7b1', // muted raspberry yogurt pink
-  '#bab0ac', // muted middle gray
-  '#bdbf20', // muted curry yellow-green
-  '#76b7b2' // muted blue-teal
-]
-
-const getUniqueColor = (index: number) => {
-  return colors[index % colors.length]
-}
-
 const FoXSEnsembleCharts = ({
   combinedData,
   minYAxis,

--- a/apps/ui/src/features/foxs/__tests__/DimensionlessKratkyChart.test.tsx
+++ b/apps/ui/src/features/foxs/__tests__/DimensionlessKratkyChart.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import DimensionlessKratkyChart from '../DimensionlessKratkyChart'
+import {
+  buildKratkyData,
+  GLOBULAR_QRG,
+  GLOBULAR_PEAK,
+  DEFAULT_MAX_QRG
+} from '../kratkyUtils'
+import type { FoxsData, GuinierFit } from '@bilbomd/bilbomd-types'
+
+const guinier: GuinierFit = {
+  rg: 20,
+  i0: 1000,
+  qmin: 0.012,
+  qmax: 0.032,
+  r2: 0.99
+}
+
+const makeFoxsData = (points: FoxsData['data']): FoxsData => ({
+  filename: 'minimization_output_experiment.dat',
+  chisq: 1.5,
+  c1: '1.0',
+  c2: '0.0',
+  data: points
+})
+
+describe('globular reference constants', () => {
+  it('places the crosshairs at (√3, 3/e)', () => {
+    expect(GLOBULAR_QRG).toBeCloseTo(1.732, 3)
+    expect(GLOBULAR_PEAK).toBeCloseTo(1.104, 3)
+  })
+})
+
+describe('buildKratkyData', () => {
+  it('transforms points into dimensionless Kratky coordinates', () => {
+    const foxsData = [
+      makeFoxsData([
+        { q: 0.05, exp_intensity: 500, model_intensity: 490, error: 5 }
+      ])
+    ]
+    const [pt] = buildKratkyData(foxsData, guinier)
+
+    // qRg = 0.05 * 20 = 1; y_exp = 1² * 500/1000 = 0.5
+    expect(pt!.qRg).toBeCloseTo(1.0, 4)
+    expect(pt!.exp).toBeCloseTo(0.5, 4)
+    expect(pt!.kratky_model_0).toBeCloseTo(0.49, 4)
+  })
+
+  it('includes ensemble model curves on the shared q-grid', () => {
+    const base = makeFoxsData([
+      { q: 0.05, exp_intensity: 500, model_intensity: 490, error: 5 }
+    ])
+    const ensemble = {
+      ...makeFoxsData([
+        { q: 0.05, exp_intensity: 500, model_intensity: 510, error: 5 }
+      ]),
+      filename: 'multi_state_model_2_1_1.dat'
+    }
+    const [pt] = buildKratkyData([base, ensemble], guinier)
+
+    expect(pt!.kratky_model_1).toBeCloseTo(0.51, 4)
+  })
+
+  it('excludes low-SNR points (error >= exp_intensity) and non-positive intensities', () => {
+    const foxsData = [
+      makeFoxsData([
+        { q: 0.05, exp_intensity: 500, model_intensity: 490, error: 5 },
+        { q: 0.3, exp_intensity: 2, model_intensity: 2, error: 3 },
+        { q: 0.35, exp_intensity: -1, model_intensity: 1, error: 1 }
+      ])
+    ]
+    const points = buildKratkyData(foxsData, guinier)
+    expect(points).toHaveLength(1)
+  })
+
+  it(`caps the displayed range at qRg = ${DEFAULT_MAX_QRG}`, () => {
+    const foxsData = [
+      makeFoxsData([
+        { q: 0.05, exp_intensity: 500, model_intensity: 490, error: 5 },
+        // qRg = 0.6 * 20 = 12 > cap
+        { q: 0.6, exp_intensity: 100, model_intensity: 99, error: 1 }
+      ])
+    ]
+    const points = buildKratkyData(foxsData, guinier)
+    expect(points).toHaveLength(1)
+    expect(points[0]!.qRg).toBeLessThanOrEqual(DEFAULT_MAX_QRG)
+  })
+
+  it('returns empty for degenerate Guinier parameters', () => {
+    const foxsData = [
+      makeFoxsData([
+        { q: 0.05, exp_intensity: 500, model_intensity: 490, error: 5 }
+      ])
+    ]
+    expect(buildKratkyData(foxsData, { ...guinier, i0: 0 })).toHaveLength(0)
+    expect(buildKratkyData(foxsData, { ...guinier, rg: 0 })).toHaveLength(0)
+    expect(buildKratkyData([], guinier)).toHaveLength(0)
+  })
+})
+
+describe('DimensionlessKratkyChart', () => {
+  const foxsData = [
+    makeFoxsData([
+      { q: 0.05, exp_intensity: 500, model_intensity: 490, error: 5 },
+      { q: 0.1, exp_intensity: 200, model_intensity: 195, error: 3 }
+    ])
+  ]
+
+  it('renders the title and Guinier fit parameters', () => {
+    render(
+      <DimensionlessKratkyChart
+        foxsData={foxsData}
+        guinier={guinier}
+      />
+    )
+    expect(screen.getByText('Dimensionless Kratky')).toBeInTheDocument()
+    expect(screen.getByText('20.00 Å')).toBeInTheDocument()
+    expect(screen.getByText('1.00e+3')).toBeInTheDocument()
+    expect(screen.getByText(/0\.0120–0\.0320/)).toBeInTheDocument()
+    expect(screen.getByText('0.990')).toBeInTheDocument()
+  })
+
+  it('renders nothing when no plottable points remain', () => {
+    const noisy = [
+      makeFoxsData([
+        { q: 0.05, exp_intensity: 2, model_intensity: 2, error: 5 }
+      ])
+    ]
+    const { container } = render(
+      <DimensionlessKratkyChart
+        foxsData={noisy}
+        guinier={guinier}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/ui/src/features/foxs/__tests__/FoXSEnsembleCharts.test.tsx
+++ b/apps/ui/src/features/foxs/__tests__/FoXSEnsembleCharts.test.tsx
@@ -85,7 +85,7 @@ describe('FoXSEnsembleCharts', () => {
     expect(screen.getByText('Ensemble Models - I vs. q')).toBeInTheDocument()
   })
 
-  it('shows correct filenames in the table for 1-state and 2-state', () => {
+  it('shows a chip for each ensemble for 1-state and 2-state', () => {
     const foxsData: FoxsData[] = [baseFoxsData, make1State(), make2State()]
     render(
       <FoXSEnsembleCharts
@@ -93,15 +93,11 @@ describe('FoXSEnsembleCharts', () => {
         foxsData={foxsData}
       />
     )
-    expect(
-      screen.getByText('multi_state_model_1_1_1.dat')
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText('multi_state_model_2_1_1.dat')
-    ).toBeInTheDocument()
+    expect(screen.getByText('Ens. Size 1: 1.50')).toBeInTheDocument()
+    expect(screen.getByText('Ens. Size 2: 1.20')).toBeInTheDocument()
   })
 
-  it('shows correct filename in the table when only 2-state is present', () => {
+  it('shows only the 2-state chip when only 2-state is present', () => {
     // Simulates back-end sending [base, 2-state] (no 1-state)
     const foxsData: FoxsData[] = [baseFoxsData, make2State()]
     render(
@@ -110,17 +106,14 @@ describe('FoXSEnsembleCharts', () => {
         foxsData={foxsData}
       />
     )
-    expect(
-      screen.getByText('multi_state_model_2_1_1.dat')
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText('multi_state_model_1_1_1.dat')
-    ).not.toBeInTheDocument()
+    expect(screen.getByText('Ens. Size 2: 1.20')).toBeInTheDocument()
+    expect(screen.queryByText('Ens. Size 1: 1.50')).not.toBeInTheDocument()
   })
 
   // Part of #971: chi² is surfaced in a header line above the residuals plot,
-  // colour-keyed to each visible ensemble trace.
-  it('renders a chi² chip for each visible ensemble', () => {
+  // colour-keyed to each ensemble trace. The base dataset (index 0) has its
+  // own Original Model charts, so it gets no chip here.
+  it('does not render a chip for the base dataset', () => {
     const foxsData: FoxsData[] = [baseFoxsData, make1State(), make2State()]
     render(
       <FoXSEnsembleCharts
@@ -128,13 +121,10 @@ describe('FoXSEnsembleCharts', () => {
         foxsData={foxsData}
       />
     )
-    expect(screen.getByText('Ens. Size 1: 1.50')).toBeInTheDocument()
-    expect(screen.getByText('Ens. Size 2: 1.20')).toBeInTheDocument()
-    // The base dataset starts hidden, so it gets no chip.
     expect(screen.queryByText(/sample\.dat: /)).not.toBeInTheDocument()
   })
 
-  it('removes an ensemble chip when its checkbox is unchecked', async () => {
+  it('toggles ensemble visibility when its chip is clicked', async () => {
     const user = userEvent.setup()
     const foxsData: FoxsData[] = [baseFoxsData, make1State(), make2State()]
     render(
@@ -143,13 +133,18 @@ describe('FoXSEnsembleCharts', () => {
         foxsData={foxsData}
       />
     )
-    expect(screen.getByText('Ens. Size 2: 1.20')).toBeInTheDocument()
+    const chip2 = screen.getByText('Ens. Size 2: 1.20').closest('[aria-pressed]')
+    expect(chip2).toHaveAttribute('aria-pressed', 'true')
 
-    // Table rows skip index 0, so the checkboxes map to ensembles 1 and 2.
-    const checkboxes = screen.getAllByRole('checkbox')
-    await user.click(checkboxes[1]!)
+    await user.click(chip2!)
+    expect(chip2).toHaveAttribute('aria-pressed', 'false')
 
-    expect(screen.queryByText('Ens. Size 2: 1.20')).not.toBeInTheDocument()
-    expect(screen.getByText('Ens. Size 1: 1.50')).toBeInTheDocument()
+    await user.click(chip2!)
+    expect(chip2).toHaveAttribute('aria-pressed', 'true')
+
+    // The other ensemble is unaffected
+    expect(
+      screen.getByText('Ens. Size 1: 1.50').closest('[aria-pressed]')
+    ).toHaveAttribute('aria-pressed', 'true')
   })
 })

--- a/apps/ui/src/features/foxs/foxsUtils.ts
+++ b/apps/ui/src/features/foxs/foxsUtils.ts
@@ -2,3 +2,19 @@ export const getEnsembleSizeLabel = (filename: string): string => {
   const match = filename.match(/multi_state_model_(\d+)_/)
   return match ? `Ens. Size ${match[1]}` : `Ens. Size ${filename}`
 }
+
+export const ensembleColors = [
+  '#4e79a7', // muted blue
+  '#f28e2b', // muted safety orange
+  '#59a14f', // muted asparagus green
+  '#e15759', // muted brick red
+  '#b07aa1', // muted purple
+  '#9c755f', // muted chestnut brown
+  '#f1b7b1', // muted raspberry yogurt pink
+  '#bab0ac', // muted middle gray
+  '#bdbf20', // muted curry yellow-green
+  '#76b7b2' // muted blue-teal
+]
+
+export const getUniqueColor = (index: number): string =>
+  ensembleColors[index % ensembleColors.length] ?? '#4e79a7'

--- a/apps/ui/src/features/foxs/kratkyUtils.ts
+++ b/apps/ui/src/features/foxs/kratkyUtils.ts
@@ -1,0 +1,56 @@
+import { FoxsData, GuinierFit } from '@bilbomd/bilbomd-types'
+
+// Universal reference for compact globular particles on a dimensionless
+// Kratky plot: peak at qRg = √3 with height 3/e ≈ 1.104
+export const GLOBULAR_QRG = Math.sqrt(3)
+export const GLOBULAR_PEAK = 3 / Math.E
+
+// Beyond qRg ≈ 10 the q² weighting mostly amplifies noise, so cap the
+// displayed range there.
+export const DEFAULT_MAX_QRG = 10
+
+export type KratkyPoint = {
+  qRg: number
+  exp: number
+} & Partial<Record<`kratky_model_${number}`, number>>
+
+/**
+ * Transform FoXS I(q) datasets into dimensionless Kratky coordinates:
+ * x = qRg, y = (qRg)² · I(q)/I(0), normalizing every curve with the
+ * experimental Guinier (Rg, I0) so they share a common frame. Points are
+ * filtered with the repo's SNR ≥ 1 convention (see issue #572) since the
+ * q² weighting amplifies high-q noise.
+ */
+export const buildKratkyData = (
+  foxsData: FoxsData[],
+  guinier: GuinierFit,
+  maxQRg: number = DEFAULT_MAX_QRG
+): KratkyPoint[] => {
+  const base = foxsData[0]
+  if (!base?.data?.length || guinier.rg <= 0 || guinier.i0 <= 0) return []
+
+  const points: KratkyPoint[] = []
+  base.data.forEach((pt, index) => {
+    if (!(pt.exp_intensity > 0) || !(pt.error < pt.exp_intensity)) return
+    const qRg = pt.q * guinier.rg
+    if (qRg > maxQRg) return
+
+    const scale = (qRg * qRg) / guinier.i0
+    const point: KratkyPoint = {
+      qRg: parseFloat(qRg.toFixed(4)),
+      exp: parseFloat((scale * pt.exp_intensity).toFixed(4))
+    }
+    // All datasets share the base q-grid (index-aligned), matching the
+    // assumption made by the ensemble I(q) charts.
+    foxsData.forEach((fd, n) => {
+      const modelPoint = fd.data[index]
+      if (modelPoint && modelPoint.model_intensity > 0) {
+        point[`kratky_model_${n}`] = parseFloat(
+          (scale * modelPoint.model_intensity).toFixed(4)
+        )
+      }
+    })
+    points.push(point)
+  })
+  return points
+}

--- a/apps/ui/src/features/jobs/FoXSAnalysis.tsx
+++ b/apps/ui/src/features/jobs/FoXSAnalysis.tsx
@@ -7,6 +7,7 @@ import { useGetFoxsAnalysisByIdQuery } from 'slices/jobsApiSlice'
 import { useGetPublicFoxsDataQuery } from 'slices/publicJobsApiSlice'
 import CircularProgress from '@mui/material/CircularProgress'
 import FoXSEnsembleCharts from 'features/foxs/FoXSEnsembleCharts'
+import DimensionlessKratkyChart from 'features/foxs/DimensionlessKratkyChart'
 import Item from 'themes/components/Item'
 import { FoxsData, FoxsDataPoint } from '@bilbomd/bilbomd-types'
 
@@ -265,6 +266,7 @@ const FoXSAnalysis = ({
   const origChiSq = foxsData[0]!.chisq
   const origC1 = foxsData[0]!.c1
   const origC2 = foxsData[0]!.c2
+  const guinier = foxsData[0]!.guinier
 
   return (
     <Item>
@@ -302,6 +304,24 @@ const FoXSAnalysis = ({
               <AlertTitle>No ensemble data</AlertTitle>
               Only a single FoXS dataset is available; ensemble comparison
               charts are hidden.
+            </Alert>
+          )}
+        </Grid>
+        <Grid size={{ xs: 12 }}>
+          {guinier ? (
+            <DimensionlessKratkyChart
+              foxsData={foxsData}
+              guinier={guinier}
+            />
+          ) : (
+            <Alert
+              severity="info"
+              variant="outlined"
+            >
+              <AlertTitle>Dimensionless Kratky plot unavailable</AlertTitle>
+              Guinier parameters (R<sub>g</sub>, I(0)) could not be determined
+              from the experimental data, so the dimensionless Kratky plot
+              cannot be displayed.
             </Alert>
           )}
         </Grid>

--- a/apps/ui/src/features/jobs/__tests__/FoXSAnalysis.test.tsx
+++ b/apps/ui/src/features/jobs/__tests__/FoXSAnalysis.test.tsx
@@ -42,6 +42,10 @@ vi.mock('features/foxs/FoXSEnsembleCharts', () => ({
   default: () => <div data-testid="foxs-ensemble-charts">Ensemble Charts</div>
 }))
 
+vi.mock('features/foxs/DimensionlessKratkyChart', () => ({
+  default: () => <div data-testid="kratky-chart">Kratky Chart</div>
+}))
+
 describe('FoXSAnalysis', () => {
   const mockFoxsDataSingle: FoxsData[] = [
     {
@@ -596,6 +600,53 @@ describe('FoXSAnalysis', () => {
 
       // Component should process and render the data
       expect(screen.getByText('Original Model')).toBeInTheDocument()
+    })
+  })
+
+  describe('dimensionless Kratky rendering', () => {
+    it('should render the Kratky chart when Guinier data is present', async () => {
+      const mockDataWithGuinier: FoxsData[] = [
+        {
+          ...mockFoxsDataSingle[0]!,
+          guinier: { rg: 40.4, i0: 1234.5, qmin: 0.012, qmax: 0.032, r2: 0.99 }
+        }
+      ]
+
+      vi.spyOn(jobsApiSlice, 'useGetFoxsAnalysisByIdQuery').mockReturnValue({
+        data: mockDataWithGuinier,
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+        refetch: vi.fn()
+      } as never)
+
+      renderWithProviders(<FoXSAnalysis id="job-123" />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('kratky-chart')).toBeInTheDocument()
+      })
+      expect(
+        screen.queryByText('Dimensionless Kratky plot unavailable')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should show an unavailable alert when Guinier data is absent', async () => {
+      vi.spyOn(jobsApiSlice, 'useGetFoxsAnalysisByIdQuery').mockReturnValue({
+        data: mockFoxsDataSingle,
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+        refetch: vi.fn()
+      } as never)
+
+      renderWithProviders(<FoXSAnalysis id="job-123" />)
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Dimensionless Kratky plot unavailable')
+        ).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('kratky-chart')).not.toBeInTheDocument()
     })
   })
 

--- a/apps/ui/src/features/scoperjob/FoXSChart.tsx
+++ b/apps/ui/src/features/scoperjob/FoXSChart.tsx
@@ -65,7 +65,7 @@ const FoXSChart = ({
   return (
     <>
       <Typography
-        variant="h5"
+        variant="h4"
         sx={{ pl: 2, m: 1 }}
       >
         {title} - I vs. q
@@ -142,7 +142,7 @@ const FoXSChart = ({
         </LineChart>
       </ResponsiveContainer>
       <Typography
-        variant="h5"
+        variant="h4"
         sx={{ pl: 2, m: 1, mt: 3 }}
       >
         {title} - Chi&sup2; residuals

--- a/infra/docker-compose-epyc.dev.yml
+++ b/infra/docker-compose-epyc.dev.yml
@@ -87,7 +87,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   backend:
-    image: ghcr.io/bl1231/bilbomd-backend:2.11.2
+    image: ghcr.io/bl1231/bilbomd-backend:pr-988-89c6dc30
     pull_policy: missing
     security_opt:
       - no-new-privileges:true
@@ -252,7 +252,7 @@ services:
 
   # ------------------------------------------------------------------------------------
   ui:
-    image: ghcr.io/bl1231/bilbomd-ui:2.23.1
+    image: ghcr.io/bl1231/bilbomd-ui:pr-988-89c6dc30
     pull_policy: missing
     security_opt:
       - seccomp:./seccomp/bilbomd-seccomp.json

--- a/packages/bilbomd-types/src/jobs/publicJob.ts
+++ b/packages/bilbomd-types/src/jobs/publicJob.ts
@@ -35,10 +35,22 @@ export type FoxsDataPoint = {
   error: number
 }
 
+// Guinier fit of the experimental SAXS profile, computed server-side by
+// autorg.py. Used to normalize dimensionless Kratky plots: (qRg)²·I(q)/I(0).
+export type GuinierFit = {
+  rg: number // unrounded Rg from the Guinier fit (Å)
+  i0: number // forward scattering intensity I(0)
+  qmin: number // low-q bound of the fit window (Å⁻¹)
+  qmax: number // high-q bound of the fit window (Å⁻¹)
+  r2?: number // coefficient of determination of the fit
+}
+
 export type FoxsData = {
   filename: string
   chisq: number
   c1: string
   c2: string
   data: FoxsDataPoint[]
+  // Present only on the first (experimental/base) dataset when AutoRg succeeds
+  guinier?: GuinierFit
 }

--- a/tools/python/autorg.py
+++ b/tools/python/autorg.py
@@ -124,13 +124,21 @@ def calculate_rg(file_path, output_file):
         # Clamp rg_max to be no less than 10 and no more than 100
         rg_max = max(10, min(100, rg_max))
 
-        # Create a dictionary with the results
+        # Create a dictionary with the results.
+        # "rg" stays rounded for MD setup; "rg_exact" and "i0" carry the
+        # unrounded Guinier fit values needed for dimensionless Kratky
+        # normalization downstream.
         result_dict = {
             "rg": round(rg),
             "rg_min": rg_min,
             "rg_max": rg_max,
             "qmin": qmin,
             "qmax": qmax,
+            "rg_exact": rg,
+            "i0": izero,
+            "r2": r_sqr,
+            "qrg_min": qrg_min,
+            "qrg_max": qrg_max,
         }
 
         # Write the results to the output file

--- a/tools/python/python_tests/test_autorg.py
+++ b/tools/python/python_tests/test_autorg.py
@@ -40,11 +40,13 @@ def test_calculate_rg_writes_expected_json(monkeypatch):
     monkeypatch.setattr(
         autorg, "load_profile", lambda fp: ([1, 2, 3], [10, 20, 30], [1, 1, 1])
     )
-    # Mock _auto_guinier to return a fixed rg
+    # Mock _auto_guinier to return a fixed Guinier fit:
+    # (rg, izero, rg_err, izero_err, qmin, qmax, qrg_min, qrg_max,
+    #  idx_min, idx_max, r_sqr)
     monkeypatch.setattr(
         autorg,
         "_auto_guinier",
-        lambda q, i, s: (40.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.99),
+        lambda q, i, s: (40.4, 1234.5, 0, 0, 0.012, 0.032, 0.48, 1.29, 0, 0, 0.99),
     )
 
     with tempfile.NamedTemporaryFile("r+", delete=False) as tmp:
@@ -55,6 +57,16 @@ def test_calculate_rg_writes_expected_json(monkeypatch):
     assert "rg" in data and "rg_min" in data and "rg_max" in data
     assert 10 <= data["rg_min"] <= 100
     assert 10 <= data["rg_max"] <= 100
+    # rg is rounded for MD setup; rg_exact preserves the fit value
+    assert data["rg"] == 40
+    assert data["rg_exact"] == 40.4
+    # Guinier fit values needed for dimensionless Kratky normalization
+    assert data["i0"] == 1234.5
+    assert data["r2"] == 0.99
+    assert data["qmin"] == 0.012
+    assert data["qmax"] == 0.032
+    assert data["qrg_min"] == 0.48
+    assert data["qrg_max"] == 1.29
 
 
 def test_calculate_rg_handles_exceptions(monkeypatch, capsys):


### PR DESCRIPTION
Implements #987 — adds a dimensionless Kratky plot to the FoXS analysis panel, with all Guinier fitting kept in the existing Python tooling (no duplicated numerics in the frontend).

## Changes by layer

**tools/python**
- `autorg.py` now emits `i0`, `rg_exact`, `r2`, `qrg_min`, `qrg_max` in its JSON output — values `guinier_scan` already computed but were previously discarded. `rg` stays rounded for MD setup.

**backend**
- New `guinierService.ts`: returns the experimental Guinier fit (Rg, I0, fit window) for a job, computing it on demand via the existing `spawnAutoRgCalculator` and caching the result as `autorg.json` in the job directory — so existing completed jobs get the feature on first view with no reprocessing. Caches written before `i0` existed are detected and recomputed. Failures degrade to `undefined`, never a 500.
- `buildBilboFoxsData` attaches the fit to the base dataset (`FoxsData.guinier`), covering both the protected and public FoXS endpoints.
- `/autorg` endpoint response now passes through `rg_exact`, `i0`, `r2`.

**types**
- `@bilbomd/bilbomd-types`: new `GuinierFit` type; `FoxsData` gains optional `guinier`.

**ui**
- New `DimensionlessKratkyChart` rendered always-visible, full-width, directly below the existing I(q) panels in `FoXSAnalysis` (both protected and public views).
- Plots (qRg)²·I(q)/I(0) vs qRg for the experimental curve, original model, and every ensemble model, with globular reference crosshairs at (√3, 3/e ≈ 1.104) and the Rg / I(0) / fit-range / r² values displayed beneath.
- Transform lives in `kratkyUtils.ts`: normalizes all curves with the experimental (Rg, I0), applies the repo's SNR ≥ 1 exclusion convention, and caps display at qRg ≤ 10 (constant `DEFAULT_MAX_QRG`, easy to revisit).
- Ensemble color palette extracted to `foxsUtils.ts` so Kratky curves match the ensemble I(q) chart colors.
- Informative fallback alert when Guinier parameters are unavailable.

## Tests
- python: `test_autorg.py` asserts the new output fields (4 passed)
- backend: new `guinierService.test.ts` (cache hit / stale-cache recompute / miss / missing .dat / AutoRg failure) + `foxsDataService` attachment test (513 passed)
- ui: new `DimensionlessKratkyChart.test.tsx` (transform math, SNR filtering, qRg cap, degenerate params, render) + `FoXSAnalysis` integration tests (1145 passed)

`pnpm lint`, `pnpm build`, `pnpm test` all pass. Changeset included (minor: bilbomd-types, backend, ui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
