### PR TITLE
feat(ui): cap job title input with live counter and shared TitleField

### DIFF
--- a/.changeset/ui-title-field-live-validation.md
+++ b/.changeset/ui-title-field-live-validation.md
@@ -1,0 +1,5 @@
+---
+'@bilbomd/ui': patch
+---
+
+Improve job title input UX across all job forms. The Title box now caps typing at 30 characters and shows a live character counter (e.g. `12/30`) that switches to the validation message once the field is touched, so users get immediate feedback instead of only discovering the limit on submit. The title input and its Yup validation were factored into a shared `TitleField` component and `titleSchema` helper, and the Classic job's inconsistent 24-character cap was normalized to 30 to match every other job type. Fixes #1010.

--- a/apps/ui/src/components/TitleField.tsx
+++ b/apps/ui/src/components/TitleField.tsx
@@ -1,0 +1,61 @@
+import { TextField } from '@mui/material'
+import type { SxProps, Theme } from '@mui/material'
+import { useField, useFormikContext } from 'formik'
+import { TITLE_MAX_LENGTH } from '../schemas/titleSchema'
+
+type TitleFieldProps = {
+  /** Formik field name. Defaults to `title`. */
+  name?: string
+  /** Field label. Defaults to `Title`. */
+  label?: string
+  /** Hard character cap applied to the input. Defaults to {@link TITLE_MAX_LENGTH}. */
+  maxLength?: number
+  /**
+   * Disable the field. When omitted the field is disabled while the form is
+   * submitting.
+   */
+  disabled?: boolean
+  fullWidth?: boolean
+  sx?: SxProps<Theme>
+}
+
+/**
+ * Shared job-title input used by every BilboMD job form.
+ *
+ * Wires itself to Formik via `useField`, caps typing at `maxLength`, and shows
+ * a live character counter that switches to the validation error once the
+ * field is touched. Pair with `titleSchema` in the form's validation schema.
+ */
+const TitleField = ({
+  name = 'title',
+  label = 'Title',
+  maxLength = TITLE_MAX_LENGTH,
+  disabled,
+  fullWidth = true,
+  sx = { width: '100%' }
+}: TitleFieldProps) => {
+  const [field, meta] = useField<string | undefined>(name)
+  const { isSubmitting } = useFormikContext()
+
+  const value = field.value ?? ''
+  const showError = Boolean(meta.error) && meta.touched
+  const isDisabled = disabled ?? isSubmitting
+
+  return (
+    <TextField
+      id={name}
+      label={label}
+      type="text"
+      fullWidth={fullWidth}
+      disabled={isDisabled}
+      error={showError}
+      helperText={showError ? meta.error : `${value.length}/${maxLength}`}
+      slotProps={{ htmlInput: { maxLength } }}
+      sx={sx}
+      {...field}
+      value={value}
+    />
+  )
+}
+
+export default TitleField

--- a/apps/ui/src/components/__tests__/TitleField.test.tsx
+++ b/apps/ui/src/components/__tests__/TitleField.test.tsx
@@ -1,0 +1,125 @@
+// apps/ui/src/components/__tests__/TitleField.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { Formik, Form } from 'formik'
+import { object } from 'yup'
+import TitleField from '../TitleField'
+import { titleSchema, TITLE_MAX_LENGTH } from '../../schemas/titleSchema'
+
+const validationSchema = object({ title: titleSchema() })
+
+type HarnessProps = {
+  initialTitle?: string
+  onSubmit?: () => void | Promise<void>
+  children?: React.ReactNode
+}
+
+const renderTitleField = ({
+  initialTitle = '',
+  onSubmit = vi.fn(),
+  children
+}: HarnessProps = {}) =>
+  render(
+    <Formik
+      initialValues={{ title: initialTitle }}
+      validationSchema={validationSchema}
+      onSubmit={onSubmit}
+    >
+      <Form>
+        <TitleField />
+        {children}
+      </Form>
+    </Formik>
+  )
+
+const getInput = () =>
+  screen.getByRole('textbox', { name: /title/i }) as HTMLInputElement
+
+describe('TitleField', () => {
+  describe('rendering', () => {
+    it('renders a Title input', () => {
+      renderTitleField()
+      expect(getInput()).toBeInTheDocument()
+    })
+
+    it('reflects the Formik field value', () => {
+      renderTitleField({ initialTitle: 'Existing' })
+      expect(getInput().value).toBe('Existing')
+    })
+  })
+
+  describe('character cap', () => {
+    it('applies a maxLength attribute equal to TITLE_MAX_LENGTH', () => {
+      renderTitleField()
+      expect(getInput()).toHaveAttribute('maxlength', String(TITLE_MAX_LENGTH))
+    })
+
+    it('prevents typing beyond the maximum length', async () => {
+      const user = userEvent.setup()
+      renderTitleField()
+      const input = getInput()
+      await user.type(input, 'a'.repeat(TITLE_MAX_LENGTH + 10))
+      expect(input.value).toHaveLength(TITLE_MAX_LENGTH)
+    })
+  })
+
+  describe('live character counter', () => {
+    it('shows 0/max when empty', () => {
+      renderTitleField()
+      expect(screen.getByText(`0/${TITLE_MAX_LENGTH}`)).toBeInTheDocument()
+    })
+
+    it('updates the counter as the user types', async () => {
+      const user = userEvent.setup()
+      renderTitleField()
+      await user.type(getInput(), 'Hello')
+      expect(screen.getByText(`5/${TITLE_MAX_LENGTH}`)).toBeInTheDocument()
+    })
+  })
+
+  describe('validation feedback', () => {
+    it('shows the error message once the field is touched and invalid', async () => {
+      const user = userEvent.setup()
+      renderTitleField()
+      const input = getInput()
+      await user.type(input, 'ab')
+      fireEvent.blur(input) // marks the field touched -> Formik validates
+      expect(
+        await screen.findByText(/at least 4 characters/i)
+      ).toBeInTheDocument()
+    })
+
+    it('does not show an error before the field is touched', async () => {
+      const user = userEvent.setup()
+      renderTitleField()
+      await user.type(getInput(), 'ab')
+      expect(screen.queryByText(/at least 4 characters/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('disabled state', () => {
+    it('honors an explicit disabled prop', () => {
+      render(
+        <Formik initialValues={{ title: '' }} onSubmit={vi.fn()}>
+          <Form>
+            <TitleField disabled />
+          </Form>
+        </Formik>
+      )
+      expect(getInput()).toBeDisabled()
+    })
+
+    it('disables the input while the form is submitting', async () => {
+      const user = userEvent.setup()
+      // A submit handler that never resolves keeps isSubmitting true.
+      renderTitleField({
+        initialTitle: 'Valid Title',
+        onSubmit: () => new Promise<void>(() => {}),
+        children: <button type="submit">Submit</button>
+      })
+      await user.click(screen.getByRole('button', { name: /submit/i }))
+      expect(await screen.findByRole('textbox', { name: /title/i })).toBeDisabled()
+    })
+  })
+})

--- a/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
+++ b/apps/ui/src/features/alphafoldjob/NewAlphaFoldJobForm.tsx
@@ -31,6 +31,7 @@ import { BilboMDAlphaFoldJobSchema } from 'schemas/BilboMDAlphaFoldJobSchema'
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
 import HeaderBox from 'components/HeaderBox'
+import TitleField from 'components/TitleField'
 import useTitle from 'hooks/useTitle'
 import { Entity, NewAlphaFoldJobFormValues } from 'types/alphafoldForm'
 import NewAlphaFoldJobFormInstructions from './NewAlphaFoldJobFormInstructions'
@@ -656,22 +657,7 @@ const NewAlphaFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
                     >
                       {/* Title */}
                       <Box sx={{ minWidth: { xs: 0, md: '520px' }, width: '100%', maxWidth: '520px' }}>
-                        <Field
-                          fullWidth
-                          label="Title"
-                          name="title"
-                          id="title"
-                          type="text"
-                          disabled={isSubmitting}
-                          as={TextField}
-                          onChange={handleChange}
-                          onBlur={handleBlur}
-                          error={errors.title && touched.title}
-                          helperText={
-                            errors.title && touched.title ? errors.title : ''
-                          }
-                          value={values.title || ''}
-                        />
+                        <TitleField />
                       </Box>
                       <Box sx={{ ml: { xs: 0, md: 8 }, minWidth: 'fit-content' }}>
                         <Button

--- a/apps/ui/src/features/autojob/NewAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/NewAutoJobForm.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useState } from 'react'
-import { Box, Button, TextField, Typography, Alert, Paper } from '@mui/material'
+import { Box, Button, Typography, Alert, Paper } from '@mui/material'
 import LaunchIcon from '@mui/icons-material/Launch'
 import Grid from '@mui/material/Grid'
 import { Form, Formik, Field } from 'formik'
@@ -17,6 +17,7 @@ import {
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
 import HeaderBox from 'components/HeaderBox'
+import TitleField from 'components/TitleField'
 import useTitle from 'hooks/useTitle'
 import NerscStatusChecker from 'features/nersc/NerscStatusChecker'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
@@ -188,8 +189,6 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                   touched,
                   isValid,
                   isSubmitting,
-                  handleChange,
-                  handleBlur,
                   setFieldValue,
                   setFieldTouched,
                   validateForm
@@ -215,22 +214,7 @@ const NewAutoJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                         }}
                       >
                         <Box sx={{ minWidth: { xs: 0, md: '520px' }, width: '100%', maxWidth: '520px' }}>
-                          <Field
-                            label="Title"
-                            name="title"
-                            id="title"
-                            type="text"
-                            disabled={isSubmitting}
-                            as={TextField}
-                            onChange={handleChange}
-                            onBlur={handleBlur}
-                            error={errors.title && touched.title}
-                            helperText={
-                              errors.title && touched.title ? errors.title : ''
-                            }
-                            value={values.title || ''}
-                            sx={{ width: '100%' }}
-                          />
+                          <TitleField />
                         </Box>
                         <Box sx={{ ml: { xs: 0, md: 8 }, minWidth: 'fit-content' }}>
                           <Button

--- a/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
+++ b/apps/ui/src/features/autojob/ResubmitAutoJobForm.tsx
@@ -2,7 +2,6 @@ import { ReactNode, useState } from 'react'
 import {
   Box,
   Button,
-  TextField,
   Typography,
   Alert,
   AlertTitle,
@@ -29,6 +28,7 @@ import {
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
 import HeaderBox from 'components/HeaderBox'
+import TitleField from 'components/TitleField'
 import useTitle from 'hooks/useTitle'
 import NerscStatusChecker from 'features/nersc/NerscStatusChecker'
 import { useGetConfigsQuery } from 'slices/configsApiSlice'
@@ -220,8 +220,6 @@ const ResubmitAutoJobForm = () => {
                 touched,
                 isValid,
                 isSubmitting,
-                handleChange,
-                handleBlur,
                 status,
                 setFieldValue,
                 setFieldTouched
@@ -238,22 +236,7 @@ const ResubmitAutoJobForm = () => {
                       />
                     )}
                     <Grid sx={{ my: 2, width: '100%', maxWidth: '520px' }}>
-                      <Field
-                        fullWidth
-                        label="Title"
-                        name="title"
-                        id="title"
-                        type="text"
-                        disabled={isSubmitting}
-                        as={TextField}
-                        onChange={handleChange}
-                        onBlur={handleBlur}
-                        error={errors.title && touched.title}
-                        helperText={
-                          errors.title && touched.title ? errors.title : ''
-                        }
-                        value={values.title || ''}
-                      />
+                      <TitleField />
                     </Grid>
 
                     <Grid>

--- a/apps/ui/src/features/jobs/NewJobForm.tsx
+++ b/apps/ui/src/features/jobs/NewJobForm.tsx
@@ -39,6 +39,7 @@ import { BilboMDClassicJobFormValues } from '../../types/classicJobForm'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from './JobSuccessAlert'
 import MdEngineField from 'components/MdEngineField'
+import TitleField from 'components/TitleField'
 import { getRgMaxWarning } from './rgMaxWarning'
 
 type NewJobFormProps = {
@@ -266,22 +267,7 @@ const NewJobForm = ({ mode = 'authenticated' }: NewJobFormProps) => {
                       }}
                     >
                       <Box sx={{ minWidth: { xs: 0, md: '520px' }, width: '100%', maxWidth: '520px' }}>
-                        <Field
-                          label="Title"
-                          name="title"
-                          id="title"
-                          type="text"
-                          disabled={isSubmitting}
-                          as={TextField}
-                          onChange={handleChange}
-                          onBlur={handleBlur}
-                          error={errors.title && touched.title}
-                          helperText={
-                            errors.title && touched.title ? errors.title : ''
-                          }
-                          value={values.title || ''}
-                          sx={{ width: '100%' }}
-                        />
+                        <TitleField />
                       </Box>
                       <Box sx={{ ml: { xs: 0, md: 8 }, minWidth: 'fit-content' }}>
                         <Button

--- a/apps/ui/src/features/jobs/ResubmitJobForm.tsx
+++ b/apps/ui/src/features/jobs/ResubmitJobForm.tsx
@@ -41,6 +41,7 @@ import PipelineSchematic from './PipelineSchematic'
 import { BilboMDClassicJobFormValues } from '../../types/classicJobForm'
 import type { BilboMDCRDDTO, BilboMDPDBDTO } from '@bilbomd/bilbomd-types'
 import MdEngineField from 'components/MdEngineField'
+import TitleField from 'components/TitleField'
 
 const ResubmitJobForm = () => {
   useTitle('BilboMD: Resubmit Classic Job')
@@ -330,22 +331,7 @@ const ResubmitJobForm = () => {
                         Job Form
                       </Divider>
                       <Grid sx={{ my: 2, width: '100%', maxWidth: '520px' }}>
-                        <Field
-                          fullWidth
-                          label="Title"
-                          name="title"
-                          id="title"
-                          type="text"
-                          disabled={isSubmitting}
-                          as={TextField}
-                          onChange={handleChange}
-                          onBlur={handleBlur}
-                          error={errors.title && touched.title}
-                          helperText={
-                            errors.title && touched.title ? errors.title : ''
-                          }
-                          value={values.title || ''}
-                        />
+                        <TitleField />
                       </Grid>
                       {/* MD Engine selection */}
                       <Grid sx={{ width: '100%', maxWidth: '520px', mb: 1 }}>

--- a/apps/ui/src/features/multimd/NewMultiMDJobForm.tsx
+++ b/apps/ui/src/features/multimd/NewMultiMDJobForm.tsx
@@ -13,7 +13,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TextField,
   Typography,
   Alert,
   Paper,
@@ -26,9 +25,11 @@ import Grid from '@mui/material/Grid'
 import SendIcon from '@mui/icons-material/Send'
 import type { BilboMDJobDTO } from '@bilbomd/bilbomd-types'
 import HeaderBox from 'components/HeaderBox'
+import TitleField from 'components/TitleField'
+import { titleSchema } from 'schemas/titleSchema'
 import useTitle from 'hooks/useTitle'
 import { Instructions } from './Instructions.tsx'
-import { Formik, Form, Field } from 'formik'
+import { Formik, Form } from 'formik'
 import { Debug } from 'components/Debug'
 import useAuth from 'hooks/useAuth'
 import { formatDateSafe } from 'utils/dates'
@@ -70,11 +71,7 @@ const NewMultiMDJobForm: React.FC = () => {
   }
 
   const validationSchema = Yup.object({
-    title: Yup.string()
-      .required('Please provide a title for your BilboMD Multi Job.')
-      .min(4, 'Title must contain at least 4 characters.')
-      .max(30, 'Title must contain less than 30 characters.')
-      .matches(/^[\w\s-]+$/, 'No special characters allowed'),
+    title: titleSchema('BilboMD Multi Job'),
     bilbomd_uuids: Yup.array().min(2, 'Select at least two jobs to combine'),
     data_file_from: Yup.string()
       .required(
@@ -173,12 +170,9 @@ const NewMultiMDJobForm: React.FC = () => {
                 {({
                   values,
                   errors,
-                  touched,
                   isValid,
                   isSubmitting,
-                  handleChange,
                   setFieldValue,
-                  handleBlur,
                   status
                 }) => (
                   <Form>
@@ -187,22 +181,7 @@ const NewMultiMDJobForm: React.FC = () => {
                       sx={{ flexDirection: 'column' }}
                     >
                       <Grid sx={{ my: 2, width: '100%', maxWidth: '520px' }}>
-                        <Field
-                          fullWidth
-                          label="Title"
-                          name="title"
-                          id="title"
-                          type="text"
-                          disabled={isSubmitting}
-                          as={TextField}
-                          onChange={handleChange}
-                          onBlur={handleBlur}
-                          error={errors.title && touched.title}
-                          helperText={
-                            errors.title && touched.title ? errors.title : ''
-                          }
-                          value={values.title || ''}
-                        />
+                        <TitleField />
                       </Grid>
                       <Divider
                         textAlign="left"

--- a/apps/ui/src/features/openfoldjob/NewOpenFoldJobForm.tsx
+++ b/apps/ui/src/features/openfoldjob/NewOpenFoldJobForm.tsx
@@ -31,6 +31,7 @@ import { BilboMDOpenFoldJobSchema } from 'schemas/BilboMDOpenFoldJobSchema'
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
 import HeaderBox from 'components/HeaderBox'
+import TitleField from 'components/TitleField'
 import useTitle from 'hooks/useTitle'
 import {
   OpenFoldEntity,
@@ -614,22 +615,7 @@ const NewOpenFoldJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
                       >
                         {/* Title */}
                         <Box sx={{ minWidth: { xs: 0, md: '520px' }, width: '100%', maxWidth: '520px' }}>
-                          <Field
-                            fullWidth
-                            label="Title"
-                            name="title"
-                            id="title"
-                            type="text"
-                            disabled={isSubmitting}
-                            as={TextField}
-                            onChange={handleChange}
-                            onBlur={handleBlur}
-                            error={errors.title && touched.title}
-                            helperText={
-                              errors.title && touched.title ? errors.title : ''
-                            }
-                            value={values.title || ''}
-                          />
+                          <TitleField />
                         </Box>
                         <Box sx={{ ml: { xs: 0, md: 8 }, minWidth: 'fit-content' }}>
                           <Button

--- a/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
+++ b/apps/ui/src/features/sansjob/NewSANSJobForm.tsx
@@ -26,6 +26,7 @@ import { expdataSchema } from 'schemas/ExpdataSchema'
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
 import HeaderBox from 'components/HeaderBox'
+import TitleField from 'components/TitleField'
 import useTitle from 'hooks/useTitle'
 import { NewSANSJobFormValues } from '../../types/sansForm'
 import NewSANSJobFormInstructions from './NewSANSJobFormInstructions'
@@ -269,22 +270,7 @@ const NewSANSJob = ({ mode = 'authenticated' }: NewJobFormProps) => {
 
                     {/* Title */}
                     <Grid sx={{ my: 2, width: '100%', maxWidth: '520px' }}>
-                      <Field
-                        fullWidth
-                        label="Title"
-                        name="title"
-                        id="title"
-                        type="text"
-                        disabled={isSubmitting}
-                        as={TextField}
-                        onChange={handleChange}
-                        onBlur={handleBlur}
-                        error={errors.title && touched.title}
-                        helperText={
-                          errors.title && touched.title ? errors.title : ''
-                        }
-                        value={values.title || ''}
-                      />
+                      <TitleField />
                     </Grid>
 
                     {/* PDB file */}

--- a/apps/ui/src/features/scoperjob/NewScoperJobForm.tsx
+++ b/apps/ui/src/features/scoperjob/NewScoperJobForm.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import {
   Box,
   Button,
-  TextField,
   Typography,
   Alert,
   Paper,
@@ -24,6 +23,7 @@ import { bilbomdScoperJobSchema } from 'schemas/ScoperValidationSchema'
 import { Debug } from 'components/Debug'
 import LinearProgress from '@mui/material/LinearProgress'
 import HeaderBox from 'components/HeaderBox'
+import TitleField from 'components/TitleField'
 import useTitle from 'hooks/useTitle'
 import PublicJobSuccessAlert from 'features/public/PublicJobSuccessAlert'
 import JobSuccessAlert from 'features/jobs/JobSuccessAlert'
@@ -220,8 +220,6 @@ const NewScoperJobForm = ({
                   touched,
                   isValid,
                   isSubmitting,
-                  handleChange,
-                  handleBlur,
                   setFieldValue,
                   setFieldTouched,
                   validateForm
@@ -241,22 +239,7 @@ const NewScoperJobForm = ({
                         }}
                       >
                         <Box sx={{ minWidth: { xs: 0, md: '520px' }, width: '100%', maxWidth: '520px' }}>
-                          <Field
-                            fullWidth
-                            label="Title"
-                            name="title"
-                            id="title"
-                            type="text"
-                            disabled={isSubmitting}
-                            as={TextField}
-                            onChange={handleChange}
-                            onBlur={handleBlur}
-                            error={errors.title && touched.title}
-                            helperText={
-                              errors.title && touched.title ? errors.title : ''
-                            }
-                            value={values.title || ''}
-                          />
+                          <TitleField />
                         </Box>
                         <Box sx={{ ml: { xs: 0, md: 8 }, minWidth: 'fit-content' }}>
                           <Button

--- a/apps/ui/src/schemas/BilboMDAlphaFoldJobSchema.ts
+++ b/apps/ui/src/schemas/BilboMDAlphaFoldJobSchema.ts
@@ -7,6 +7,7 @@ import {
   noSpacesTest,
   saxsCheck
 } from './fieldTests/fieldTests'
+import { titleSchema } from './titleSchema'
 
 const isAminoAcidSequence = (sequence: string) => {
   const aminoAcidRegex = /^[ACDEFGHIKLMNPQRSTVWY]+$/i
@@ -17,11 +18,7 @@ const BilboMDAlphaFoldJobSchema = object().shape({
   md_engine: string()
     .oneOf(['charmm', 'openmm'], 'Invalid MD engine')
     .required('Please select an MD engine'),
-  title: string()
-    .required('Please provide a title for your BilboMD Job.')
-    .min(4, 'Title must contain at least 4 characters.')
-    .max(30, 'Title must contain less than 30 characters.')
-    .matches(/^[\w\s-]+$/, 'No spaces or special characters allowed'),
+  title: titleSchema('BilboMD Job'),
 
   dat_file: requiredFile('Experimental SAXS data is required')
     .concat(fileSizeTest(2_000_000))

--- a/apps/ui/src/schemas/BilboMDAutoJobSchema.ts
+++ b/apps/ui/src/schemas/BilboMDAutoJobSchema.ts
@@ -12,16 +12,13 @@ import {
   pdbOrCifResidueCheck,
   singleModelCheck
 } from './fieldTests/fieldTests'
+import { titleSchema } from './titleSchema'
 
 const BilboMDAutoJobSchema = object().shape({
   md_engine: string()
     .oneOf(['charmm', 'openmm'], 'Invalid MD engine')
     .required('Please select an MD engine'),
-  title: string()
-    .required('Please provide a title for your BilboMD Job.')
-    .min(4, 'Title must contain at least 4 characters.')
-    .max(30, 'Title must contain less than 30 characters.')
-    .matches(/^[\w\s-]+$/, 'no spaces or special characters allowed'),
+  title: titleSchema('BilboMD Job'),
   pdb_file: requiredFile('A PDB or CIF file is required')
     .concat(pdbOrCifChainIdCheck())
     .concat(singleModelCheck())

--- a/apps/ui/src/schemas/BilboMDClassicJobSchema.ts
+++ b/apps/ui/src/schemas/BilboMDClassicJobSchema.ts
@@ -15,17 +15,14 @@ import {
   pdbOrCifChainIdCheck,
   pdbOrCifResidueCheck
 } from './fieldTests/fieldTests'
+import { titleSchema } from './titleSchema'
 
 const BilboMDClassicJobSchema = object().shape({
   bilbomd_mode: string().required('Selection is required'),
   md_engine: string()
     .oneOf(['charmm', 'openmm'], 'Invalid MD engine')
     .required('Please select an MD engine'),
-  title: string()
-    .required('Please provide a title for your BilboMD Job.')
-    .min(4, 'Title must contain at least 4 characters.')
-    .max(24, 'Title must contain less than 24 characters.')
-    .matches(/^[\w\s-]+$/, 'no spaces or special characters allowed'),
+  title: titleSchema('BilboMD Job'),
   psf_file: mixed().when('bilbomd_mode', {
     is: 'crd_psf',
     then: () =>

--- a/apps/ui/src/schemas/BilboMDOpenFoldJobSchema.ts
+++ b/apps/ui/src/schemas/BilboMDOpenFoldJobSchema.ts
@@ -7,6 +7,7 @@ import {
   noSpacesTest,
   saxsCheck
 } from './fieldTests/fieldTests'
+import { titleSchema } from './titleSchema'
 
 const isAminoAcidSequence = (sequence: string) =>
   /^[ACDEFGHIKLMNPQRSTVWY]+$/i.test(sequence)
@@ -16,11 +17,7 @@ const isDnaSequence = (sequence: string) => /^[ACGT]+$/i.test(sequence)
 const isRnaSequence = (sequence: string) => /^[ACGU]+$/i.test(sequence)
 
 const BilboMDOpenFoldJobSchema = object().shape({
-  title: string()
-    .required('Please provide a title for your BilboMD Job.')
-    .min(4, 'Title must contain at least 4 characters.')
-    .max(30, 'Title must contain less than 30 characters.')
-    .matches(/^[\w\s-]+$/, 'No spaces or special characters allowed'),
+  title: titleSchema('BilboMD Job'),
 
   dat_file: requiredFile('Experimental SAXS data is required')
     .concat(fileSizeTest(2_000_000))

--- a/apps/ui/src/schemas/BilboMDSANSJobSchema.ts
+++ b/apps/ui/src/schemas/BilboMDSANSJobSchema.ts
@@ -12,16 +12,13 @@ import {
   fileExtTest,
   constInpCheck
 } from './fieldTests/fieldTests'
+import { titleSchema } from './titleSchema'
 
 const BilboMDSANSJobSchema = object().shape({
   md_engine: string()
     .oneOf(['charmm', 'openmm'], 'Invalid MD engine')
     .required('Please select an MD engine'),
-  title: string()
-    .required('Please provide a title for your BilboMD SANS Job.')
-    .min(4, 'Title must contain at least 4 characters.')
-    .max(30, 'Title must contain less than 30 characters.')
-    .matches(/^[\w\s-]+$/, 'No special characters allowed'),
+  title: titleSchema('BilboMD SANS Job'),
   pdb_file: requiredFile('A PDB or CIF file is required')
     .concat(pdbOrCifChainIdCheck())
     .concat(singleModelCheck())

--- a/apps/ui/src/schemas/ScoperValidationSchema.ts
+++ b/apps/ui/src/schemas/ScoperValidationSchema.ts
@@ -1,12 +1,9 @@
-import { mixed, object, string } from 'yup'
+import { mixed, object } from 'yup'
 import { noSpaces, isSaxsData, isRNA } from './ValidationFunctions'
+import { titleSchema } from './titleSchema'
 
 export const bilbomdScoperJobSchema = object().shape({
-  title: string()
-    .required('Please provide a title for your BilboMD Scoper Job.')
-    .min(4, 'Title must contain at least 4 characters.')
-    .max(30, 'Title must contain less than 30 characters.')
-    .matches(/^[\w\s-]+$/, 'no special characters allowed'),
+  title: titleSchema('BilboMD Scoper Job'),
 
   pdb_file: mixed()
     .required('An RNA PDB file is required')

--- a/apps/ui/src/schemas/__tests__/BilboMDClassicJobSchema.test.ts
+++ b/apps/ui/src/schemas/__tests__/BilboMDClassicJobSchema.test.ts
@@ -97,17 +97,16 @@ describe('BilboMDClassicJobSchema - title', () => {
     ).rejects.toThrow('at least 4 characters')
   })
 
-  // Classic schema max is 24 characters (not 30 like other schemas)
-  it('rejects title longer than 24 characters', async () => {
+  it('rejects title longer than 30 characters', async () => {
     await expect(
-      BilboMDClassicJobSchema.validateAt('title', { title: 'a'.repeat(25) })
-    ).rejects.toThrow('less than 24 characters')
+      BilboMDClassicJobSchema.validateAt('title', { title: 'a'.repeat(31) })
+    ).rejects.toThrow('less than 30 characters')
   })
 
-  it('accepts title of exactly 24 characters', async () => {
+  it('accepts title of exactly 30 characters', async () => {
     await expect(
-      BilboMDClassicJobSchema.validateAt('title', { title: 'a'.repeat(24) })
-    ).resolves.toBe('a'.repeat(24))
+      BilboMDClassicJobSchema.validateAt('title', { title: 'a'.repeat(30) })
+    ).resolves.toBe('a'.repeat(30))
   })
 
   it('rejects title with special characters', async () => {

--- a/apps/ui/src/schemas/__tests__/titleSchema.test.ts
+++ b/apps/ui/src/schemas/__tests__/titleSchema.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { ValidationError } from 'yup'
+import {
+  titleSchema,
+  TITLE_MIN_LENGTH,
+  TITLE_MAX_LENGTH
+} from '../titleSchema'
+
+describe('titleSchema', () => {
+  const schema = titleSchema()
+
+  it('accepts a valid title with letters, numbers, spaces, and hyphens', async () => {
+    await expect(schema.validate('My-Job 123')).resolves.toBe('My-Job 123')
+  })
+
+  it('accepts a title at exactly the minimum length', async () => {
+    const min = 'a'.repeat(TITLE_MIN_LENGTH)
+    await expect(schema.validate(min)).resolves.toBe(min)
+  })
+
+  it('accepts a title at exactly the maximum length', async () => {
+    const max = 'a'.repeat(TITLE_MAX_LENGTH)
+    await expect(schema.validate(max)).resolves.toBe(max)
+  })
+
+  it('rejects a title shorter than the minimum length', async () => {
+    await expect(
+      schema.validate('a'.repeat(TITLE_MIN_LENGTH - 1))
+    ).rejects.toThrow('at least 4 characters')
+  })
+
+  it('rejects a title longer than the maximum length', async () => {
+    await expect(
+      schema.validate('a'.repeat(TITLE_MAX_LENGTH + 1))
+    ).rejects.toThrow('less than 30 characters')
+  })
+
+  it('rejects a title with special characters', async () => {
+    await expect(schema.validate('Bad@Title!')).rejects.toThrow(
+      'No special characters'
+    )
+  })
+
+  it('rejects a missing title with the required message', async () => {
+    await expect(schema.validate(undefined)).rejects.toThrow(
+      'Please provide a title for your BilboMD Job.'
+    )
+  })
+
+  it('uses the provided job label in the required message', async () => {
+    await expect(
+      titleSchema('BilboMD SANS Job').validate(undefined)
+    ).rejects.toThrow('Please provide a title for your BilboMD SANS Job.')
+  })
+
+  it('surfaces validation failures as Yup ValidationErrors', async () => {
+    await expect(schema.validate('a')).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('exposes the canonical length bounds', () => {
+    expect(TITLE_MIN_LENGTH).toBe(4)
+    expect(TITLE_MAX_LENGTH).toBe(30)
+  })
+})

--- a/apps/ui/src/schemas/titleSchema.ts
+++ b/apps/ui/src/schemas/titleSchema.ts
@@ -1,0 +1,30 @@
+import { string } from 'yup'
+
+/** Minimum number of characters allowed in a job title. */
+export const TITLE_MIN_LENGTH = 4
+
+/** Maximum number of characters allowed in a job title. */
+export const TITLE_MAX_LENGTH = 30
+
+/**
+ * Shared Yup validation for a BilboMD job title.
+ *
+ * Every job form enforces identical title rules (length + allowed
+ * characters); only the "required" message differs per job type. Pass a job
+ * label (e.g. "BilboMD SANS Job") to customize that message.
+ *
+ * The UI also caps typing at {@link TITLE_MAX_LENGTH} via `TitleField`, so the
+ * `.max()` rule here is primarily a backstop for pasted/programmatic input.
+ */
+export const titleSchema = (jobLabel = 'BilboMD Job') =>
+  string()
+    .required(`Please provide a title for your ${jobLabel}.`)
+    .min(
+      TITLE_MIN_LENGTH,
+      `Title must contain at least ${TITLE_MIN_LENGTH} characters.`
+    )
+    .max(
+      TITLE_MAX_LENGTH,
+      `Title must contain less than ${TITLE_MAX_LENGTH} characters.`
+    )
+    .matches(/^[\w\s-]+$/, 'No special characters allowed.')


### PR DESCRIPTION
## Summary

Fixes #1010. A user noted the Title box allows unlimited typing but blocks submission past the character limit, which is unintuitive.

This caps typing at the limit and adds real-time feedback, while factoring the duplicated title input + validation into shared code.

- **`TitleField` component** (`components/TitleField.tsx`) — Formik-aware title input. Hard-caps typing via `maxLength`, shows a **live character counter** (`12/30`) that switches to the validation error once the field is touched, and auto-disables while submitting.
- **`titleSchema` helper** (`schemas/titleSchema.ts`) — single Yup fragment (min 4, max 30, allowed-character rule) with per-job-type "required" messages, plus exported `TITLE_MIN_LENGTH` / `TITLE_MAX_LENGTH` constants.
- **Normalized the cap** — Classic bumped from 24 → 30 to match every other job type.
- **Rolled out** across all New job forms (Classic, Auto, AlphaFold, SANS, OpenFold, Scoper, Multi) and both Resubmit forms, replacing the copy-pasted `<Field>` blocks and inline/duplicated Yup rules.

## Design note

Went with a **hard input cap** rather than silently truncating on submit — truncation would surprise users. `.max()` stays in the schema as a backstop for pasted/programmatic input.

## Tests

- `TitleField.test.tsx` (10 tests): render, value reflection, `maxLength` attr + typing cap, live counter, touched-error display, no error before touched, explicit + submitting disabled states.
- `titleSchema.test.ts` (10 tests): length bounds, allowed chars, required message + custom job label.
- Updated `BilboMDClassicJobSchema.test.ts` for the 24 → 30 change.

## Verification

- `pnpm -F @bilbomd/ui lint` — clean
- `pnpm -F @bilbomd/ui build` — succeeds
- `pnpm -F @bilbomd/ui test` — **1174 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)