### PR TITLE
fix(worker): don't report false NERSC status error during sacct propagation lag

### DIFF
--- a/.changeset/worker-nersc-status-pending-guard.md
+++ b/.changeset/worker-nersc-status-pending-guard.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Fix false "Failed to fetch NERSC job state" error shown briefly after Slurm submission. When the Superfacility API returns empty accounting data for a job whose stored state is still PENDING (sacct propagation lag), the monitor now reports a benign "Waiting for job to appear in Slurm accounting..." status instead of an Error step.

--- a/apps/worker/src/workers/__tests__/bilboMdNerscJobMonitor.test.ts
+++ b/apps/worker/src/workers/__tests__/bilboMdNerscJobMonitor.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import { IJob, INerscInfo, NerscStatus } from '@bilbomd/mongodb-schema'
+import { queryNERSCForJobState } from '../bilboMdNerscJobMonitor.js'
+import { updateSingleJobStep } from '../../services/functions/job-monitor-functions.js'
+
+vi.mock('../../helpers/loggers.js', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn()
+  }
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    isAxiosError: vi.fn(() => false)
+  }
+}))
+
+vi.mock('../../services/functions/nersc-api-token-functions.js', () => ({
+  ensureValidToken: vi.fn().mockResolvedValue('a-valid-token')
+}))
+
+vi.mock('../../services/functions/nersc-api-functions.js', () => ({
+  getSlurmStatusFile: vi.fn()
+}))
+
+vi.mock('../../services/functions/job-monitor-functions.js', () => ({
+  copyBilboMDResults: vi.fn(),
+  prepareBilboMDResults: vi.fn(),
+  sendBilboMDEmail: vi.fn(),
+  updateSingleJobStep: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../../services/functions/usage-events.js', () => ({
+  recordWorkerUsageEvent: vi.fn(),
+  buildContext: vi.fn()
+}))
+
+vi.mock('@bilbomd/md-utils', () => ({
+  discriminatorToPipeline: vi.fn()
+}))
+
+const makeJob = (nersc?: Partial<INerscInfo> | null): IJob =>
+  ({
+    uuid: 'test-uuid',
+    status: 'Running',
+    steps: {},
+    nersc:
+      nersc === null
+        ? undefined
+        : {
+            jobid: '12345678',
+            state: NerscStatus.PENDING,
+            qos: 'regular',
+            time_submitted: new Date(),
+            ...nersc
+          },
+    save: vi.fn().mockResolvedValue(undefined)
+  }) as unknown as IJob
+
+const mockApiResponse = (output: unknown[]) => {
+  vi.mocked(axios.get).mockResolvedValue({ data: { output } })
+}
+
+describe('queryNERSCForJobState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the parsed state when the API has accounting data', async () => {
+    mockApiResponse([
+      {
+        state: 'RUNNING',
+        qos: 'regular',
+        submit: '2026-08-24T10:00:00',
+        start: '2026-08-24T10:05:00',
+        end: 'Unknown'
+      }
+    ])
+    const job = makeJob()
+
+    const result = await queryNERSCForJobState(job)
+
+    expect(result).not.toBeNull()
+    expect(result?.state).toBe(NerscStatus.RUNNING)
+    expect(result?.jobid).toBe('12345678')
+    expect(updateSingleJobStep).not.toHaveBeenCalled()
+  })
+
+  it('reports a benign Waiting step when accounting is empty and stored state is PENDING', async () => {
+    mockApiResponse([])
+    const job = makeJob({ state: NerscStatus.PENDING })
+
+    const result = await queryNERSCForJobState(job)
+
+    expect(result).toBeNull()
+    expect(updateSingleJobStep).toHaveBeenCalledExactlyOnceWith(
+      job,
+      'nersc_job_status',
+      'Waiting',
+      'Waiting for job to appear in Slurm accounting...'
+    )
+  })
+
+  it('reports an Error step when accounting is empty and stored state is not PENDING', async () => {
+    mockApiResponse([])
+    const job = makeJob({ state: NerscStatus.RUNNING })
+
+    const result = await queryNERSCForJobState(job)
+
+    expect(result).toBeNull()
+    expect(updateSingleJobStep).toHaveBeenCalledExactlyOnceWith(
+      job,
+      'nersc_job_status',
+      'Error',
+      'Failed to fetch NERSC job state.'
+    )
+  })
+
+  it('reports an Error step when the job has no NERSC jobid', async () => {
+    const job = makeJob(null)
+
+    const result = await queryNERSCForJobState(job)
+
+    expect(result).toBeNull()
+    expect(axios.get).not.toHaveBeenCalled()
+    expect(updateSingleJobStep).toHaveBeenCalledExactlyOnceWith(
+      job,
+      'nersc_job_status',
+      'Error',
+      'Failed to fetch NERSC job state.'
+    )
+  })
+
+  it('marks the job as Error when the API request throws', async () => {
+    vi.mocked(axios.get).mockRejectedValue(new Error('network down'))
+    const job = makeJob()
+
+    const result = await queryNERSCForJobState(job)
+
+    expect(result).toBeNull()
+    expect(updateSingleJobStep).toHaveBeenCalledExactlyOnceWith(
+      job,
+      'nersc_job_status',
+      'Error',
+      'Error: network down'
+    )
+    expect(job.status).toBe('Error')
+    expect(job.save).toHaveBeenCalled()
+  })
+})

--- a/apps/worker/src/workers/bilboMdNerscJobMonitor.ts
+++ b/apps/worker/src/workers/bilboMdNerscJobMonitor.ts
@@ -84,8 +84,24 @@ const queryNERSCForJobState = async (job: IJob): Promise<INerscInfo | null> => {
     }
     const nerscState = await fetchNERSCJobState(jobid)
     if (!nerscState) {
-      logger.warn(`Failed to fetch NERSC state for job ${jobid}.`)
-      await handleStateFetchFailure(job)
+      // A freshly submitted job can take a minute or two to show up in Slurm
+      // accounting (sacct), during which the API returns an empty result. If
+      // the stored state is still PENDING this is expected — report a benign
+      // waiting status instead of a false error.
+      if (job.nersc?.state === NerscStatus.PENDING) {
+        logger.info(
+          `NERSC job ${jobid} not yet in Slurm accounting (state: PENDING) — will retry on next poll.`
+        )
+        await updateSingleJobStep(
+          job,
+          'nersc_job_status',
+          'Waiting',
+          'Waiting for job to appear in Slurm accounting...'
+        )
+      } else {
+        logger.warn(`Failed to fetch NERSC state for job ${jobid}.`)
+        await handleStateFetchFailure(job)
+      }
       return null
     }
     return nerscState
@@ -622,4 +638,4 @@ const updateJobStepsFromSlurmStatusFile = async (
   }
 }
 
-export { monitorAndCleanupJobs }
+export { monitorAndCleanupJobs, queryNERSCForJobState }


### PR DESCRIPTION
## Problem

Right after a BilboMD job is submitted to the Slurm queue on Perlmutter, the UI briefly shows **"NERSC Job Status: Failed to fetch NERSC job state."** even though nothing is wrong. Freshly submitted jobs take a minute or two to appear in Slurm accounting (sacct), during which the Superfacility API returns a successful response with an empty \`output\` array. The monitor treated that as a fetch failure and wrote an \`Error\` step, which self-corrected on the next successful poll.

## Fix

In \`queryNERSCForJobState\`, when the API returns no accounting data **and** the stored \`nersc.state\` is still \`PENDING\`, report a benign \`Waiting\` step ("Waiting for job to appear in Slurm accounting...") instead of the Error step. All real failure paths are unchanged: missing jobid, HTTP errors, and empty output on a job previously seen in any non-PENDING state still report the Error step.

During the guard window the job's overall status still syncs to Pending via the existing stored-state fallback, so downstream behavior is unchanged — only the false error message goes away.

## Changes

- \`apps/worker/src/workers/bilboMdNerscJobMonitor.ts\` — PENDING-state guard; exported \`queryNERSCForJobState\` for testability
- New tests in \`apps/worker/src/workers/__tests__/bilboMdNerscJobMonitor.test.ts\` covering the successful fetch, the new PENDING guard, the empty-output-while-RUNNING error path, the missing-jobid path, and the API-throw path
- Changeset: \`@bilbomd/worker\` patch

## Verification

Worker package lint, build, and full test suite (186 tests, 24 files) all pass on Node 26.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)