### PR TITLE
fix(backend): retry MongoDB connections with capped backoff instead of wedging

### DIFF
--- a/.changeset/backend-mongo-connect-retry.md
+++ b/.changeset/backend-mongo-connect-retry.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/backend': patch
+---
+
+Retry MongoDB connections with capped exponential backoff instead of giving up after one failed attempt. Previously, if MongoDB was unreachable when the backend started (e.g. during a deploy or an NFS lock-recovery window), the backend stayed up but permanently wedged — every DB operation buffered and timed out until the pod was manually restarted. The backend now keeps retrying (5s doubling to a 60s cap) and recovers as soon as MongoDB is reachable, while /healthcheck continues to report 503 until connected.

--- a/apps/backend/src/config/__tests__/dbConn.test.ts
+++ b/apps/backend/src/config/__tests__/dbConn.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('mongoose', () => ({
+  default: {
+    set: vi.fn(),
+    connect: vi.fn()
+  }
+}))
+
+vi.mock('../../middleware/loggers.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+import { connectDB } from '../dbConn.js'
+import mongoose from 'mongoose'
+import { logger } from '../../middleware/loggers.js'
+
+const mockConnect = vi.mocked(mongoose.connect)
+
+describe('connectDB', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('connects on the first attempt without retrying', async () => {
+    mockConnect.mockResolvedValueOnce(mongoose)
+
+    await connectDB()
+
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledWith('Successfully connected to MongoDB')
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('retries after a failed attempt and resolves once connected', async () => {
+    mockConnect
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValueOnce(mongoose)
+
+    const promise = connectDB()
+    await vi.advanceTimersByTimeAsync(5_000)
+    await promise
+
+    expect(mockConnect).toHaveBeenCalledTimes(2)
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('MongoDB connection attempt 1 failed')
+    )
+    expect(logger.info).toHaveBeenCalledWith('Successfully connected to MongoDB')
+  })
+
+  it('backs off exponentially between attempts', async () => {
+    mockConnect
+      .mockRejectedValueOnce(new Error('down'))
+      .mockRejectedValueOnce(new Error('down'))
+      .mockRejectedValueOnce(new Error('down'))
+      .mockResolvedValueOnce(mongoose)
+
+    const promise = connectDB()
+
+    // attempt 1 fails -> 5s delay
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(mockConnect).toHaveBeenCalledTimes(2)
+
+    // attempt 2 fails -> 10s delay; 5s in, attempt 3 has not started yet
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(mockConnect).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(mockConnect).toHaveBeenCalledTimes(3)
+
+    // attempt 3 fails -> 20s delay
+    await vi.advanceTimersByTimeAsync(20_000)
+    await promise
+    expect(mockConnect).toHaveBeenCalledTimes(4)
+    expect(logger.info).toHaveBeenCalledWith('Successfully connected to MongoDB')
+  })
+
+  it('caps the retry delay at 60 seconds', async () => {
+    // 5 failures: delays 5s, 10s, 20s, 40s, then capped at 60s (not 80s)
+    for (let i = 0; i < 6; i++) {
+      mockConnect.mockRejectedValueOnce(new Error('down'))
+    }
+    mockConnect.mockResolvedValueOnce(mongoose)
+
+    const promise = connectDB()
+    await vi.advanceTimersByTimeAsync(5_000 + 10_000 + 20_000 + 40_000)
+    expect(mockConnect).toHaveBeenCalledTimes(5)
+
+    // 5th failure -> capped 60s delay
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(mockConnect).toHaveBeenCalledTimes(6)
+
+    // 6th failure -> still 60s, never grows beyond the cap
+    await vi.advanceTimersByTimeAsync(60_000)
+    await promise
+    expect(mockConnect).toHaveBeenCalledTimes(7)
+    expect(logger.info).toHaveBeenCalledWith('Successfully connected to MongoDB')
+  })
+
+  it('never rejects while MongoDB stays down', async () => {
+    mockConnect.mockRejectedValue(new Error('down'))
+
+    let settled = false
+    const promise = connectDB()
+    promise.finally(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(settled).toBe(false)
+    expect(mockConnect.mock.calls.length).toBeGreaterThan(5)
+
+    // let it recover so the dangling promise resolves cleanly
+    mockConnect.mockResolvedValue(mongoose)
+    await vi.advanceTimersByTimeAsync(60_000)
+    await promise
+    expect(settled).toBe(true)
+  })
+})

--- a/apps/backend/src/config/dbConn.ts
+++ b/apps/backend/src/config/dbConn.ts
@@ -11,13 +11,31 @@ const {
 
 const url = `mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOSTNAME}:${MONGO_PORT}/${MONGO_DB}?authSource=${MONGO_AUTH_SRC}`
 
-const connectDB = async () => {
-  // logger.info(`MongoDB URL: ${url}`)
-  try {
-    mongoose.set('strictQuery', false)
-    await mongoose.connect(url)
-  } catch (error) {
-    logger.error(`Error connecting to MongoDB: ${error}`)
+const INITIAL_RETRY_DELAY_MS = 5_000
+const MAX_RETRY_DELAY_MS = 60_000
+
+// Retry forever with capped exponential backoff rather than giving up (or
+// crashing): a mongod that is briefly unreachable during a deploy or an NFS
+// lock-recovery window must not leave the backend permanently wedged, and a
+// crash-loop at startup stalls Helm upgrades (see #999 for the Redis
+// equivalent). While disconnected, /healthcheck reports 503 so orchestrators
+// still see the pod as unhealthy.
+const connectDB = async (): Promise<void> => {
+  mongoose.set('strictQuery', false)
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await mongoose.connect(url)
+      logger.info('Successfully connected to MongoDB')
+      return
+    } catch (error) {
+      const delay = Math.min(
+        INITIAL_RETRY_DELAY_MS * 2 ** (attempt - 1),
+        MAX_RETRY_DELAY_MS
+      )
+      logger.error(`MongoDB connection attempt ${attempt} failed: ${error}`)
+      logger.info(`Retrying MongoDB connection in ${delay / 1000} seconds...`)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

This morning the mongo pod on the NERSC dev server was rescheduled to a new node and crash-looped for ~15 minutes on a stale NFS lock (`DBPathInUse`). Mongo recovered on its own, and the worker reconnected (it retries) — but the backend stayed permanently wedged: `connectDB()` tries `mongoose.connect()` exactly once and swallows the error, so a pod that starts while Mongo is down never gets a connection and every DB operation buffers and times out (`users.findOne() buffering timed out after 10000ms`) until someone manually restarts it.

## Fix

Retry forever with capped exponential backoff (5s doubling to a 60s cap), mirroring the approach of the Redis retry fix in #999 — a crash-loop at startup stalls Helm upgrades, so staying up and retrying is preferable. `/healthcheck` already reports 503 while `mongoose.connection.readyState !== 1`, so orchestrators still see the pod as unhealthy until the connection lands.

## Testing

- 5 new unit tests in `apps/backend/src/config/__tests__/dbConn.test.ts` covering first-try success, retry-then-recover, exponential backoff timing, the 60s delay cap, and never-rejecting while Mongo stays down (fake timers).
- `pnpm -F @bilbomd/backend lint` / `build` / `test` all pass (47 files, 525 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)