### PR TITLE
chore(infra): auto-sync helm Chart.yaml version and appVersion on release

### DIFF
--- a/infra/scripts/sync-image-tags.mjs
+++ b/infra/scripts/sync-image-tags.mjs
@@ -5,6 +5,12 @@
 // compose + helm files pointed at those freshly released tags without waiting
 // for Renovate.
 //
+// Also keeps infra/helm/Chart.yaml current: appVersion tracks the UI version
+// (the user-facing version of the deployed app), and the chart patch version is
+// bumped whenever this run changes helm content (values tags or appVersion) so
+// CD tooling sees a new chart release. Template-only edits under
+// infra/helm/templates/ still require a manual chart version bump.
+//
 // Idempotent: running it when everything is already in sync changes nothing.
 // Only the four changeset-driven images are touched (backend/ui/worker/scoper).
 // Third-party (mongo, redis) and the non-changeset of3/colabfold service images
@@ -64,7 +70,13 @@ const versions = Object.fromEntries(
   services.map(({ app, image }) => [image, versionFor(app)])
 )
 
+const helmValuesFiles = new Set([
+  'infra/helm/values-dev.yaml',
+  'infra/helm/values-prod.yaml'
+])
+
 let changedAny = false
+let helmValuesChanged = false
 for (const file of targetFiles) {
   const path = resolve(repoRoot, file)
   const original = readFileSync(path, 'utf8')
@@ -75,8 +87,33 @@ for (const file of targetFiles) {
   if (updated !== original) {
     writeFileSync(path, updated)
     changedAny = true
+    if (helmValuesFiles.has(file)) helmValuesChanged = true
     console.log(`updated ${file}`)
   }
+}
+
+// Sync Chart.yaml: appVersion follows the UI version; the chart patch version
+// bumps only when this run changed helm content, so re-runs on an already
+// synced tree are no-ops (changesets/action re-runs the version script on
+// every release-PR refresh, always from a fresh checkout of main).
+const chartFile = 'infra/helm/Chart.yaml'
+const chartPath = resolve(repoRoot, chartFile)
+const chartOriginal = readFileSync(chartPath, 'utf8')
+let chartUpdated = chartOriginal.replace(
+  /^(appVersion:\s*).*$/m,
+  `$1'${versions['bilbomd-ui']}'`
+)
+if (chartUpdated !== chartOriginal || helmValuesChanged) {
+  chartUpdated = chartUpdated.replace(
+    /^(version:\s*)(\d+)\.(\d+)\.(\d+)\s*$/m,
+    (_, prefix, major, minor, patch) =>
+      `${prefix}${major}.${minor}.${Number(patch) + 1}`
+  )
+}
+if (chartUpdated !== chartOriginal) {
+  writeFileSync(chartPath, chartUpdated)
+  changedAny = true
+  console.log(`updated ${chartFile}`)
 }
 
 const summary = services


### PR DESCRIPTION
## Problem

\`infra/helm/Chart.yaml\` has been maintained by hand: \`appVersion\` manually set to the UI version, and the chart \`version\` bumped "one bigger" in ad-hoc "bump helm chart" PRs (e.g. #1002).

## Change

Extends \`infra/scripts/sync-image-tags.mjs\` — which already runs via \`changeset:version\` inside the Version Packages PR — to also maintain \`Chart.yaml\`:

- \`appVersion\` is set to \`apps/ui/package.json\`'s version (the user-facing version of the deployed app), preserving the existing quote style
- the chart patch \`version\` bumps **only when the run actually changed helm content** (the values-dev/prod image tags or \`appVersion\`), so CD tooling sees a new chart release for every deploy-relevant change

The conditional bump keeps the script idempotent: re-running on an in-sync tree is a strict no-op, which matters because \`changesets/action\` re-runs the version script on every release-PR refresh (always from a fresh checkout of main).

**Caveat:** template-only edits under \`infra/helm/templates/\` still require a manual chart version bump — this automation covers release-driven changes only (noted in the script header).

## Verification

No test harness covers \`infra/scripts/\`, so behavior was verified with scratch-tree runs of the real script against copies of the real files:

- in-sync tree → no-op, Chart.yaml untouched
- worker-only bump → values updated + chart \`0.1.63 → 0.1.64\`, \`appVersion\` untouched
- UI bump → \`appVersion\` updated + chart patch bump
- hand-drifted \`appVersion\` with values in sync → repaired + chart patch bump
- rerun after each scenario → strict no-op

Prettier passes. No changeset — \`infra/scripts\` isn't a versioned package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)