### PR TITLE
fix(backend): retry Redis connections instead of crashing at startup

### DIFF
--- a/.changeset/backend-redis-connect-retry.md
+++ b/.changeset/backend-redis-connect-retry.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/backend': patch
+---
+
+Retry Redis connections with capped backoff instead of crashing at startup. Previously a Redis outage during a rolling deploy (e.g. while the redis image pulls on NERSC Spin) caused an uncaught ECONNREFUSED that crash-looped the backend and stalled the Helm upgrade. Both the session client (redis) and BullMQ client (ioredis) now log connection errors and reconnect automatically, and the delete-jobs worker reuses the shared Redis connection instead of a hardcoded host.

--- a/apps/backend/src/queues/__tests__/redisConn.test.ts
+++ b/apps/backend/src/queues/__tests__/redisConn.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'events'
+
+vi.mock('../../middleware/loggers.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() }
+}))
+
+const hoisted = vi.hoisted(() => ({
+  constructorCalls: [] as unknown[]
+}))
+
+vi.mock('ioredis', async () => {
+  const { EventEmitter } = await import('events')
+  class MockRedis extends EventEmitter {
+    constructor(options: unknown) {
+      super()
+      hoisted.constructorCalls.push(options)
+    }
+  }
+  return { Redis: MockRedis }
+})
+
+import { logger } from '../../middleware/loggers.js'
+import { redis, redisRetryStrategy } from '../redisConn.js'
+
+describe('redisConn', () => {
+  it('configures ioredis with a retry strategy', () => {
+    expect(hoisted.constructorCalls).toHaveLength(1)
+    const options = hoisted.constructorCalls[0] as {
+      retryStrategy: unknown
+      maxRetriesPerRequest: unknown
+    }
+    expect(options.retryStrategy).toBe(redisRetryStrategy)
+    expect(options.maxRetriesPerRequest).toBeNull()
+  })
+
+  it('retries with backoff capped at 5 seconds', () => {
+    expect(redisRetryStrategy(1)).toBe(500)
+    expect(redisRetryStrategy(5)).toBe(2500)
+    expect(redisRetryStrategy(10)).toBe(5000)
+    expect(redisRetryStrategy(1000)).toBe(5000)
+  })
+
+  it('logs connection errors instead of crashing the process', () => {
+    expect(() =>
+      (redis as unknown as EventEmitter).emit('error', new Error('connect ECONNREFUSED'))
+    ).not.toThrow()
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('connect ECONNREFUSED')
+    )
+  })
+})

--- a/apps/backend/src/queues/__tests__/sessionRedisConn.test.ts
+++ b/apps/backend/src/queues/__tests__/sessionRedisConn.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventEmitter } from 'events'
+
+vi.mock('../../middleware/loggers.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() }
+}))
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn()
+}))
+
+vi.mock('redis', async () => {
+  const { EventEmitter } = await import('events')
+  return {
+    createClient: (config: unknown) => {
+      createClientMock(config)
+      return new EventEmitter()
+    }
+  }
+})
+
+import { logger } from '../../middleware/loggers.js'
+import { sessionRedis, sessionRedisReconnectStrategy } from '../sessionRedisConn.js'
+
+describe('sessionRedisConn', () => {
+  it('configures the client with a reconnect strategy', () => {
+    expect(createClientMock).toHaveBeenCalledTimes(1)
+    const config = createClientMock.mock.calls[0][0] as {
+      socket: { reconnectStrategy: unknown }
+    }
+    expect(config.socket.reconnectStrategy).toBe(sessionRedisReconnectStrategy)
+  })
+
+  it('retries with backoff capped at 5 seconds', () => {
+    expect(sessionRedisReconnectStrategy(1)).toBe(500)
+    expect(sessionRedisReconnectStrategy(5)).toBe(2500)
+    expect(sessionRedisReconnectStrategy(10)).toBe(5000)
+    expect(sessionRedisReconnectStrategy(1000)).toBe(5000)
+  })
+
+  it('logs connection errors instead of crashing the process', () => {
+    expect(() =>
+      (sessionRedis as unknown as EventEmitter).emit(
+        'error',
+        new Error('connect ECONNREFUSED')
+      )
+    ).not.toThrow()
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('connect ECONNREFUSED')
+    )
+  })
+
+  it('logs reconnect attempts', () => {
+    ;(sessionRedis as unknown as EventEmitter).emit('reconnecting')
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('reconnecting')
+    )
+  })
+})

--- a/apps/backend/src/queues/redisConn.ts
+++ b/apps/backend/src/queues/redisConn.ts
@@ -1,4 +1,9 @@
 import { Redis, RedisOptions } from 'ioredis'
+import { logger } from '../middleware/loggers.js'
+
+// Retry indefinitely with capped backoff so a redis outage during a rolling
+// deploy doesn't crash the backend (see sessionRedisConn.ts).
+const redisRetryStrategy = (times: number): number => Math.min(times * 500, 5000)
 
 const redisOptions: RedisOptions = {
   port:
@@ -7,9 +12,16 @@ const redisOptions: RedisOptions = {
       : 6379,
   host: process.env.REDIS_HOST || 'localhost',
   maxRetriesPerRequest: null,
+  retryStrategy: redisRetryStrategy,
   tls: process.env.REDIS_TLS ? JSON.parse(process.env.REDIS_TLS) : false
 }
 
 const redis = new Redis(redisOptions)
 
-export { redis }
+// Without an 'error' listener ioredis connection errors are raised as
+// uncaught exceptions and kill the process.
+redis.on('error', (err: Error) => {
+  logger.error(`Redis client error: ${err.message}`)
+})
+
+export { redis, redisRetryStrategy }

--- a/apps/backend/src/queues/sessionRedisConn.ts
+++ b/apps/backend/src/queues/sessionRedisConn.ts
@@ -1,4 +1,5 @@
 import { createClient } from 'redis'
+import { logger } from '../middleware/loggers.js'
 
 const port =
   process.env.REDIS_PORT && !isNaN(parseInt(process.env.REDIS_PORT, 10))
@@ -8,10 +9,30 @@ const port =
 const host = process.env.REDIS_HOST || 'localhost'
 const useTls = process.env.REDIS_TLS === 'true'
 
+// Retry indefinitely with capped backoff — during a rolling deploy the redis
+// Deployment (Recreate strategy) is down while its image pulls, and a startup
+// crash here stalls the whole Helm upgrade.
+const sessionRedisReconnectStrategy = (retries: number): number =>
+  Math.min(retries * 500, 5000)
+
 const sessionRedis = createClient({
   socket: useTls
-    ? { port, host, tls: true as const }
-    : { port, host }
+    ? { port, host, tls: true as const, reconnectStrategy: sessionRedisReconnectStrategy }
+    : { port, host, reconnectStrategy: sessionRedisReconnectStrategy }
 })
 
-export { sessionRedis }
+// Without an 'error' listener a failed connection attempt is raised as an
+// uncaught exception and kills the process.
+sessionRedis.on('error', (err: Error) => {
+  logger.error(`Session Redis client error: ${err.message}`)
+})
+
+sessionRedis.on('reconnecting', () => {
+  logger.warn(`Session Redis reconnecting to ${host}:${port}`)
+})
+
+sessionRedis.on('ready', () => {
+  logger.info(`Session Redis connected to ${host}:${port}`)
+})
+
+export { sessionRedis, sessionRedisReconnectStrategy }

--- a/apps/backend/src/workers/deleteBilboMDJobsWorker.ts
+++ b/apps/backend/src/workers/deleteBilboMDJobsWorker.ts
@@ -4,13 +4,9 @@ import path from 'path'
 import fs from 'fs-extra'
 import { logger } from '../middleware/loggers.js'
 import { getEnvVar } from '../config/config.js'
+import { redis as connection } from '../queues/redisConn.js'
 
 const uploadFolder = path.join(getEnvVar('DATA_VOL'))
-
-const connection = {
-  host: 'redis',
-  port: 6379
-}
 
 function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return (


### PR DESCRIPTION
## Problem

During a Helm upgrade on NERSC Spin dev, the release sat in `pending-upgrade` for minutes. Root cause chain:

1. The redis Deployment uses `strategy: Recreate` (RWO PVC), so the old redis pod is killed before the new one starts.
2. The new redis pod's image pull was queued ~4 minutes behind the multi-GB `bilbomd-worker` pull on the same node (kubelet serializes pulls), so redis was completely down that whole time.
3. The new backend pod started, hit `ECONNREFUSED` connecting to redis, and died with an uncaught exception (the redis client emitted `error` with no listener), crash-looping and stalling `helm --wait`.

## Fix

- **`sessionRedisConn.ts`** (the crash site): add a capped-backoff `reconnectStrategy` (500ms × attempts, max 5s, retries indefinitely) plus `error`/`reconnecting`/`ready` listeners. `connect()` now waits for redis to come up instead of killing the process.
- **`redisConn.ts`**: same treatment for the BullMQ ioredis client — explicit `retryStrategy` and an `error` listener.
- **`deleteBilboMDJobsWorker.ts`**: reuse the shared `redis` connection instead of a private one with a hardcoded `host: 'redis'` that ignored `REDIS_HOST`/`REDIS_PORT`.

## Tests

New tests in `apps/backend/src/queues/__tests__/` cover the backoff values, the strategy wiring into both clients, and that an emitted `error` event logs instead of throwing. `pnpm -F @bilbomd/backend lint/build/test` all pass (520 tests).

Changeset included (`@bilbomd/backend` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)