### PR TITLE
ci: fix changesets/action v2 renamed input (version → version-script)

### DIFF
--- a/.github/workflows/changesets-release-pr.yml
+++ b/.github/workflows/changesets-release-pr.yml
@@ -63,6 +63,6 @@ jobs:
           # merges (no waiting for Renovate). changesets/action stages all
           # working-tree changes (git add .), so the infra edits are committed
           # onto the release branch alongside the version bumps.
-          version: pnpm run changeset:version
+          version-script: pnpm run changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The `changesets/action` v2 upgrade (#991) renamed the `version` input to `version-script`, which broke the **Changesets – Release PR** workflow. The failing run errored with:

> Error: The following inputs have been renamed:
> - "version" -> "version-script"

This updates `.github/workflows/changesets-release-pr.yml` to use the new input name.

## Reference

- Failing run: https://github.com/bl1231/bilbomd/actions/runs/32539409069
- v2.1.1 valid inputs: `version-script`, `publish-script`, `github-token`, `commit-message`, `pr-title`, `pr-draft`, `pr-base-branch`, `create-github-releases`, `push-git-tags`, `push-with-git-cli`, `cwd`

The workflow only uses the `version` input, so `version-script` is the only change required (no `publish` input in use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)