### PR TITLE
fix: version private packages with changesets v3 (ui never got bumped)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": { "version": true, "tag": false }
 }


### PR DESCRIPTION
## Summary

After the `@changesets/cli` v3 upgrade (#992), `@bilbomd/ui` stopped receiving version bumps. The "Version Packages" commit generated by the release workflow came out **empty**, and `apps/ui` was stuck at `2.24.0` despite a pending `minor` changeset.

## Root cause

`@changesets/cli` v3 **no longer versions private packages by default**. `@bilbomd/ui` is `"private": true` and is the only private package versioned through changesets, so it was silently dropped from the release plan.

Diagnosis (each tested with a temp changeset):

| Package | `private` | Picked up by `changeset status` |
|---|---|---|
| `@bilbomd/backend` | public | ✅ |
| `@bilbomd/worker` | public | ✅ |
| `@bilbomd/mongodb-schema` | public | ✅ |
| `@bilbomd/bilbomd-types` | public | ✅ |
| **`@bilbomd/ui`** | **private** | ❌ |

`@manypkg/get-packages` still resolves `@bilbomd/ui` fine — it's changesets' own release-plan assembly that excludes private packages under v3.

## Fix

Add to `.changeset/config.json`:

```json
"privatePackages": { "version": true, "tag": false }
```

- `version: true` — restore v2 behavior (bump version + write CHANGELOG for private packages).
- `tag: false` — matches prior behavior: `@bilbomd/ui` was **never** git-tagged (`git tag --list '@bilbomd/ui@*'` is empty). Its Docker image tag is derived from `package.json` via `infra/scripts/sync-image-tags.mjs`, not from git tags.

## Verification

With the fix, `pnpm exec changeset version` bumps `@bilbomd/ui` `2.24.0 → 2.25.0` (minor) and consumes the pending changeset. Before the fix, the same command was a no-op.

## Follow-up

Once merged, the release workflow re-runs and the standing **Version Packages** PR (#997, currently empty) will correctly include the `@bilbomd/ui` bump from PR #993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)