### PR TITLE
fix(worker): retry MongoDB connections indefinitely with capped backoff

### DIFF
--- a/.changeset/worker-mongo-connect-retry.md
+++ b/.changeset/worker-mongo-connect-retry.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/worker': patch
+---
+
+Retry MongoDB connections indefinitely with capped exponential backoff instead of giving up after 5 attempts. Previously, a MongoDB outage longer than ~25 seconds at worker startup exhausted the retry budget and the resulting unhandled rejection killed the worker process. The worker now keeps retrying (5s doubling to a 60s cap) and connects as soon as MongoDB is reachable, matching the backend's connection behavior.

--- a/apps/worker/src/helpers/__tests__/db.test.ts
+++ b/apps/worker/src/helpers/__tests__/db.test.ts
@@ -1,6 +1,5 @@
-import { vi, Mock } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-// Mock mongoose.connect
 // 👇 Must come BEFORE imports of mongoose or connectDB
 vi.mock('mongoose', () => ({
   default: {
@@ -8,42 +7,105 @@ vi.mock('mongoose', () => ({
     connection: {}
   }
 }))
-import { describe, it, expect, beforeEach } from 'vitest'
+
+vi.mock('../loggers.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
 import mongoose from 'mongoose'
+import { logger } from '../loggers.js'
+
+const mockConnect = vi.mocked(mongoose.connect)
+
+process.env.MONGO_USERNAME = 'testuser'
+process.env.MONGO_PASSWORD = 'testpass'
+process.env.MONGO_HOSTNAME = 'localhost'
+process.env.MONGO_PORT = '27017'
+process.env.MONGO_DB = 'testdb'
+process.env.MONGO_AUTH_SRC = 'admin'
+
+// 👇 Dynamic import after setting env (the URL is built at module load)
+const { connectDB } = await import('../db.js')
 
 describe('connectDB', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('calls mongoose.connect with the correct URL', async () => {
-    process.env.MONGO_USERNAME = 'testuser'
-    process.env.MONGO_PASSWORD = 'testpass'
-    process.env.MONGO_HOSTNAME = 'localhost'
-    process.env.MONGO_PORT = '27017'
-    process.env.MONGO_DB = 'testdb'
-    process.env.MONGO_AUTH_SRC = 'admin'
-
-    const expectedUrl = 'mongodb://testuser:testpass@localhost:27017/testdb?authSource=admin'
-
-    // 👇 Dynamic import after setting env
-    const { connectDB } = await import('../db.js')
+    mockConnect.mockResolvedValueOnce(mongoose)
 
     await connectDB()
-    expect(mongoose.connect).toHaveBeenCalledWith(expectedUrl)
+
+    expect(mockConnect).toHaveBeenCalledWith(
+      'mongodb://testuser:testpass@localhost:27017/testdb?authSource=admin'
+    )
+    expect(logger.info).toHaveBeenCalledWith('Successfully connected to MongoDB')
   })
 
-  it('retries connection and throws after all attempts fail', async () => {
-    ;(mongoose.connect as unknown as Mock).mockImplementation(() => {
-      throw new Error('connection failed')
+  it('retries after a failed attempt and resolves once connected', async () => {
+    mockConnect
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValueOnce(mongoose)
+
+    const promise = connectDB()
+    await vi.advanceTimersByTimeAsync(5_000)
+    await promise
+
+    expect(mockConnect).toHaveBeenCalledTimes(2)
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('MongoDB connection attempt 1 failed')
+    )
+    expect(logger.info).toHaveBeenCalledWith('Successfully connected to MongoDB')
+  })
+
+  it('backs off exponentially and caps the retry delay at 60 seconds', async () => {
+    // 6 failures: delays 5s, 10s, 20s, 40s, then capped at 60s (not 80s)
+    for (let i = 0; i < 6; i++) {
+      mockConnect.mockRejectedValueOnce(new Error('down'))
+    }
+    mockConnect.mockResolvedValueOnce(mongoose)
+
+    const promise = connectDB()
+    await vi.advanceTimersByTimeAsync(5_000 + 10_000 + 20_000 + 40_000)
+    expect(mockConnect).toHaveBeenCalledTimes(5)
+
+    // 5th failure -> capped 60s delay
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(mockConnect).toHaveBeenCalledTimes(6)
+
+    // 6th failure -> still 60s, never grows beyond the cap
+    await vi.advanceTimersByTimeAsync(60_000)
+    await promise
+    expect(mockConnect).toHaveBeenCalledTimes(7)
+    expect(logger.info).toHaveBeenCalledWith('Successfully connected to MongoDB')
+  })
+
+  it('never rejects while MongoDB stays down', async () => {
+    mockConnect.mockRejectedValue(new Error('down'))
+
+    let settled = false
+    const promise = connectDB()
+    promise.finally(() => {
+      settled = true
     })
-    // 👇 Dynamic import after setting env
-    const { connectDB } = await import('../db.js')
 
-    // Should throw after all retries fail
-    await expect(connectDB(3, 100)).rejects.toThrow('connection failed')
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(settled).toBe(false)
+    expect(mockConnect.mock.calls.length).toBeGreaterThan(5)
 
-    // Should have attempted 3 times
-    expect(mongoose.connect).toHaveBeenCalledTimes(3)
+    // let it recover so the dangling promise resolves cleanly
+    mockConnect.mockResolvedValue(mongoose)
+    await vi.advanceTimersByTimeAsync(60_000)
+    await promise
+    expect(settled).toBe(true)
   })
 })

--- a/apps/worker/src/helpers/db.ts
+++ b/apps/worker/src/helpers/db.ts
@@ -12,21 +12,27 @@ const {
 
 const url = `mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOSTNAME}:${MONGO_PORT}/${MONGO_DB}?authSource=${MONGO_AUTH_SRC}`
 
-const connectDB = async (retries = 5, delay = 5000) => {
-  for (let i = 0; i < retries; i++) {
+const INITIAL_RETRY_DELAY_MS = 5_000
+const MAX_RETRY_DELAY_MS = 60_000
+
+// Retry forever with capped exponential backoff rather than giving up after a
+// fixed number of attempts: a mongod that is briefly unreachable during a
+// deploy or an NFS lock-recovery window can outlast a finite retry budget, and
+// connectDB() is called fire-and-forget, so a throw here becomes an unhandled
+// rejection that kills the worker. Mirrors the backend's dbConn.ts.
+const connectDB = async (): Promise<void> => {
+  for (let attempt = 1; ; attempt++) {
     try {
       await mongoose.connect(url)
       logger.info('Successfully connected to MongoDB')
       return
     } catch (err) {
-      logger.error(
-        `MongoDB connection attempt ${i + 1}/${retries} failed: ${err}`
+      const delay = Math.min(
+        INITIAL_RETRY_DELAY_MS * 2 ** (attempt - 1),
+        MAX_RETRY_DELAY_MS
       )
-      if (i === retries - 1) {
-        logger.error('All MongoDB connection attempts failed')
-        throw err
-      }
-      logger.info(`Retrying in ${delay / 1000} seconds...`)
+      logger.error(`MongoDB connection attempt ${attempt} failed: ${err}`)
+      logger.info(`Retrying MongoDB connection in ${delay / 1000} seconds...`)
       await new Promise((resolve) => setTimeout(resolve, delay))
     }
   }


### PR DESCRIPTION
## Problem

The worker's `connectDB()` retried 5 times at a fixed 5s interval (~25s budget) and then threw. Since it's called fire-and-forget in `worker.ts`, the throw became an unhandled rejection that killed the worker process. During this morning's mongo outage on the NERSC dev server (stale NFS lock after pod rescheduling, ~15 min of CrashLoopBackOff), the worker survived only because mongod happened to come back on attempt 5/5.

## Fix

Retry forever with capped exponential backoff (5s doubling to a 60s cap), matching the backend's equivalent fix in #1006 and the spirit of the Redis retry fix in #999. The `connectDB(retries, delay)` parameters are removed; the only call site (`worker.ts:33`) passed no arguments.

## Testing

- Rewrote `apps/worker/src/helpers/__tests__/db.test.ts`: URL construction, retry-then-recover, exponential backoff with 60s cap, and never-rejecting while Mongo stays down (fake timers).
- `pnpm -F @bilbomd/worker lint` / `build` / `test` all pass (24 files, 188 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)