### PR TITLE
feat(ui): ensemble conformation weights, coloring, and starting model overlay

### DIFF
--- a/.changeset/ensemble-conformation-weights.md
+++ b/.changeset/ensemble-conformation-weights.md
@@ -1,0 +1,11 @@
+---
+'@bilbomd/ui': minor
+---
+
+Display per-conformation weights beneath the Molstar viewer for multi-state ensembles. When a 2+ state ensemble is toggled visible, the viewer now shows each contributing conformation of the best-fit model with its weight (value plus a proportion bar), sourced from the MultiFoXS results already included in the job data.
+
+Add a "Starting Model" toggle to the Molstar viewer that overlays the original minimized input structure (rendered semi-transparent light green) independently of the ensemble selection, so users can compare the best N-state ensemble models against the starting model. The toggle only appears when a starting model is available for the job.
+
+Make the ensemble size selector in the Molstar viewer exclusive: exactly one ensemble is displayed at a time, so selecting a "Size N" button now hides the others (the "Show All / Hide All" button is removed).
+
+Add a "Color by Conformation" button to the Molstar viewer that colors each ensemble member structure a distinct color, with matching color swatches shown next to each conformation in the weights panel so color, structure, and weight line up. For jobs with a multi-member ensemble this coloring is now the default when the viewer loads. This is independent of the existing "Color by Domain" button (fixed/rigid/flexible domains from the MD constraints); the two are mutually exclusive and each toggles back to the standard per-structure coloring.

--- a/apps/ui/src/features/molstar/EnsembleTogglePanel.tsx
+++ b/apps/ui/src/features/molstar/EnsembleTogglePanel.tsx
@@ -4,46 +4,64 @@ import Chip from '@mui/material/Chip'
 import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
+import { STARTING_MODEL_CSS_COLOR } from './ensembleColors'
 
 interface EnsembleTogglePanelProps {
   ensembleSizes: number[]
   visibility: Record<number, boolean>
-  onToggle: (size: number) => void
-  onToggleAll: (action: 'show' | 'hide') => void
+  onSelect: (size: number) => void
   hasConstraints?: boolean
   domainColorActive?: boolean
   onColorByDomain?: () => void
+  showConformationColor?: boolean
+  conformationColorActive?: boolean
+  onColorByConformation?: () => void
+  showStartingModel?: boolean
+  startingModelActive?: boolean
+  onToggleStartingModel?: () => void
 }
 
 const EnsembleTogglePanel = ({
   ensembleSizes,
   visibility,
-  onToggle,
-  onToggleAll,
+  onSelect,
   hasConstraints,
   domainColorActive,
-  onColorByDomain
+  onColorByDomain,
+  showConformationColor,
+  conformationColorActive,
+  onColorByConformation,
+  showStartingModel,
+  startingModelActive,
+  onToggleStartingModel
 }: EnsembleTogglePanelProps) => {
   const showEnsembleControls = ensembleSizes.length >= 2
   const showSingleEnsembleChip = ensembleSizes.length === 1
   const showDomainButton = !!hasConstraints && !!onColorByDomain
+  const showConformationButton =
+    !!showConformationColor && !!onColorByConformation
+  const showStartingModelButton =
+    !!showStartingModel && !!onToggleStartingModel
 
-  if (!showEnsembleControls && !showSingleEnsembleChip && !showDomainButton) return null
+  if (
+    !showEnsembleControls &&
+    !showSingleEnsembleChip &&
+    !showDomainButton &&
+    !showConformationButton &&
+    !showStartingModelButton
+  )
+    return null
 
-  const selectedSizes = ensembleSizes.filter((s) => visibility[s])
-  const allVisible = selectedSizes.length === ensembleSizes.length
+  // Exactly one ensemble is displayed at a time, so this is an exclusive
+  // (radio-like) selector.
+  const selectedSize = ensembleSizes.find((s) => visibility[s]) ?? null
 
   const handleChange = (
     _: React.MouseEvent<HTMLElement>,
-    newSelected: number[]
+    newSelected: number | null
   ) => {
-    const oldSet = new Set(selectedSizes)
-    const newSet = new Set(newSelected)
-    for (const size of ensembleSizes) {
-      if (oldSet.has(size) !== newSet.has(size)) {
-        onToggle(size)
-      }
-    }
+    // Ignore attempts to deselect the active button — keep one always shown.
+    if (newSelected !== null) onSelect(newSelected)
   }
 
   return (
@@ -71,17 +89,10 @@ const EnsembleTogglePanel = ({
       {showEnsembleControls && (
         <>
           <Typography variant='body2'>Ensembles:</Typography>
-          <Button
-            size='small'
-            variant='outlined'
-            onClick={() => onToggleAll(allVisible ? 'hide' : 'show')}
-            sx={{ textTransform: 'none', minWidth: 72, alignSelf: 'stretch' }}
-          >
-            {allVisible ? 'Hide All' : 'Show All'}
-          </Button>
           <ToggleButtonGroup
             size='small'
-            value={selectedSizes}
+            exclusive
+            value={selectedSize}
             onChange={handleChange}
           >
             {ensembleSizes.map((size) => (
@@ -115,6 +126,38 @@ const EnsembleTogglePanel = ({
           sx={{ textTransform: 'none', minWidth: 120, alignSelf: 'stretch' }}
         >
           Color by Domain
+        </Button>
+      )}
+
+      {showConformationButton && (
+        <Button
+          size='small'
+          variant={conformationColorActive ? 'contained' : 'outlined'}
+          onClick={onColorByConformation}
+          sx={{ textTransform: 'none', minWidth: 160, alignSelf: 'stretch' }}
+        >
+          Color by Conformation
+        </Button>
+      )}
+
+      {showStartingModelButton && (
+        <Button
+          size='small'
+          variant={startingModelActive ? 'contained' : 'outlined'}
+          onClick={onToggleStartingModel}
+          startIcon={
+            <Box
+              sx={{
+                width: 12,
+                height: 12,
+                borderRadius: 0.5,
+                backgroundColor: STARTING_MODEL_CSS_COLOR
+              }}
+            />
+          }
+          sx={{ textTransform: 'none', minWidth: 150, alignSelf: 'stretch' }}
+        >
+          Starting Model
         </Button>
       )}
     </Box>

--- a/apps/ui/src/features/molstar/EnsembleWeightsPanel.tsx
+++ b/apps/ui/src/features/molstar/EnsembleWeightsPanel.tsx
@@ -1,0 +1,146 @@
+import Box from '@mui/material/Box'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import type { IEnsemble, IEnsembleMember } from '@bilbomd/bilbomd-types'
+import { ensembleMemberCssColor } from './ensembleColors'
+
+interface EnsembleWeightsPanelProps {
+  ensembles: IEnsemble[]
+  visibility: Record<number, boolean>
+  // When true, each conformation row shows the color swatch matching the
+  // viewer's "Color by Conformation" coloring, acting as a legend.
+  showColors?: boolean
+}
+
+// Strip the leading path and the .pdb extension so a conformation like
+// "../foxs/rg25_run3/dcd2pdb_rg25_run3_271500.pdb" reads as
+// "dcd2pdb_rg25_run3_271500".
+const conformationLabel = (pdb: string): string => {
+  const base = pdb.split('/').pop() ?? pdb
+  return base.replace(/\.pdb$/i, '')
+}
+
+const formatWeight = (weight?: number): string =>
+  typeof weight === 'number' ? weight.toFixed(3) : '—'
+
+const EnsembleWeightsPanel = ({
+  ensembles,
+  visibility,
+  showColors = false
+}: EnsembleWeightsPanelProps) => {
+  // Only show weights for multi-state ensembles (2+ conformations) that are
+  // currently toggled visible in the viewer, so the numbers always match what
+  // is on screen.
+  const visibleEnsembles = ensembles
+    .filter((e) => e.size >= 2 && visibility[e.size] && e.models.length > 0)
+    .sort((a, b) => a.size - b.size)
+
+  if (visibleEnsembles.length === 0) return null
+
+  return (
+    <Box sx={{ px: 1, py: 1 }}>
+      <Typography variant='subtitle2' sx={{ mb: 0.5 }}>
+        Conformation weights
+      </Typography>
+      {visibleEnsembles.map((ensemble) => {
+        // The viewer loads the rank-1 (best scoring) model, so weights come
+        // from models[0]; its state order matches the model order on screen.
+        const bestModel = ensemble.models[0]
+        if (!bestModel) return null
+        return (
+          <Box key={ensemble.size} sx={{ mb: 1 }}>
+            <Typography
+              variant='caption'
+              color='text.secondary'
+              sx={{ display: 'block', mb: 0.5 }}
+            >
+              {ensemble.size}-state ensemble
+            </Typography>
+            {bestModel.states.map((state: IEnsembleMember, index: number) => {
+              const label = conformationLabel(state.pdb)
+              const fraction =
+                typeof state.weight === 'number'
+                  ? Math.max(0, Math.min(1, state.weight))
+                  : 0
+              const memberColor = ensembleMemberCssColor(index)
+              return (
+                <Box
+                  key={`${ensemble.size}-${index}`}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    py: 0.25
+                  }}
+                >
+                  {showColors && (
+                    <Box
+                      data-testid='conformation-swatch'
+                      sx={{
+                        flex: '0 0 auto',
+                        width: 12,
+                        height: 12,
+                        borderRadius: 0.5,
+                        backgroundColor: memberColor
+                      }}
+                    />
+                  )}
+                  <Typography
+                    variant='body2'
+                    sx={{ minWidth: 20, color: 'text.secondary' }}
+                  >
+                    {index + 1}
+                  </Typography>
+                  <Tooltip title={label}>
+                    <Typography
+                      variant='body2'
+                      sx={{
+                        flex: '1 1 auto',
+                        minWidth: 0,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        fontFamily: 'monospace'
+                      }}
+                    >
+                      {label}
+                    </Typography>
+                  </Tooltip>
+                  <Box
+                    sx={{
+                      flex: '0 0 120px',
+                      height: 8,
+                      borderRadius: 1,
+                      backgroundColor: 'grey.200',
+                      overflow: 'hidden'
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        width: `${fraction * 100}%`,
+                        height: '100%',
+                        backgroundColor: showColors ? memberColor : 'primary.main'
+                      }}
+                    />
+                  </Box>
+                  <Typography
+                    variant='body2'
+                    sx={{
+                      flex: '0 0 48px',
+                      textAlign: 'right',
+                      fontVariantNumeric: 'tabular-nums'
+                    }}
+                  >
+                    {formatWeight(state.weight)}
+                  </Typography>
+                </Box>
+              )
+            })}
+          </Box>
+        )
+      })}
+    </Box>
+  )
+}
+
+export default EnsembleWeightsPanel

--- a/apps/ui/src/features/molstar/Viewer.tsx
+++ b/apps/ui/src/features/molstar/Viewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, createRef } from 'react'
+import { useEffect, useMemo, useRef, useState, createRef } from 'react'
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
 import useMediaQuery from '@mui/material/useMediaQuery'
@@ -31,11 +31,18 @@ import { PluginUIContext } from 'molstar/lib/mol-plugin-ui/context'
 import { logger } from 'utils/logger'
 import { ViewportComponent } from './Viewport'
 import EnsembleTogglePanel from './EnsembleTogglePanel'
+import EnsembleWeightsPanel from './EnsembleWeightsPanel'
 import {
   ShowButtons,
   StructurePreset,
-  createDomainColorPreset
+  createDomainColorPreset,
+  createUniformColorPreset
 } from './presets'
+import {
+  ensembleMemberColorValue,
+  STARTING_MODEL_COLOR_VALUE,
+  STARTING_MODEL_ALPHA
+} from './ensembleColors'
 import { BuiltInTrajectoryFormat } from 'molstar/lib/mol-plugin-state/formats/trajectory'
 import 'molstar/lib/mol-plugin-ui/skin/light.scss'
 import Item from 'themes/components/Item'
@@ -59,6 +66,35 @@ type PDBsToLoad = LoadParams[]
 
 interface HasEnsembles {
   ensembles: IEnsemble[]
+}
+
+// How structures are colored in the viewer:
+// - 'default': per-structure palette coloring (Molstar structure-index)
+// - 'domain': fixed/rigid/flexible domains from the MD constraints
+// - 'conformation': each ensemble member a distinct color (see ensembleColors)
+type ColorMode = 'default' | 'domain' | 'conformation'
+
+// Job types whose results carry MultiFoXS ensembles, mapped to the key under
+// which those ensembles live in JobResultsDTO.
+const ensembleResultsKeys: Partial<Record<JobType, keyof JobResultsDTO>> = {
+  pdb: 'classic',
+  crd: 'classic',
+  auto: 'auto',
+  alphafold: 'alphafold',
+  openfold: 'openfold',
+  sans: 'sans'
+}
+
+// Extract the ensembles array for a job so the weights panel can render the
+// per-conformation weights that the viewer already loads.
+const getEnsemblesForJob = (
+  jobType: JobType,
+  results: JobResultsDTO
+): IEnsemble[] => {
+  const key = ensembleResultsKeys[jobType]
+  if (!key) return []
+  const jobResults = results?.[key] as HasEnsembles | null | undefined
+  return Array.isArray(jobResults?.ensembles) ? jobResults.ensembles : []
 }
 
 const DefaultViewerOptions = {
@@ -110,15 +146,37 @@ const MolstarViewer = ({
   const [ensembleVisibility, setEnsembleVisibility] = useState<
     Record<number, boolean>
   >({})
-  const [isDomainColor, setIsDomainColor] = useState(false)
+  // Default to coloring each ensemble member a distinct color (with the
+  // weights-panel legend) whenever there is a multi-member ensemble to show.
+  const [colorMode, setColorMode] = useState<ColorMode>(() =>
+    getEnsemblesForJob(jobType, results).some((e) => e.size >= 2)
+      ? 'conformation'
+      : 'default'
+  )
   const ensembleStructureRefs = useRef<Map<number, string[]>>(new Map())
   const ensembleVisibilityRef = useRef<Record<number, boolean>>({})
-  const isDomainColorRef = useRef(false)
+  const colorModeRef = useRef<ColorMode>('default')
   const allStructureRefs = useRef<string[]>([])
+
+  // The original starting (minimized input) model, toggled independently of the
+  // ensembles for comparison. Kept out of allStructureRefs / ensembleStructureRefs
+  // so color-mode and ensemble-visibility changes never touch it.
+  const startingModelRef = useRef<string | null>(null)
+  const [hasStartingModel, setHasStartingModel] = useState(false)
+  const [showStartingModel, setShowStartingModel] = useState(false)
 
   const hasConstraints =
     (constraints?.fixed_bodies?.length ?? 0) > 0 ||
     (constraints?.rigid_bodies?.length ?? 0) > 0
+
+  const ensembles = useMemo(
+    () => getEnsemblesForJob(jobType, results),
+    [jobType, results]
+  )
+
+  // Color-by-conformation is only meaningful when at least one visible ensemble
+  // has multiple members to distinguish.
+  const showConformationColor = ensembles.some((e) => e.size >= 2)
 
   const createLoadParamsArray = async (
     id: string,
@@ -241,8 +299,8 @@ const MolstarViewer = ({
   }, [ensembleVisibility])
 
   useEffect(() => {
-    isDomainColorRef.current = isDomainColor
-  }, [isDomainColor])
+    colorModeRef.current = colorMode
+  }, [colorMode])
 
   const hasRun = useRef(false)
 
@@ -367,8 +425,12 @@ const MolstarViewer = ({
           // Track all loaded structure refs for domain coloring
           structRefs.push(struct.ref)
 
+          // A member's index within its ensemble is its position in the refs
+          // array — this matches the weights-panel row order and legend colors.
+          let memberIndex = 0
           if (ensembleSize !== undefined) {
             const refs = ensembleStructureRefs.current.get(ensembleSize) ?? []
+            memberIndex = refs.length
             refs.push(struct.ref)
             ensembleStructureRefs.current.set(ensembleSize, refs)
           }
@@ -379,9 +441,15 @@ const MolstarViewer = ({
             (s) => s.cell.transform.ref === struct.ref
           )
           if (structureRef) {
+            // Color each ensemble member distinctly when conformation coloring
+            // is the active default; otherwise use the standard preset.
+            const preset =
+              colorMode === 'conformation' && ensembleSize !== undefined
+                ? createUniformColorPreset(ensembleMemberColorValue(memberIndex))
+                : StructurePreset
             await plugin.managers.structure.component.applyPreset(
               [structureRef],
-              StructurePreset
+              preset
             )
           }
         }
@@ -437,6 +505,52 @@ const MolstarViewer = ({
             }
         }
       }
+
+      // Load the original starting (minimized input) model so it can be toggled
+      // on for comparison with the ensemble models. Hidden by default, colored a
+      // neutral gray, and deliberately kept out of the ref maps that drive
+      // coloring/visibility so it stays independent of them.
+      if (ensembleResultsKeys[jobType] && window.molstar) {
+        const startingUrl = isPublic
+          ? `/public/jobs/${publicId}/results/minimization_output.pdb`
+          : `/jobs/${id}/results/minimization_output.pdb`
+        try {
+          const startingData = await fetchPdbData(startingUrl)
+          if (startingData) {
+            const plugin = window.molstar
+            const data = await plugin.builders.data.rawData({
+              data: startingData,
+              label: 'minimization_output.pdb'
+            })
+            const trajectory =
+              await plugin.builders.structure.parseTrajectory(data, 'pdb')
+            const model = await plugin.builders.structure.createModel(trajectory)
+            const struct =
+              await plugin.builders.structure.createStructure(model)
+            startingModelRef.current = struct.ref
+            const structureRef =
+              plugin.managers.structure.hierarchy.current.structures.find(
+                (s) => s.cell.transform.ref === struct.ref
+              )
+            if (structureRef) {
+              await plugin.managers.structure.component.applyPreset(
+                [structureRef],
+                createUniformColorPreset(
+                  STARTING_MODEL_COLOR_VALUE,
+                  STARTING_MODEL_ALPHA
+                )
+              )
+              plugin.managers.structure.hierarchy.toggleVisibility(
+                [structureRef],
+                'hide'
+              )
+            }
+            setHasStartingModel(true)
+          }
+        } catch {
+          // No starting model available for this job; leave the toggle hidden.
+        }
+      }
     }
 
     void init()
@@ -447,34 +561,44 @@ const MolstarViewer = ({
       hasRun.current = false
       refsMap.clear()
       structRefs.length = 0
+      startingModelRef.current = null
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const toggleDomainColor = async () => {
+  const applyColorMode = async (nextMode: ColorMode) => {
     const plugin = window.molstar
-    if (!plugin || !constraints) return
+    if (!plugin) return
+    if (nextMode === 'domain' && !constraints) return
 
-    const nextMode = !isDomainColorRef.current
     const allStructures = plugin.managers.structure.hierarchy.current.structures
-    const targets = allStructures.filter((s) =>
-      allStructureRefs.current.includes(s.cell.transform.ref)
-    )
-
-    if (targets.length === 0) return
 
     try {
-      if (nextMode) {
-        const domainPreset = createDomainColorPreset(constraints)
-        await plugin.managers.structure.component.applyPreset(
-          targets,
-          domainPreset
-        )
+      if (nextMode === 'conformation') {
+        // Color each ensemble member its own palette color, indexed by its
+        // position within the ensemble so it matches the weights-panel legend.
+        for (const refs of ensembleStructureRefs.current.values()) {
+          for (let i = 0; i < refs.length; i++) {
+            const target = allStructures.find(
+              (s) => s.cell.transform.ref === refs[i]
+            )
+            if (!target) continue
+            await plugin.managers.structure.component.applyPreset(
+              [target],
+              createUniformColorPreset(ensembleMemberColorValue(i))
+            )
+          }
+        }
       } else {
-        await plugin.managers.structure.component.applyPreset(
-          targets,
-          StructurePreset
+        const targets = allStructures.filter((s) =>
+          allStructureRefs.current.includes(s.cell.transform.ref)
         )
+        if (targets.length === 0) return
+        const preset =
+          nextMode === 'domain' && constraints
+            ? createDomainColorPreset(constraints)
+            : StructurePreset
+        await plugin.managers.structure.component.applyPreset(targets, preset)
       }
 
       // Re-apply ensemble visibility after rebuilding representations
@@ -483,40 +607,56 @@ const MolstarViewer = ({
       ).reapplyVisibility
       if (typeof reapply === 'function') reapply()
 
-      setIsDomainColor(nextMode)
+      setColorMode(nextMode)
     } catch (error) {
-      logger.error('Failed to apply domain color preset:', error)
+      logger.error('Failed to apply color preset:', error)
     }
   }
 
-  const toggleAllEnsembles = (action: 'show' | 'hide') => {
+  const toggleDomainColor = () =>
+    applyColorMode(colorModeRef.current === 'domain' ? 'default' : 'domain')
+
+  const toggleConformationColor = () =>
+    applyColorMode(
+      colorModeRef.current === 'conformation' ? 'default' : 'conformation'
+    )
+
+  const toggleStartingModel = () => {
+    const plugin = window.molstar
+    const ref = startingModelRef.current
+    if (!plugin || !ref) return
+    const target = plugin.managers.structure.hierarchy.current.structures.find(
+      (s) => s.cell.transform.ref === ref
+    )
+    if (!target) return
+    const next = !showStartingModel
+    plugin.managers.structure.hierarchy.toggleVisibility(
+      [target],
+      next ? 'show' : 'hide'
+    )
+    setShowStartingModel(next)
+  }
+
+  // Show exactly one ensemble at a time: reveal the chosen size and hide all
+  // others.
+  const selectEnsemble = (size: number) => {
     const plugin = window.molstar
     if (!plugin) return
-    const allRefs = Array.from(ensembleStructureRefs.current.values()).flat()
-    const targets = plugin.managers.structure.hierarchy.current.structures.filter(
-      (s) => allRefs.includes(s.cell.transform.ref)
-    )
-    if (targets.length > 0) {
-      plugin.managers.structure.hierarchy.toggleVisibility(targets, action)
-    }
+    const allStructures = plugin.managers.structure.hierarchy.current.structures
     const sizes = Array.from(ensembleStructureRefs.current.keys())
-    setEnsembleVisibility(
-      Object.fromEntries(sizes.map((s) => [s, action === 'show']))
-    )
-  }
-
-  const toggleEnsemble = (size: number) => {
-    const plugin = window.molstar
-    if (!plugin) return
-    const refs = ensembleStructureRefs.current.get(size) ?? []
-    const action = ensembleVisibility[size] ? 'hide' : 'show'
-    const targets = plugin.managers.structure.hierarchy.current.structures.filter(
-      (s) => refs.includes(s.cell.transform.ref)
-    )
-    if (targets.length > 0) {
-      plugin.managers.structure.hierarchy.toggleVisibility(targets, action)
+    for (const s of sizes) {
+      const refs = ensembleStructureRefs.current.get(s) ?? []
+      const targets = allStructures.filter((st) =>
+        refs.includes(st.cell.transform.ref)
+      )
+      if (targets.length > 0) {
+        plugin.managers.structure.hierarchy.toggleVisibility(
+          targets,
+          s === size ? 'show' : 'hide'
+        )
+      }
     }
-    setEnsembleVisibility((prev) => ({ ...prev, [size]: !prev[size] }))
+    setEnsembleVisibility(Object.fromEntries(sizes.map((s) => [s, s === size])))
   }
 
   return (
@@ -526,11 +666,16 @@ const MolstarViewer = ({
           <EnsembleTogglePanel
             ensembleSizes={Object.keys(ensembleVisibility).map(Number)}
             visibility={ensembleVisibility}
-            onToggle={toggleEnsemble}
-            onToggleAll={toggleAllEnsembles}
+            onSelect={selectEnsemble}
             hasConstraints={hasConstraints}
-            domainColorActive={isDomainColor}
+            domainColorActive={colorMode === 'domain'}
             onColorByDomain={toggleDomainColor}
+            showConformationColor={showConformationColor}
+            conformationColorActive={colorMode === 'conformation'}
+            onColorByConformation={toggleConformationColor}
+            showStartingModel={hasStartingModel}
+            startingModelActive={showStartingModel}
+            onToggleStartingModel={toggleStartingModel}
           />
           <Box sx={{ position: 'relative', width: '100%' }}>
             <div
@@ -549,6 +694,11 @@ const MolstarViewer = ({
               />
             )}
           </Box>
+          <EnsembleWeightsPanel
+            ensembles={ensembles}
+            visibility={ensembleVisibility}
+            showColors={colorMode === 'conformation'}
+          />
         </Box>
       </Grid>
     </Item>

--- a/apps/ui/src/features/molstar/__tests__/EnsembleTogglePanel.test.tsx
+++ b/apps/ui/src/features/molstar/__tests__/EnsembleTogglePanel.test.tsx
@@ -7,8 +7,7 @@ import EnsembleTogglePanel from '../EnsembleTogglePanel'
 const baseProps = {
   ensembleSizes: [],
   visibility: {},
-  onToggle: vi.fn(),
-  onToggleAll: vi.fn()
+  onSelect: vi.fn()
 }
 
 describe('EnsembleTogglePanel', () => {
@@ -54,9 +53,21 @@ describe('EnsembleTogglePanel', () => {
         />
       )
       expect(screen.getByText('Ensembles:')).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Show All' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Size 1' })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Size 2' })).toBeInTheDocument()
+    })
+
+    it('does not render a Show All / Hide All button', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: false }}
+        />
+      )
+      expect(
+        screen.queryByRole('button', { name: /Hide All|Show All/ })
+      ).not.toBeInTheDocument()
     })
 
     it('renders both ensemble controls and domain button when both apply', () => {
@@ -141,18 +152,7 @@ describe('EnsembleTogglePanel', () => {
   })
 
   describe('ensemble controls', () => {
-    it('shows "Hide All" when all ensembles are visible', () => {
-      renderWithProviders(
-        <EnsembleTogglePanel
-          {...baseProps}
-          ensembleSizes={[1, 2]}
-          visibility={{ 1: true, 2: true }}
-        />
-      )
-      expect(screen.getByRole('button', { name: 'Hide All' })).toBeInTheDocument()
-    })
-
-    it('shows "Show All" when not all ensembles are visible', () => {
+    it('marks the visible ensemble size as selected (exclusive)', () => {
       renderWithProviders(
         <EnsembleTogglePanel
           {...baseProps}
@@ -160,35 +160,91 @@ describe('EnsembleTogglePanel', () => {
           visibility={{ 1: true, 2: false }}
         />
       )
-      expect(screen.getByRole('button', { name: 'Show All' })).toBeInTheDocument()
-    })
-
-    it('calls onToggleAll with "hide" when Hide All is clicked', async () => {
-      const onToggleAll = vi.fn()
-      renderWithProviders(
-        <EnsembleTogglePanel
-          {...baseProps}
-          ensembleSizes={[1, 2]}
-          visibility={{ 1: true, 2: true }}
-          onToggleAll={onToggleAll}
-        />
+      expect(screen.getByRole('button', { name: 'Size 1' })).toHaveAttribute(
+        'aria-pressed',
+        'true'
       )
-      await userEvent.click(screen.getByRole('button', { name: 'Hide All' }))
-      expect(onToggleAll).toHaveBeenCalledWith('hide')
+      expect(screen.getByRole('button', { name: 'Size 2' })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      )
     })
 
-    it('calls onToggle when an ensemble size button is clicked', async () => {
-      const onToggle = vi.fn()
+    it('calls onSelect when a different ensemble size is clicked', async () => {
+      const onSelect = vi.fn()
       renderWithProviders(
         <EnsembleTogglePanel
           {...baseProps}
           ensembleSizes={[1, 2]}
           visibility={{ 1: true, 2: false }}
-          onToggle={onToggle}
+          onSelect={onSelect}
         />
       )
       await userEvent.click(screen.getByRole('button', { name: 'Size 2' }))
-      expect(onToggle).toHaveBeenCalledWith(2)
+      expect(onSelect).toHaveBeenCalledWith(2)
+    })
+
+    it('does not call onSelect when the already-selected size is clicked', async () => {
+      const onSelect = vi.fn()
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[1, 2]}
+          visibility={{ 1: true, 2: false }}
+          onSelect={onSelect}
+        />
+      )
+      // Clicking the active button would deselect it in an exclusive group;
+      // the panel ignores that so one ensemble is always shown.
+      await userEvent.click(screen.getByRole('button', { name: 'Size 1' }))
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('starting model toggle', () => {
+    it('is hidden when no starting model is available', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[2]}
+          visibility={{ 2: true }}
+        />
+      )
+      expect(
+        screen.queryByRole('button', { name: /Starting Model/ })
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows the toggle when a starting model is available', () => {
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[2]}
+          visibility={{ 2: true }}
+          showStartingModel
+          onToggleStartingModel={vi.fn()}
+        />
+      )
+      expect(
+        screen.getByRole('button', { name: /Starting Model/ })
+      ).toBeInTheDocument()
+    })
+
+    it('calls onToggleStartingModel when clicked', async () => {
+      const onToggleStartingModel = vi.fn()
+      renderWithProviders(
+        <EnsembleTogglePanel
+          {...baseProps}
+          ensembleSizes={[2]}
+          visibility={{ 2: true }}
+          showStartingModel
+          onToggleStartingModel={onToggleStartingModel}
+        />
+      )
+      await userEvent.click(
+        screen.getByRole('button', { name: /Starting Model/ })
+      )
+      expect(onToggleStartingModel).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/apps/ui/src/features/molstar/__tests__/EnsembleWeightsPanel.test.tsx
+++ b/apps/ui/src/features/molstar/__tests__/EnsembleWeightsPanel.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import { describe, test, expect } from 'vitest'
+import type { IEnsemble } from '@bilbomd/bilbomd-types'
+import EnsembleWeightsPanel from '../EnsembleWeightsPanel'
+
+const makeEnsemble = (size: number): IEnsemble => ({
+  size,
+  models: [
+    {
+      rank: 1,
+      chi2: 2.89,
+      c1: 0.99,
+      c2: -0.5,
+      states: Array.from({ length: size }, (_, i) => ({
+        pdb: `../foxs/rg${i}/dcd2pdb_rg${i}_run1_${i}000.pdb`,
+        weight: 1 / size,
+        weight_avg: 1 / size,
+        weight_stddev: 0.01,
+        fraction: 0.1
+      }))
+    }
+  ]
+})
+
+describe('EnsembleWeightsPanel', () => {
+  test('renders nothing when there are no ensembles', () => {
+    const { container } = render(
+      <EnsembleWeightsPanel ensembles={[]} visibility={{}} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  test('renders nothing for single-state (size 1) ensembles', () => {
+    const { container } = render(
+      <EnsembleWeightsPanel
+        ensembles={[makeEnsemble(1)]}
+        visibility={{ 1: true }}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  test('shows weights only for visible multi-state ensembles', () => {
+    render(
+      <EnsembleWeightsPanel
+        ensembles={[makeEnsemble(2), makeEnsemble(3)]}
+        visibility={{ 2: true, 3: false }}
+      />
+    )
+
+    expect(screen.getByText('Conformation weights')).toBeInTheDocument()
+    expect(screen.getByText('2-state ensemble')).toBeInTheDocument()
+    expect(screen.queryByText('3-state ensemble')).not.toBeInTheDocument()
+
+    // Two conformations, each with weight 0.500
+    expect(screen.getAllByText('0.500')).toHaveLength(2)
+  })
+
+  test('renders a cleaned conformation label (no path, no .pdb)', () => {
+    render(
+      <EnsembleWeightsPanel
+        ensembles={[makeEnsemble(2)]}
+        visibility={{ 2: true }}
+      />
+    )
+    expect(screen.getByText('dcd2pdb_rg0_run1_0000')).toBeInTheDocument()
+  })
+
+  test('shows no color swatches by default', () => {
+    render(
+      <EnsembleWeightsPanel
+        ensembles={[makeEnsemble(3)]}
+        visibility={{ 3: true }}
+      />
+    )
+    expect(screen.queryAllByTestId('conformation-swatch')).toHaveLength(0)
+  })
+
+  test('shows one color swatch per conformation when showColors is set', () => {
+    render(
+      <EnsembleWeightsPanel
+        ensembles={[makeEnsemble(3)]}
+        visibility={{ 3: true }}
+        showColors
+      />
+    )
+    expect(screen.getAllByTestId('conformation-swatch')).toHaveLength(3)
+  })
+})

--- a/apps/ui/src/features/molstar/ensembleColors.ts
+++ b/apps/ui/src/features/molstar/ensembleColors.ts
@@ -1,0 +1,36 @@
+// Shared palette for coloring individual ensemble member structures.
+// Used both by the Molstar "Color by Conformation" preset and by the
+// EnsembleWeightsPanel swatches, so the viewer and the legend always match.
+//
+// Values are the d3 category10 palette (distinguishable, colorblind-reasonable),
+// stored as 0xRRGGBB numbers so Molstar's Color() can consume them directly and
+// the panel can derive CSS hex strings.
+export const ENSEMBLE_MEMBER_COLOR_VALUES = [
+  0x1f77b4, // blue
+  0xff7f0e, // orange
+  0x2ca02c, // green
+  0xd62728, // red
+  0x9467bd, // purple
+  0x8c564b, // brown
+  0xe377c2, // pink
+  0x7f7f7f, // gray
+  0xbcbd22, // olive
+  0x17becf // cyan
+]
+
+// The 0xRRGGBB color value for a given member index (wraps if there are more
+// members than palette entries).
+export const ensembleMemberColorValue = (index: number): number =>
+  ENSEMBLE_MEMBER_COLOR_VALUES[index % ENSEMBLE_MEMBER_COLOR_VALUES.length]!
+
+// The CSS hex string ('#rrggbb') for a given member index, for MUI swatches.
+export const ensembleMemberCssColor = (index: number): string =>
+  `#${ensembleMemberColorValue(index).toString(16).padStart(6, '0')}`
+
+// Light green used for the original starting model, so it reads as a reference
+// structure distinct from the colored ensemble members. rgb(188, 230, 192).
+export const STARTING_MODEL_COLOR_VALUE = 0xbce6c0
+export const STARTING_MODEL_CSS_COLOR = '#bce6c0'
+
+// Opacity for the semi-transparent starting-model overlay.
+export const STARTING_MODEL_ALPHA = 0.5

--- a/apps/ui/src/features/molstar/presets.ts
+++ b/apps/ui/src/features/molstar/presets.ts
@@ -509,6 +509,115 @@ export const InteractionsPreset = StructureRepresentationPresetProvider({
   }
 })
 
+// Colors an entire structure's polymer (protein + nucleic) a single uniform
+// color, keeping ligands/ions/branched element-colored. Used to give each
+// ensemble member structure its own distinct color ("Color by Conformation").
+export const createUniformColorPreset = (colorValue: number, alpha = 1) =>
+  StructureRepresentationPresetProvider({
+    id: 'preset-uniform-color',
+    display: { name: 'Uniform Color' },
+    params: () => PresetParams,
+    async apply(ref, params, plugin) {
+      const structureCell = StateObjectRef.resolveAndCheck(plugin.state.data, ref)
+      if (!structureCell) return {}
+
+      const color = Color(colorValue)
+
+      const components = {
+        ligand: await presetStaticComponent(plugin, structureCell, 'ligand'),
+        protein: await presetStaticComponent(plugin, structureCell, 'protein'),
+        nucleic: await plugin.builders.structure.tryCreateComponentFromSelection(
+          structureCell,
+          nucleicResidueQuery,
+          'nucleic'
+        ),
+        ions: await presetStaticComponent(plugin, structureCell, 'ion'),
+        branched: await presetStaticComponent(plugin, structureCell, 'branched')
+      }
+
+      const { update, builder, typeParams } =
+        StructureRepresentationPresetProvider.reprBuilder(plugin, params)
+      const representations = {
+        ligand: builder.buildRepresentation(
+          update,
+          components.ligand,
+          {
+            type: 'ball-and-stick',
+            typeParams: {
+              ...typeParams,
+              material: CustomMaterial,
+              sizeFactor: 0.35,
+              alpha
+            },
+            color: 'element-symbol',
+            colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
+          },
+          { tag: 'ligand' }
+        ),
+        protein: builder.buildRepresentation(
+          update,
+          components.protein,
+          {
+            type: 'cartoon',
+            typeParams: { ...typeParams, material: CustomMaterial, alpha },
+            color: 'uniform',
+            colorParams: { value: color }
+          },
+          { tag: 'protein' }
+        ),
+        nucleic: builder.buildRepresentation(
+          update,
+          components.nucleic,
+          {
+            type: 'cartoon',
+            typeParams: { ...typeParams, material: CustomMaterial, alpha },
+            color: 'uniform',
+            colorParams: { value: color }
+          },
+          { tag: 'nucleic' }
+        ),
+        ions: builder.buildRepresentation(
+          update,
+          components.ions,
+          {
+            type: 'spacefill',
+            typeParams: {
+              ...typeParams,
+              material: CustomMaterial,
+              sizeFactor: 1.0,
+              alpha
+            },
+            color: 'element-symbol',
+            colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
+          },
+          { tag: 'ions' }
+        ),
+        branched: builder.buildRepresentation(
+          update,
+          components.branched,
+          {
+            type: 'ball-and-stick',
+            typeParams: {
+              ...typeParams,
+              material: CustomMaterial,
+              sizeFactor: 0.35,
+              alpha
+            },
+            color: 'element-symbol',
+            colorParams: { carbonColor: { name: 'element-symbol', params: {} } }
+          },
+          { tag: 'branched' }
+        )
+      }
+
+      await update.commit({ revertOnError: true })
+      await shinyStyle(plugin)
+      plugin.managers.interactivity.setProps({ granularity: 'residue' })
+
+      return { components, representations }
+    }
+  })
+
 export const ShowButtons = PluginConfig.item('showButtons', true)
 
 // Colors matching MDConstraintsRenderer


### PR DESCRIPTION
## Summary

Enhances the Molstar molecular viewer to better display and compare ensemble models produced by MultiFoXS. All changes are frontend-only — the underlying weight data was already parsed, stored in Mongo, and shipped to the frontend, but the viewer was discarding it.

## Changes

- **Ensemble weights panel** — For ensemble models with 2+ component structures, a new `EnsembleWeightsPanel` displays each contributing conformation with its cleaned PDB label, a proportion bar, and weight value.
- **Color by Conformation** — New coloring mode assigning each ensemble member a distinct color (d3 category10 palette). This is now the **default** coloring when the viewer loads. "Color by Domain" is retained unchanged.
- **Mutually exclusive ensemble selection** — The "Size N" buttons are now an exclusive toggle group, so only one ensemble is displayed at a time.
- **Starting Model overlay** — An independent toggle overlays the original minimized input structure (`minimization_output.pdb`), rendered semi-transparent light green (rgb 188, 230, 192), so users can compare the best N-state ensemble models against the starting model. The toggle only appears when a starting model is available for the job. Its color and visibility stay fully independent of the color-mode and ensemble-selection controls.

## Notes

- No backend/worker changes required.
- Scoper is intentionally excluded from these features.

## Testing

- `pnpm -F @bilbomd/ui build` ✓
- `pnpm -F @bilbomd/ui lint` ✓
- `pnpm -F @bilbomd/ui test` ✓ (1154 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)